### PR TITLE
fix: cross-repo context drops incoming/outgoing relationships (#41)

### DIFF
--- a/gitnexus/src/mcp/local/local-backend.ts
+++ b/gitnexus/src/mcp/local/local-backend.ts
@@ -481,16 +481,49 @@ export class LocalBackend {
               // Add _repoId to each candidate
               aggregated.candidates.push(...result.candidates.map((c: any) => ({ ...c, _repoId: repoId })));
             } else if (result.status === 'found' && result.symbol) {
-              // Found in one repo, return with _repoId
-              aggregated.symbol = { ...result.symbol, _repoId: repoId };
-              aggregated.repoId = repoId;
+              // First-repo wins: skip if already found in an earlier repo
+              if (!aggregated.symbol) {
+                aggregated.symbol = { ...result.symbol, _repoId: repoId };
+                aggregated.repoId = repoId;
+                // Preserve relationship data with _repoId attribution
+                if (result.incoming) {
+                  aggregated.incoming = Object.fromEntries(
+                    Object.entries(result.incoming).map(([cat, entries]) => [
+                      cat,
+                      (entries as any[]).map((e: any) => ({ ...e, _repoId: repoId })),
+                    ]),
+                  );
+                }
+                if (result.outgoing) {
+                  aggregated.outgoing = Object.fromEntries(
+                    Object.entries(result.outgoing).map(([cat, entries]) => [
+                      cat,
+                      (entries as any[]).map((e: any) => ({ ...e, _repoId: repoId })),
+                    ]),
+                  );
+                }
+                if (result.processes) {
+                  aggregated.processes = result.processes.map((p: any) => ({ ...p, _repoId: repoId }));
+                }
+              }
             }
           }
         }
 
-        // If we found an exact match, return it
+        // If we found an exact match, return it with relationships
         if (aggregated.symbol) {
-          return { status: 'found', symbol: aggregated.symbol, _repoId: aggregated.repoId };
+          const found: any = {
+            status: 'found',
+            symbol: aggregated.symbol,
+            incoming: aggregated.incoming || {},
+            outgoing: aggregated.outgoing || {},
+            processes: aggregated.processes || [],
+            _repoId: aggregated.repoId,
+          };
+          if (aggregated.errors.length > 0) {
+            found.errors = aggregated.errors;
+          }
+          return found;
         }
 
         // Otherwise return aggregated candidates

