### PR TITLE
fix: validate minConfidence range (#66) + guard empty-dir analyze (#48)

### DIFF
--- a/gitnexus/src/cli/analyze.ts
+++ b/gitnexus/src/cli/analyze.ts
@@ -324,6 +324,19 @@ export const analyzeCommand = async (
   // ── Phase 5: Finalize (98–100%) ───────────────────────────────────
   updateBar(98, 'Saving metadata...');
 
+  // Bail before writing the registry if the pipeline produced no files (#48).
+  // Otherwise a --skip-git run on an empty dir creates a 0-node entry that
+  // pollutes `gitnexus list` and triggers "Multiple repositories indexed"
+  // for subsequent calls. Use the same exit-code-via-processExitCode pattern
+  // the early-return path uses, so scripts can detect the failure.
+  if (pipelineResult.totalFileCount === 0) {
+    bar.stop();
+    console.log(`\n  No source files found in ${repoPath}. Aborting — nothing to index.\n`);
+    console.log('  Tip: pass a path with source files, or remove --skip-git to let GitNexus locate the repo root.\n');
+    process.exitCode = 1;
+    return;
+  }
+
   // Count embeddings in the index (cached + newly generated)
   let embeddingCount = 0;
   try {

--- a/gitnexus/src/mcp/local/local-backend.ts
+++ b/gitnexus/src/mcp/local/local-backend.ts
@@ -3225,6 +3225,15 @@ export class LocalBackend {
     includeTests?: boolean;
     minConfidence?: number;
   }): Promise<any> {
+    // Validate minConfidence range (#66). Reject out-of-range values explicitly
+    // so callers learn about the 0-1 contract instead of silently getting
+    // an empty result set (minConfidence=1.5 reads as "no result above 150%").
+    if (params.minConfidence !== undefined &&
+        (params.minConfidence < 0 || params.minConfidence > 1)) {
+      throw new Error(
+        `minConfidence must be between 0 and 1 (got ${params.minConfidence})`
+      );
+    }
     try {
       return await this._impactImpl(repo, params);
     } catch (err: any) {


### PR DESCRIPTION
## Summary

Two LOW-risk guards from the 2026-06-03 triage v2 § "Batch J — Tool parameter plumbing & quick wins":

- **#66** — `impact` tool's `minConfidence` parameter accepted out-of-range values (0-1 contract) silently. Calling with `minConfidence=1.5` returned results instead of rejecting.
- **#48** — `gitnexus analyze --skip-git <empty-dir>` created a 0-node index and added the path to the global registry, polluting `gitnexus list` and triggering "Multiple repositories indexed" for subsequent calls.

## Changes (22 insertions, 2 files)

| File | Change |
|---|---|
| `gitnexus/src/mcp/local/local-backend.ts` | Top-of-`impact()` guard: throws when `minConfidence` is outside `[0, 1]` (undefined falls through to default 0.7). |
| `gitnexus/src/cli/analyze.ts` | Pre-`saveMeta`/`registerRepo` guard: bails with exit code 1 + clear message when `pipelineResult.totalFileCount === 0`. Uses the same `process.exitCode = 1; return;` pattern the CLI already uses for "not a git repo". |

## Behavior

- **#66**: out-of-range `minConfidence` now throws `Error('minConfidence must be between 0 and 1 (got 1.5)')`. In-range values (including 0 and 1 boundary) are unaffected. The MCP server surfaces this as a structured error in the tool response.
- **#48**: zero-source-file runs no longer write a registry entry. Users get a clear "No source files found in <path>. Aborting" message + non-zero exit code. Scripts that check `$?` will see the failure.

## Test results

- `npx tsc --noEmit` — clean
- `test/unit/impacted-endpoints-impl.test.ts` — 96/96 passed
- `test/unit/cli/` — 15/15 passed
- Pre-commit hook (full unit suite, 5250 passed + 1 todo) — approved

## Linked issues

Closes #66, #48 (after merge).

## Branch & commit

- Branch: `fix/parameter-validation-batch`
- Commit: `479b891`