### PR TITLE
feat(mcp): auto-resolve repo from cwd when multiple repos indexed

### DIFF
--- a/gitnexus/src/mcp/local/local-backend.ts
+++ b/gitnexus/src/mcp/local/local-backend.ts
@@ -289,7 +289,34 @@ export class LocalBackend {
       return this.repos.values().next().value!;
     }
 
-    return null; // Multiple repos, no param — ambiguous
+    // Multiple repos, no param — try to resolve from cwd
+    const cwd = process.cwd();
+    const cwdMatch = this.resolveRepoFromCwd(cwd);
+    if (cwdMatch) {
+      console.error(`GitNexus: auto-resolved repo "${cwdMatch.name}" from working directory`);
+      return cwdMatch;
+    }
+
+    return null; // Ambiguous — resolveRepo will throw
+  }
+
+  /**
+   * Returns the indexed repo whose repoPath contains cwd (longest-prefix wins).
+   * Guards with path.sep so /foo does NOT match /foo-bar.
+   */
+  private resolveRepoFromCwd(cwd: string): RepoHandle | null {
+    let best: RepoHandle | null = null;
+    let bestLen = -1;
+    for (const handle of this.repos.values()) {
+      const root = handle.repoPath;
+      if (cwd === root || cwd.startsWith(root + path.sep)) {
+        if (root.length > bestLen) {
+          best = handle;
+          bestLen = root.length;
+        }
+      }
+    }
+    return best;
   }
 
   // ─── Lazy LadybugDB Init ────────────────────────────────────────────

