### PR TITLE
fix: Go struct field type resolution for handler→service CALLS edges (#19)

### DIFF
--- a/gitnexus/src/core/ingestion/field-extractors/configs/go.ts
+++ b/gitnexus/src/core/ingestion/field-extractors/configs/go.ts
@@ -3,6 +3,7 @@
 import { SupportedLanguages } from '../../../../config/supported-languages.js';
 import type { FieldExtractionConfig } from '../generic.js';
 import { extractSimpleTypeName } from '../../type-extractors/shared.js';
+import type { SyntaxNode } from '../../utils/ast-helpers.js';
 
 /**
  * Go field extraction config.
@@ -64,5 +65,41 @@ export const goConfig: FieldExtractionConfig = {
 
   isReadonly(_node) {
     return false; // Go fields are not readonly
+  },
+
+  /**
+   * Go type_declaration has no named fields — children are type_spec nodes.
+   * Navigate: type_declaration > type_spec > name:type_identifier
+   */
+  nameResolver(node: SyntaxNode) {
+    for (let i = 0; i < node.namedChildCount; i++) {
+      const child = node.namedChild(i);
+      if (child?.type === 'type_spec') {
+        return child.childForFieldName('name');
+      }
+    }
+    return null;
+  },
+
+  /**
+   * Go field_declaration_list is nested 3 levels deep:
+   *   type_declaration > type_spec > struct_type > field_declaration_list
+   * type_declaration and struct_type have no named fields — walk by node type.
+   */
+  bodyResolver(node: SyntaxNode) {
+    for (let i = 0; i < node.namedChildCount; i++) {
+      const typeSpec = node.namedChild(i);
+      if (typeSpec?.type !== 'type_spec') continue;
+      const typeNode = typeSpec.childForFieldName('type');
+      if (!typeNode) continue;
+      // struct_type and interface_type have unnamed field_declaration_list children
+      for (let j = 0; j < typeNode.namedChildCount; j++) {
+        const body = typeNode.namedChild(j);
+        if (body?.type === 'field_declaration_list') {
+          return [body];
+        }
+      }
+    }
+    return [];
   },
 };

--- a/gitnexus/src/core/ingestion/field-extractors/generic.ts
+++ b/gitnexus/src/core/ingestion/field-extractors/generic.ts
@@ -48,6 +48,19 @@ export interface FieldExtractionConfig {
   isStatic: (node: SyntaxNode) => boolean;
   /** Check if a field is readonly/final/const */
   isReadonly: (node: SyntaxNode) => boolean;
+  /**
+   * Custom resolver for the type name node from a type declaration node.
+   * Default: `(node) => node.childForFieldName('name')`.
+   * Needed for Go where `type_declaration` wraps `type_spec` which holds the name.
+   */
+  nameResolver?: (node: SyntaxNode) => SyntaxNode | null;
+  /**
+   * Custom resolver for body containers from a type declaration node.
+   * Default: uses `findBodies()` which walks direct children.
+   * Needed for Go where `field_declaration_list` is nested 3 levels deep
+   * under `type_declaration`.
+   */
+  bodyResolver?: (node: SyntaxNode) => SyntaxNode[];
 }
 
 // ---------------------------------------------------------------------------
