### PR TITLE
fix: query tool test-file demotion (#57) + decoupled search limit from max_symbols (#58)

### DIFF
--- a/gitnexus/src/mcp/local/local-backend.ts
+++ b/gitnexus/src/mcp/local/local-backend.ts
@@ -809,21 +809,32 @@ export class LocalBackend {
     const maxSymbolsPerProcess = params.max_symbols || 10;
     const includeContent = params.include_content ?? false;
     const searchQuery = params.query.trim();
-    
+
     // Step 1: Run hybrid search to get matching symbols
-    const searchLimit = processLimit * maxSymbolsPerProcess; // fetch enough raw results
+    // (#58) Decouple search quality from `max_symbols`. The previous formula
+    // `processLimit * maxSymbolsPerProcess` made `max_symbols=1` shrink the
+    // raw result set to 2*1=2 per channel — missing entire processes. Use a
+    // fixed floor so results are stable regardless of output density settings.
+    const searchLimit = Math.max(100, processLimit * 20);
     const [bm25Results, semanticResults] = await Promise.all([
       this.bm25Search(repo, searchQuery, searchLimit),
       this.semanticSearch(repo, searchQuery, searchLimit),
     ]);
     
     // Merge via reciprocal rank fusion
+    // (#57) Apply test-file demotion: multiply RRF scores from test/fixture
+    // files by TEST_FILE_DEMOTION so production code naturally ranks higher.
+    // This mirrors how `impacted_endpoints` already uses `isTestFilePath`.
+    const TEST_FILE_DEMOTION = 0.5;
     const scoreMap = new Map<string, { score: number; data: any }>();
-    
+
     for (let i = 0; i < bm25Results.length; i++) {
       const result = bm25Results[i];
       const key = result.nodeId || result.filePath;
-      const rrfScore = 1 / (60 + i);
+      let rrfScore = 1 / (60 + i);
+      if (result.filePath && isTestFilePath(result.filePath)) {
+        rrfScore *= TEST_FILE_DEMOTION;
+      }
       const existing = scoreMap.get(key);
       if (existing) {
         existing.score += rrfScore;
@@ -831,11 +842,14 @@ export class LocalBackend {
         scoreMap.set(key, { score: rrfScore, data: result });
       }
     }
-    
+
     for (let i = 0; i < semanticResults.length; i++) {
       const result = semanticResults[i];
       const key = result.nodeId || result.filePath;
-      const rrfScore = 1 / (60 + i);
+      let rrfScore = 1 / (60 + i);
+      if (result.filePath && isTestFilePath(result.filePath)) {
+        rrfScore *= TEST_FILE_DEMOTION;
+      }
       const existing = scoreMap.get(key);
       if (existing) {
         existing.score += rrfScore;

--- a/gitnexus/test/unit/calltool-dispatch.test.ts
+++ b/gitnexus/test/unit/calltool-dispatch.test.ts
@@ -170,6 +170,19 @@ describe('LocalBackend.callTool', () => {
     expect((result as any).error).toContain('query parameter is required');
   });
 
+  // WI-J5: regression for #57 — query ranking should demote test files so
+  // production symbols surface above `*.test.ts`/`*_test.go`/etc.
+  // The test harness mocks bm25/semantic at a layer that does not see the
+  // score-map demotion; mark as todo until the dispatch path is plumbed
+  // through a verifiable seam.
+  it.todo('query tool demotes test files in definitions ranking (#57)');
+
+  // WI-J6: regression for #58 — `max_symbols` must not shrink the raw search
+  // pool. A query with max_symbols=1 should fetch the same number of BM25 +
+  // semantic results as max_symbols=10, otherwise `processes` becomes empty
+  // for low values. Verifiable by spying on `bm25Search` / `semanticSearch`.
+  it.todo('query search limit is independent of max_symbols (#58)');
+
   it('dispatches cypher tool and blocks write queries', async () => {
     const result = await backend.callTool('cypher', { query: 'CREATE (n:Test)' });
     expect((result as any)).toHaveProperty('error');


### PR DESCRIPTION
## What
Fixes two `query` tool quality bugs that share a root cause in the RRF (Reciprocal Rank Fusion) merge in `LocalBackend.query`:

1. **#57 — Test-file demotion missing in query ranking.** `definitions` from the `query` tool could rank test code (`BondTests.java`, `*.test.ts`, `__tests__/`, etc.) above production symbols. `isTestFilePath()` already exists in `local-backend.ts` (used by `impacted_endpoints`) but the query RRF merge did not apply it. Now: test-file results are demoted by 0.5x at score-insertion time, mirroring the existing `impacted_endpoints` pattern.

2. **#58 — `max_symbols` was driving the raw search pool size.** The formula `searchLimit = processLimit * maxSymbolsPerProcess` meant `max_symbols=1, limit=2` fetched only 2 BM25 + 2 semantic results, which could miss entire processes (`processes: []` for valid queries). Now: a fixed floor `Math.max(100, processLimit * 20)` is used so search quality is decoupled from output density.

## Files
- `gitnexus/src/mcp/local/local-backend.ts` — RRF demotion + searchLimit fix
- `gitnexus/test/unit/calltool-dispatch.test.ts` — 2 `it.todo` regression tests (WI-J5, WI-J6) for future accept-gate

## Verify
- TypeScript: clean (`tsc --noEmit`)
- Targeted tests: `hybrid-search`, `cross-repo-query`, `calltool-dispatch` — 141/141 pass
- Full pre-commit: 5250/5250 + 3 todo (the 2 new todos + 1 from #21)

## Why not just bigger `max_symbols` defaults?
- Parameter-name contract: `max_symbols` should mean "max symbols per process" not "search pool size". Renaming the param or changing its default would be a breaking change for users.

## Test seams
- The 2 new `it.todo` tests document the bug shapes; full coverage needs spies on the private `bm25Search` / `semanticSearch` methods, which the existing harness mocks at the imported layer (not the instance layer). The test stubs `searchFTSFromLbug` / `embedQuery` instead. Plumbing the spy through is a separate refactor — captured as WI-J5/J6 for future work.

Closes #57, closes #58.

🤖 Generated with [Claude Code](https://claude.com/claude-code)