--- a/gitnexus/test/unit/calltool-dispatch.test.ts
+++ b/gitnexus/test/unit/calltool-dispatch.test.ts
@@ -837,35 +837,251 @@ describe('callTool multi-repo routing', () => {
 
   describe('context tool with repos[]', () => {
     it('routes to multi-repo handler when repos array is provided', async () => {
-      (executeParameterized as any)
-        .mockResolvedValueOnce([
-          { id: 'func:auth', name: 'auth', type: 'Function', filePath: '/a.ts', startLine: 1, endLine: 10 },
-        ])
-        .mockResolvedValueOnce([]);
+      vi.spyOn(backend as any, 'context').mockImplementation(async (handle: any) => {
+        if (handle.id === 'test-project') {
+          return { status: 'found', symbol: { uid: 'func:auth', name: 'auth', kind: 'Function', filePath: '/a.ts', startLine: 1, endLine: 10 }, incoming: {}, outgoing: {}, processes: [] };
+        }
+        return { error: 'Symbol not found' };
+      });
 
       const result = await backend.callTool('context', {
         name: 'auth',
         repos: ['test-project', 'other-project'],
       });
 
-      // Should aggregate candidates from multiple repos
-      expect((result as any)).toHaveProperty('status');
+      expect(result.status).toBe('found');
+      expect(result.symbol).toBeDefined();
+      expect(result.symbol._repoId).toBe('test-project');
+      expect(result.incoming).toBeDefined();
+      expect(result.outgoing).toBeDefined();
+      expect(result.processes).toBeDefined();
     });
 
     it('returns symbol with _repoId when found in one repo', async () => {
-      (executeParameterized as any)
-        .mockResolvedValueOnce([
-          { id: 'func:auth', name: 'auth', type: 'Function', filePath: '/a.ts', startLine: 1, endLine: 10 },
-        ])
-        .mockResolvedValueOnce([]);
+      vi.spyOn(backend as any, 'context').mockImplementation(async (handle: any) => {
+        if (handle.id === 'test-project') {
+          return { status: 'found', symbol: { uid: 'func:auth', name: 'auth', kind: 'Function', filePath: '/a.ts', startLine: 1, endLine: 10 }, incoming: {}, outgoing: {}, processes: [] };
+        }
+        return { error: 'Symbol not found' };
+      });
 
       const result = await backend.callTool('context', {
         name: 'auth',
         repos: ['test-project', 'other-project'],
       });
 
-      // If found exactly one match, should return it with _repoId
-      expect((result as any)).toHaveProperty('status');
+      expect(result.status).toBe('found');
+      expect(result.symbol._repoId).toBe('test-project');
+      expect(result._repoId).toBe('test-project');
+    });
+
+    it('returns incoming relationships with _repoId (TC-1)', async () => {
+      vi.spyOn(backend as any, 'context').mockImplementation(async (handle: any) => {
+        if (handle.id === 'test-project') {
+          return {
+            status: 'found',
+            symbol: { uid: 'func:auth', name: 'auth', kind: 'Function', filePath: '/auth.ts', startLine: 1, endLine: 10 },
+            incoming: {
+              calls: [{ uid: 'func:login', name: 'login', filePath: '/login.ts', kind: 'Function' }],
+              imports: [{ uid: 'func:setup', name: 'setup', filePath: '/setup.ts', kind: 'Function' }],
+            },
+            outgoing: {},
+            processes: [],
+          };
+        }
+        return { error: 'Symbol not found' };
+      });
+
+      const result = await backend.callTool('context', {
+        name: 'auth',
+        repos: ['test-project', 'other-project'],
+      });
+
+      expect(result.status).toBe('found');
+      expect(result.incoming.calls).toBeInstanceOf(Array);
+      expect(result.incoming.calls).toHaveLength(1);
+      expect(result.incoming.calls[0]).toMatchObject({
+        uid: 'func:login', name: 'login', _repoId: 'test-project',
+      });
+      expect(result.incoming.imports).toHaveLength(1);
+      expect(result.incoming.imports[0]).toMatchObject({
+        uid: 'func:setup', name: 'setup', _repoId: 'test-project',
+      });
+    });
+
+    it('returns outgoing relationships with _repoId (TC-2)', async () => {
+      vi.spyOn(backend as any, 'context').mockImplementation(async (handle: any) => {
+        if (handle.id === 'test-project') {
+          return {
+            status: 'found',
+            symbol: { uid: 'func:auth', name: 'auth', kind: 'Function', filePath: '/auth.ts', startLine: 1, endLine: 10 },
+            incoming: {},
+            outgoing: {
+              calls: [{ uid: 'func:validate', name: 'validate', filePath: '/validate.ts', kind: 'Function' }],
+              extends: [{ uid: 'class:BaseAuth', name: 'BaseAuth', filePath: '/base.ts', kind: 'Class' }],
+            },
+            processes: [],
+          };
+        }
+        return { error: 'Symbol not found' };
+      });
+
+      const result = await backend.callTool('context', {
+        name: 'auth',
+        repos: ['test-project', 'other-project'],
+      });
+
+      expect(result.status).toBe('found');
+      expect(result.outgoing.calls[0]).toMatchObject({
+        uid: 'func:validate', _repoId: 'test-project',
+      });
+      expect(result.outgoing.extends[0]).toMatchObject({
+        uid: 'class:BaseAuth', _repoId: 'test-project',
+      });
+    });
+
+    it('returns processes with _repoId (TC-3)', async () => {
+      vi.spyOn(backend as any, 'context').mockImplementation(async (handle: any) => {
+        if (handle.id === 'test-project') {
+          return {
+            status: 'found',
+            symbol: { uid: 'func:login', name: 'login', kind: 'Function', filePath: '/login.ts', startLine: 1, endLine: 10 },
+            incoming: {},
+            outgoing: {},
+            processes: [{ id: 'proc:UserLogin', name: 'UserLogin', step_index: 2, step_count: 5 }],
+          };
+        }
+        return { error: 'Symbol not found' };
+      });
+
+      const result = await backend.callTool('context', {
+        name: 'login',
+        repos: ['test-project', 'other-project'],
+      });
+
+      expect(result.status).toBe('found');
+      expect(result.processes).toHaveLength(1);
+      expect(result.processes[0]).toMatchObject({
+        id: 'proc:UserLogin', name: 'UserLogin', _repoId: 'test-project',
+      });
+    });
+
+    it('preserves empty relationship shape when no refs exist (TC-4)', async () => {
+      vi.spyOn(backend as any, 'context').mockImplementation(async (handle: any) => {
+        if (handle.id === 'test-project') {
+          return {
+            status: 'found',
+            symbol: { uid: 'func:auth', name: 'auth', kind: 'Function', filePath: '/auth.ts', startLine: 1, endLine: 10 },
+            incoming: {},
+            outgoing: {},
+            processes: [],
+          };
+        }
+        return { error: 'Symbol not found' };
+      });
+
+      const result = await backend.callTool('context', {
+        name: 'auth',
+        repos: ['test-project', 'other-project'],
+      });
+
+      expect(result.status).toBe('found');
+      expect(result.incoming).toEqual({});
+      expect(result.outgoing).toEqual({});
+      expect(result.processes).toEqual([]);
+    });
+
+    it('adds _repoId to each nested entry in incoming categories (TC-5)', async () => {
+      vi.spyOn(backend as any, 'context').mockImplementation(async (handle: any) => {
+        if (handle.id === 'test-project') {
+          return {
+            status: 'found',
+            symbol: { uid: 'func:auth', name: 'auth', kind: 'Function', filePath: '/auth.ts', startLine: 1, endLine: 10 },
+            incoming: {
+              calls: [
+                { uid: 'func:caller1', name: 'caller1', filePath: '/c1.ts', kind: 'Function' },
+                { uid: 'func:caller2', name: 'caller2', filePath: '/c2.ts', kind: 'Function' },
+              ],
+            },
+            outgoing: {},
+            processes: [],
+          };
+        }
+        return { error: 'Symbol not found' };
+      });
+
+      const result = await backend.callTool('context', {
+        name: 'auth',
+        repos: ['test-project', 'other-project'],
+      });
+
+      expect(result.status).toBe('found');
+      expect(result.incoming.calls).toHaveLength(2);
+      expect(result.incoming.calls[0]._repoId).toBe('test-project');
+      expect(result.incoming.calls[1]._repoId).toBe('test-project');
+    });
+
+    it('returns relationships from other repo when one repo errors (TC-6)', async () => {
+      vi.spyOn(backend as any, 'context').mockImplementation(async (handle: any) => {
+        if (handle.id === 'test-project') {
+          throw new Error('connection failed');
+        }
+        return {
+          status: 'found',
+          symbol: { uid: 'func:auth', name: 'auth', kind: 'Function', filePath: '/auth.ts', startLine: 1, endLine: 10 },
+          incoming: { calls: [{ uid: 'func:caller', name: 'caller', filePath: '/c.ts', kind: 'Function' }] },
+          outgoing: {},
+          processes: [],
+        };
+      });
+
+      const result = await backend.callTool('context', {
+        name: 'auth',
+        repos: ['test-project', 'other-project'],
+      });
+
+      expect(result.status).toBe('found');
+      expect(result.symbol._repoId).toBe('other-project');
+      expect(result.incoming.calls[0]._repoId).toBe('other-project');
+      expect(result.errors).toBeDefined();
+      expect(result.errors.length).toBeGreaterThanOrEqual(1);
+      expect(result.errors[0].repoId).toBe('test-project');
+    });
+
+    it('returns ambiguous candidates with _repoId (TC-7)', async () => {
+      vi.spyOn(backend as any, 'context').mockImplementation(async (handle: any) => {
+        if (handle.id === 'test-project') {
+          return {
+            status: 'ambiguous',
+            candidates: [
+              { uid: 'func:auth:1', name: 'auth', kind: 'Function', filePath: '/a.ts', startLine: 1, endLine: 5 },
+              { uid: 'func:auth:2', name: 'auth', kind: 'Function', filePath: '/b.ts', startLine: 1, endLine: 5 },
+            ],
+          };
+        }
+        return { error: 'Symbol not found' };
+      });
+
+      const result = await backend.callTool('context', {
+        name: 'auth',
+        repos: ['test-project', 'other-project'],
+      });
+
+      expect(result.status).toBe('ambiguous');
+      expect(result.candidates).toHaveLength(2);
+      expect(result.candidates[0]._repoId).toBe('test-project');
+      expect(result.candidates[1]._repoId).toBe('test-project');
+    });
+
+    it('returns not_found when symbol not in any repo (TC-8)', async () => {
+      vi.spyOn(backend as any, 'context').mockResolvedValue({ error: 'Symbol not found' });
+
+      const result = await backend.callTool('context', {
+        name: 'nonexistent',
+        repos: ['test-project', 'other-project'],
+      });
+
+      expect(result.status).toBe('not_found');
     });
   });
 


### PR DESCRIPTION
## Summary
- Fix cross-repo `context` tool to include `incoming`, `outgoing`, and `processes` relationship data with `_repoId` attribution on each entry
- Add first-repo-wins guard when symbol found in multiple repos
- Add defensive defaults for empty relationships (`incoming: {}`, `outgoing: {}`, `processes: []`)
- Include `errors` array in found response when repo errors exist

## Test plan
- [x] TC-1: Incoming relationships with _repoId
- [x] TC-2: Outgoing relationships with _repoId
- [x] TC-3: Processes with _repoId
- [x] TC-4: Empty relationship shape preserved
- [x] TC-5: _repoId on each nested entry
- [x] TC-6: Error isolation (one repo errors, other repo's data preserved)
- [x] TC-7: Ambiguous candidates with _repoId
- [x] TC-8: Not found in any repo
- [x] Full regression suite: 5419 passed, 0 failed

Fixes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)