@@ -76,14 +89,14 @@ export function createFieldExtractor(config: FieldExtractionConfig): FieldExtrac
     extract(node: SyntaxNode, context: FieldExtractorContext): ExtractedFields | null {
       if (!this.isTypeDeclaration(node)) return null;
 
-      const nameNode = node.childForFieldName('name');
+      const nameNode = config.nameResolver?.(node) ?? node.childForFieldName('name');
       if (!nameNode) return null;
 
       const ownerFqn = nameNode.text;
       const fields: FieldInfo[] = [];
 
       // Find body container(s)
-      const bodies = this.findBodies(node);
+      const bodies = config.bodyResolver?.(node) ?? this.findBodies(node);
       for (const body of bodies) {
         this.extractFieldsFromBody(body, context, fields);
       }

--- a/gitnexus/src/core/ingestion/utils/ast-helpers.ts
+++ b/gitnexus/src/core/ingestion/utils/ast-helpers.ts
@@ -114,6 +114,8 @@ export const CLASS_CONTAINER_TYPES = new Set([
   // Kotlin
   'object_declaration',
   'companion_object',
+  // Go
+  'type_declaration',
 ]);
 
 export const CONTAINER_TYPE_TO_LABEL: Record<string, string> = {
@@ -135,6 +137,7 @@ export const CONTAINER_TYPE_TO_LABEL: Record<string, string> = {
   module: 'Module',
   object_declaration: 'Class',
   companion_object: 'Class',
+  type_declaration: 'Struct',
 };
 
 /** Check if a Kotlin function_declaration capture is inside a class_body (i.e., a method).

--- a/gitnexus/test/integration/resolvers/go-handler-service.test.ts
+++ b/gitnexus/test/integration/resolvers/go-handler-service.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Reproduce Issue #19: Go handler calls self-reference instead of service method.
+ * Pattern: h.service.GetOrder() should resolve to OrderService.GetOrder, not OrderHandler.GetOrder.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import path from 'path';
+import {
+  FIXTURES, getRelationships, getNodesByLabel,
+  runPipelineFromRepo, type PipelineResult,
+} from './helpers.js';
+
+describe('Go handler → service field chain resolution (Issue #19)', () => {
+  let result: PipelineResult;
+
+  beforeAll(async () => {
+    result = await runPipelineFromRepo(
+      path.join(FIXTURES, 'go-handler-service-field'),
+      () => {},
+    );
+  }, 60000);
+
+  it('detects OrderHandler and OrderService structs', () => {
+    const structs = getNodesByLabel(result, 'Struct');
+    expect(structs).toContain('OrderHandler');
+    expect(structs).toContain('OrderService');
+  });
+
+  it('detects GetOrder methods', () => {
+    const methods = getNodesByLabel(result, 'Method');
+    expect(methods).toContain('GetOrder');
+  });
+
+  it('service Property on OrderHandler has declaredType', () => {
+    const props: Array<{ name: string; properties: Record<string, any> }> = [];
+    result.graph.forEachNode(n => {
+      if (n.label === 'Property' && n.properties.name === 'service') {
+        props.push({ name: n.properties.name, properties: n.properties });
+      }
+    });
+    expect(props.length).toBeGreaterThanOrEqual(1);
+    const withDeclaredType = props.find(p => p.properties.declaredType);
+    expect(withDeclaredType).toBeDefined();
+    expect(withDeclaredType!.properties.declaredType).toMatch(/OrderService/);
+  });
+
+  it('resolves h.service.GetOrder() → OrderService.GetOrder (NOT self-reference)', () => {
+    const calls = getRelationships(result, 'CALLS');
+    const getOrderCalls = calls.filter(e => e.target === 'GetOrder');
+
+    // At least one CALLS edge from a handler GetOrder should point to service file
+    const handlerToServiceCall = getOrderCalls.find(c =>
+      c.source === 'GetOrder' && c.sourceFilePath.includes('handler') && c.targetFilePath.includes('service')
+    );
+    expect(handlerToServiceCall).toBeDefined();
+
+    // No handler GetOrder should self-reference (target file = source file = handler)
+    const selfRefCalls = getOrderCalls.filter(c =>
+      c.source === 'GetOrder' && c.sourceFilePath.includes('handler') && c.targetFilePath.includes('handler')
+    );
+    expect(selfRefCalls.length).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Fix Go/Gin handler CALLS edges self-referencing handler methods instead of pointing to service methods
- Add `nameResolver` and `bodyResolver` hooks to `FieldExtractionConfig` for Go's nested AST structure
- Add `type_declaration` to `CLASS_CONTAINER_TYPES` so Property nodes get `declaredType` set
- This fixes `h.service.GetOrder()` resolving to `OrderService.GetOrder` instead of `OrderHandler.GetOrder`

## Root Cause
Go's tree-sitter AST nests struct names 2 levels deep (`type_declaration > type_spec > name:type_identifier`) and field lists 3 levels deep (`type_declaration > type_spec > struct_type > field_declaration_list`). The generic field extractor couldn't navigate this structure, so Go struct fields never got `declaredType`, causing `walkMixedChain` to fail and CALLS edges to self-reference.

## Test plan
- [x] `go-handler-service.test.ts` — 4 tests pass: struct detection, method detection, declaredType on Property, handler→service CALLS edge
- [x] All 103 Go resolver tests pass
- [x] All 1407 integration resolver tests pass
- [x] All 3403 unit tests pass

Fixes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)