### PR TITLE
chore: remove dead code (#52 query task_context/goal, #54 ImportEntry fields)

### DIFF
--- a/gitnexus/src/cli/tool.ts
+++ b/gitnexus/src/cli/tool.ts
@@ -136,8 +136,6 @@ function output(data: any): void {
 
 export async function queryCommand(queryText: string, options?: {
   repo?: string;
-  context?: string;
-  goal?: string;
   limit?: string;
   content?: boolean;
 }): Promise<void> {
@@ -149,8 +147,6 @@ export async function queryCommand(queryText: string, options?: {
   const backend = await getBackend();
   const result = await backend.callTool('query', {
     query: queryText,
-    task_context: options?.context,
-    goal: options?.goal,
     limit: options?.limit ? parseInt(options.limit) : undefined,
     include_content: options?.content ?? false,
     repo: options?.repo,

--- a/gitnexus/src/core/ingestion/import-processor.ts
+++ b/gitnexus/src/core/ingestion/import-processor.ts
@@ -69,13 +69,9 @@ export interface NamedImportBinding { sourcePath: string; exportedName: string }
  * Used to flag imports that reference symbols from external repositories.
  * 
  * @property target - The resolved import target (file path or module identifier)
- * @property isExternal - True if the import is from an external dependency
- * @property externalRepo - Repository ID (e.g., "bond-exception-handler") if known
  */
 export interface ImportEntry {
   target: string;
-  isExternal?: boolean;
-  externalRepo?: string;
 }
 export type NamedImportMap = Map<string, Map<string, NamedImportBinding>>;
 

--- a/gitnexus/src/mcp/local/local-backend.ts
+++ b/gitnexus/src/mcp/local/local-backend.ts
@@ -795,8 +795,6 @@ export class LocalBackend {
    */
   private async query(repo: RepoHandle, params: {
     query: string;
-    task_context?: string;
-    goal?: string;
     limit?: number;
     max_symbols?: number;
     include_content?: boolean;

--- a/gitnexus/src/mcp/tools.ts
+++ b/gitnexus/src/mcp/tools.ts
@@ -60,8 +60,6 @@ Results from multi-repo queries include '_repoId' attribution for each item.`,
       type: 'object',
       properties: {
         query: { type: 'string', description: 'Natural language or keyword search query' },
-        task_context: { type: 'string', description: 'What you are working on (e.g., "adding OAuth support"). Helps ranking.' },
-        goal: { type: 'string', description: 'What you want to find (e.g., "existing auth validation logic"). Helps ranking.' },
         limit: { type: 'number', description: 'Max processes to return (default: 5)', default: 5 },
         max_symbols: { type: 'number', description: 'Max symbols per process (default: 10)', default: 10 },
         include_content: { type: 'boolean', description: 'Include full symbol source code (default: false)', default: false },


### PR DESCRIPTION
## Summary

Two dead-code cleanups from the 2026-06-03 triage v2 § "Batch J — Tool parameter plumbing & quick wins":

- **#52** — query tool's `task_context` and `goal` parameters were advertised in the MCP tool schema and CLI option types but never read by the query implementation. They had descriptions promising they "help ranking" but had zero effect on search results.
- **#54** — `ImportEntry.isExternal` and `ImportEntry.externalRepo` are defined in the interface but never populated anywhere in the codebase. Vestigial from an incomplete cross-repo tracking feature.

## Changes (12 deletions, 4 files)

| File | Change |
|---|---|
| `gitnexus/src/mcp/local/local-backend.ts` | Drop `task_context?`/`goal?` from `query` params type |
| `gitnexus/src/mcp/tools.ts` | Drop `task_context`/`goal` from MCP query `inputSchema` |
| `gitnexus/src/cli/tool.ts` | Drop `context?`/`goal?` from `queryCommand` options + `callTool` mapping |
| `gitnexus/src/core/ingestion/import-processor.ts` | Drop `isExternal?`/`externalRepo?` from `ImportEntry` + JSDoc |

## Behavior change

None, beyond the surface area. MCP clients that pass `task_context`/`goal` will see them ignored (same as today); the params are simply no longer part of the schema. The CLI gains no flags — the `context`/`goal` options were typed in the function signature but never wired to a CLI flag.

The COBOL `isExternal` is a different concept (COBOL `IS EXTERNAL` clause) and is preserved untouched.

## Test results

- `npx tsc --noEmit` — clean
- Targeted unit suites:
  - `test/unit/import-processor.test.ts` — 12/12 passed
  - `test/unit/calltool-dispatch.test.ts` + `test/unit/impacted-endpoints-impl.test.ts` — 201/207 passed (6 pre-existing failures in `resolveRepoFromCache` cwd-resolution tests, environmental, identical on `main-afk`)
  - `test/unit/cli/document-endpoint-all.test.ts` — 15/15 passed
- Pre-commit hook (full unit suite, 5250 passed + 1 todo) approved

## Linked issues

Closes #52, #54 (after merge).

## Branch & commit

- Branch: `chore/remove-dead-code-batch`
- Commit: `bbb9d06`