--- a/gitnexus/test/unit/calltool-dispatch.test.ts
+++ b/gitnexus/test/unit/calltool-dispatch.test.ts
@@ -45,6 +45,7 @@ vi.mock('child_process', () => ({
 import { LocalBackend } from '../../src/mcp/local/local-backend.js';
 import { listRegisteredRepos, cleanupOldKuzuFiles } from '../../src/storage/repo-manager.js';
 import { initLbug, executeQuery, executeParameterized, isLbugReady, closeLbug } from '../../src/mcp/core/lbug-adapter.js';
+import { searchFTSFromLbug } from '../../src/core/search/bm25-index.js';
 import { execFileSync as mockedExecFileSync } from 'child_process';
 
 // ─── Helpers ─────────────────────────────────────────────────────────
@@ -456,8 +457,14 @@ describe('LocalBackend.resolveRepo', () => {
   it('throws for ambiguous repos without param', async () => {
     setupMultipleRepos();
     await backend.init();
-    await expect(backend.callTool('query', { query: 'test' }))
-      .rejects.toThrow('Multiple repositories indexed');
+    // Stub cwd to a non-matching path so the test is deterministic regardless of where the suite runs
+    const cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue('/var/empty');
+    try {
+      await expect(backend.callTool('query', { query: 'test' }))
+        .rejects.toThrow('Multiple repositories indexed');
+    } finally {
+      cwdSpy.mockRestore();
+    }
   });
 
   it('resolves repo by name parameter', async () => {
@@ -1891,5 +1898,127 @@ describe('impacted_endpoints multi-repo dispatch — detailed scenarios', () => 
     expect(callArgs[2]).toBeUndefined();
 
     await singleBackend.disconnect();
+  });
+});
+
+// ─── cwd-based auto-resolution ───────────────────────────────────────
+
+describe('LocalBackend.resolveRepoFromCache — cwd resolution', () => {
+  let backend: LocalBackend;
+  let cwdSpy: ReturnType<typeof vi.spyOn>;
+
+  const REPO_A = MOCK_REPO_ENTRY; // path: '/tmp/test-project'
+  const REPO_B = {
+    ...MOCK_REPO_ENTRY,
+    name: 'other-project',
+    path: '/tmp/other-project',
+    storagePath: '/tmp/.gitnexus/other-project',
+  };
+  const REPO_MONO = {
+    ...MOCK_REPO_ENTRY,
+    name: 'mono',
+    path: '/tmp/mono',
+    storagePath: '/tmp/.gitnexus/mono',
+  };
+  const REPO_NESTED = {
+    ...MOCK_REPO_ENTRY,
+    name: 'nested-pkg',
+    path: '/tmp/mono/packages/x',
+    storagePath: '/tmp/.gitnexus/nested-pkg',
+  };
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    // clearAllMocks wipes the module-level mockResolvedValue — restore it so query() doesn't throw
+    (searchFTSFromLbug as any).mockResolvedValue([]);
+    backend = new LocalBackend();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // Case 1: cwd exactly equals an indexed repo's path → resolves that repo
+  it('resolves repo when cwd exactly equals repoPath', async () => {
+    (listRegisteredRepos as any).mockResolvedValue([REPO_A, REPO_B]);
+    await backend.init();
+    cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue('/tmp/test-project');
+    (executeParameterized as any).mockResolvedValue([]);
+    const result = await backend.callTool('query', { query: 'test' });
+    expect(result).toHaveProperty('processes');
+  });
+
+  // Case 2: cwd is a subdirectory of a repo's path → resolves that repo
+  it('resolves repo when cwd is a subdirectory of repoPath', async () => {
+    (listRegisteredRepos as any).mockResolvedValue([REPO_A, REPO_B]);
+    await backend.init();
+    cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue('/tmp/test-project/src/utils');
+    (executeParameterized as any).mockResolvedValue([]);
+    const result = await backend.callTool('query', { query: 'test' });
+    expect(result).toHaveProperty('processes');
+  });
+
+  // Case 3: cwd inside none of the repos → still throws 'Multiple repositories indexed'
+  it('throws when cwd does not match any indexed repo', async () => {
+    (listRegisteredRepos as any).mockResolvedValue([REPO_A, REPO_B]);
+    await backend.init();
+    cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue('/home/user/unrelated');
+    await expect(backend.callTool('query', { query: 'test' }))
+      .rejects.toThrow('Multiple repositories indexed');
+  });
+
+  // Case 4: nested repos — nearest ancestor wins
+  it('resolves nearest ancestor when cwd is inside a nested repo', async () => {
+    (listRegisteredRepos as any).mockResolvedValue([REPO_MONO, REPO_NESTED]);
+    await backend.init();
+    cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue('/tmp/mono/packages/x/src');
+    (executeParameterized as any).mockResolvedValue([]);
+    // Should resolve /tmp/mono/packages/x (REPO_NESTED), not /tmp/mono (REPO_MONO)
+    const result = await backend.callTool('query', { query: 'test', repo: 'nested-pkg' });
+    expect(result).toHaveProperty('processes');
+    // Spy on console.error to prove cwd-based resolution picks the NEAREST repo (nested-pkg),
+    // not the shallower ancestor (mono). Both repos contain the cwd, so a longest-prefix bug
+    // would silently pick the wrong one — this assertion catches that regression.
+    const errSpy = vi.spyOn(console, 'error');
+    (executeParameterized as any).mockResolvedValue([]);
+    const cwdResult = await backend.callTool('query', { query: 'no-param' });
+    expect(cwdResult).toHaveProperty('processes');
+    // Must have logged auto-resolution for "nested-pkg", NOT for "mono"
+    expect(errSpy).toHaveBeenCalledWith(
+      expect.stringContaining('auto-resolved repo "nested-pkg"'),
+    );
+    const loggedMessages = errSpy.mock.calls.map((c) => c[0] as string);
+    expect(loggedMessages.every((m) => !m.includes('auto-resolved repo "mono"'))).toBe(true);
+    errSpy.mockRestore();
+  });
+
+  // Case 5: boundary — sep guard; '/tmp/test-project-extra' must NOT match '/tmp/test-project'
+  it('does not match repo when cwd shares a path prefix but not a path separator boundary', async () => {
+    (listRegisteredRepos as any).mockResolvedValue([REPO_A, REPO_B]);
+    await backend.init();
+    cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue('/tmp/test-project-extra');
+    await expect(backend.callTool('query', { query: 'test' }))
+      .rejects.toThrow('Multiple repositories indexed');
+  });
+
+  // Case 6: explicit repo param takes precedence over cwd
+  it('uses explicit repo param even when cwd is inside a different repo', async () => {
+    (listRegisteredRepos as any).mockResolvedValue([REPO_A, REPO_B]);
+    await backend.init();
+    // cwd is inside REPO_A (/tmp/test-project), but we explicitly request REPO_B
+    cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue('/tmp/test-project/src');
+    (executeParameterized as any).mockResolvedValue([]);
+    const result = await backend.callTool('query', { query: 'test', repo: 'other-project' });
+    expect(result).toHaveProperty('processes');
+  });
+
+  // Case 7: single indexed repo, no param, any cwd → resolves the one repo (unchanged behavior)
+  it('resolves single repo without param regardless of cwd', async () => {
+    (listRegisteredRepos as any).mockResolvedValue([REPO_A]);
+    await backend.init();
+    cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue('/home/user/completely-unrelated');
+    (executeParameterized as any).mockResolvedValue([]);
+    const result = await backend.callTool('query', { query: 'test' });
+    expect(result).toHaveProperty('processes');
   });
 });


### PR DESCRIPTION
## Summary
- When multiple repos are indexed and a local-MCP tool is called without a `repo` parameter, the backend now resolves to the **nearest indexed repo whose absolute `repoPath` contains `process.cwd()`** (longest-prefix, `path.sep`-guarded), eliminating the most frequent GitNexus error — `Multiple repositories indexed` (~172 occurrences in a cross-session transcript audit).
- **Conservative & non-breaking:** only the previously-`return null` (no-`repo` + multi-repo) path changes. Explicit-`repo`, single-repo, and zero-repo paths are byte-for-byte unchanged. A cwd that matches no indexed repo still throws the existing helpful error — never a silent wrong-repo selection (cf. #21).
- Decisions: cwd-only (no env-var fallback), stderr debug log (no tool response-shape change), HTTP `server/api.ts` left as-is.

## Planning Artifacts
| Artifact | Path |
|---|---|
| Plan | `docs/plans/105-auto-resolve-repo-cwd.md` |

## Changes
- **Backend (mcp):** WI-1 — new private `LocalBackend.resolveRepoFromCwd` (longest-prefix ancestor match, `path.sep` boundary guard) + a cwd-resolution branch in `resolveRepoFromCache`; stderr log on auto-resolve.
- **Frontend:** N/A.
- **Tests:** WI-2 — new `LocalBackend.resolveRepoFromCache — cwd resolution` suite (7 cases incl. nested-repo nearest-ancestor and the `/foo` vs `/foo-bar` sep-guard boundary) + hardened the existing ambiguity test to be cwd-deterministic.

## Test Plan
- [x] No-param call inside exactly one indexed repo resolves to it (no error)
- [x] Subdirectory of a repo resolves (prefix, not exact)
- [x] cwd inside no indexed repo → `Multiple repositories indexed` preserved
- [x] Nested indexed repos → nearest (longest-prefix) wins
- [x] `/foo-bar` does not false-match repo `/foo` (sep guard)
- [x] Explicit `repo` param takes precedence over cwd
- [x] Single-repo / zero-repo / explicit-repo paths unchanged
- [x] `npm run test:unit` green (3404 passed / 4 skipped / 0 failed); `tsc --noEmit` clean
- [x] Impact: `resolveRepoFromCache` CRITICAL by fan-in but non-breaking — `LocalBackend.resolveRepo` suite stays green (zero regression)

Closes #105. Resolves the MCP half of the multi-repo friction; the CLI-crash variant is tracked in #47.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
