### PR TITLE
fix(#53): impact tool supports file_path for overloaded-method disambiguation

### DIFF
--- a/gitnexus/src/mcp/local/local-backend.ts
+++ b/gitnexus/src/mcp/local/local-backend.ts
@@ -3270,9 +3270,14 @@ export class LocalBackend {
     relationTypes?: string[];
     includeTests?: boolean;
     minConfidence?: number;
+    // (#53) Disambiguate overloaded methods (interface vs impl) by file path,
+    // matching the `context` tool's `file_path` parameter contract. Forwarded
+    // to the name-resolution sub-queries so the candidate whose filePath
+    // contains the suffix is preferred.
+    file_path?: string;
   }): Promise<any> {
     await this.ensureInitialized(repo.id);
-    
+
     const { target, direction } = params;
     const isQualified = target.includes(':') || target.includes('/');
     // For uid-format targets (e.g. "Class:UserController"), extract the name
@@ -3330,10 +3335,28 @@ export class LocalBackend {
         `, { targetName }).catch(() => []);
 
         if (rows.length > 0) {
-          // Pick the row with the lowest priority value (Class wins over Constructor)
-          const best = rows.reduce((a: any, b: any) =>
-            (a.priority ?? a[3] ?? 99) <= (b.priority ?? b[3] ?? 99) ? a : b,
-          );
+          // (#53) If `file_path` is supplied, prefer the row whose filePath
+          // contains it as a suffix. This disambiguates interface-vs-impl
+          // overloading (e.g., `unholdMoney` defined in both
+          // CashService.java and CashServiceV2Impl.java). Falls back to
+          // priority-based selection if no file path matches.
+          const filePathFilter = params.file_path;
+          let best: any;
+          if (filePathFilter) {
+            const fpLower = filePathFilter.toLowerCase();
+            const matched = rows.find((r: any) => {
+              const fp = (r.filePath ?? r[2] ?? '') as string;
+              return fp && fp.toLowerCase().endsWith(fpLower);
+            });
+            best = matched ?? rows.reduce((a: any, b: any) =>
+              (a.priority ?? a[3] ?? 99) <= (b.priority ?? b[3] ?? 99) ? a : b,
+            );
+          } else {
+            // Pick the row with the lowest priority value (Class wins over Constructor)
+            best = rows.reduce((a: any, b: any) =>
+              (a.priority ?? a[3] ?? 99) <= (b.priority ?? b[3] ?? 99) ? a : b,
+            );
+          }
           sym = best;
           const priorityToLabel = ['Class', 'Interface', 'Function', 'Method', 'Constructor'];
           symType = priorityToLabel[best.priority ?? best[3]] ?? '';
@@ -3348,7 +3371,19 @@ export class LocalBackend {
           RETURN n.id AS id, n.name AS name, labels(n)[0] AS type, n.filePath AS filePath
           LIMIT 1
         `, { targetName });
-        if (rows.length > 0) { sym = rows[0]; symType = sym.type || sym[2] || ''; }
+        if (rows.length > 0) {
+          // (#53) Honor `file_path` for disambiguation if a filePath matches
+          // the supplied suffix; otherwise pick the first row as before.
+          const fpLower = params.file_path?.toLowerCase();
+          const matched = fpLower
+            ? rows.find((r: any) => {
+                const fp = (r.filePath ?? r[3] ?? '') as string;
+                return fp && fp.toLowerCase().endsWith(fpLower);
+              })
+            : undefined;
+          sym = matched ?? rows[0];
+          symType = sym.type || sym[2] || '';
+        }
       }
     }
 

--- a/gitnexus/src/mcp/tools.ts
+++ b/gitnexus/src/mcp/tools.ts
@@ -224,6 +224,9 @@ Results from multi-repo queries include '_repoId' attribution.`,
         relationTypes: { type: 'array', items: { type: 'string' }, description: 'Filter: CALLS, IMPORTS, EXTENDS, IMPLEMENTS, HAS_METHOD, OVERRIDES (default: usage-based)' },
         includeTests: { type: 'boolean', description: 'Include test files (default: false)' },
         minConfidence: { type: 'number', description: 'Minimum confidence 0-1 (default: 0.7)' },
+        // (#53) Disambiguate overloaded methods (interface vs impl) by file path.
+        // Matches the `context` tool's `file_path` contract.
+        file_path: { type: 'string', description: 'File path to disambiguate symbols (matches the context tool\'s `file_path` parameter; preferred candidate is the one whose filePath ends with this suffix).' },
         repo: { type: 'string', description: 'Repository name or path. Omit if only one repo is indexed.' },
         repos: { type: 'array', items: { type: 'string' }, description: 'Multiple repos for cross-repo queries. When provided, analyzes impact across all listed repos in parallel with repoId attribution.' },
       },

--- a/gitnexus/test/unit/calltool-dispatch.test.ts
+++ b/gitnexus/test/unit/calltool-dispatch.test.ts
@@ -244,6 +244,13 @@ describe('LocalBackend.callTool', () => {
     expect((result as any).target).toBeDefined();
   });
 
+  // WI-J3: regression for #53 — impact tool must accept a `file_path` parameter
+  // and prefer the symbol whose filePath ends with that suffix (mirrors the
+  // `context` tool's disambiguation contract). Needs a harness that exposes
+  // the resolution sub-query's full UNION ALL result set so the filter can
+  // be observed.
+  it.todo('impact tool disambiguates symbols via file_path parameter (#53)');
+
   it('dispatches detect_changes tool', async () => {
     // detect_changes calls execFileSync which we haven't mocked at module level,
     // so it will throw a git error — that's fine, we test the error path


### PR DESCRIPTION
## What
The `impact` tool's symbol-resolution collapsed all matches of the same name to a single candidate (Class > Interface > Function > Method > Constructor priority, then first row). For Java/Spring codebases where the same method name lives in both an interface and its implementation (`unholdMoney` in `CashService.java` *and* `CashServiceV2Impl.java`), `impact` resolved to the interface method — returning `impactedCount: 0` even when the implementation has many CALLS edges.

The `context` tool already disambiguates via `file_path`. This change:

1. Adds `file_path` to the `impact` tool's MCP inputSchema.
2. Plumbs `file_path` through to `_impactImpl`.
3. In the UNION ALL sub-query resolution (Class/Interface/Function/Method/Constructor), when `file_path` is provided and multiple candidates exist, prefer the candidate whose `filePath` ends with the supplied suffix. Falls back to priority-based selection if no match.
4. Same disambiguation logic in the unlabeled-match fallback.

This aligns `impact` with `context`'s contract — callers can target the implementation specifically and get the actual CALLS/IMPORTS graph.

## Files
- `gitnexus/src/mcp/local/local-backend.ts` — `_impactImpl` gains `file_path?: string`; resolution queries honor it
- `gitnexus/src/mcp/tools.ts` — impact tool inputSchema exposes `file_path`
- `gitnexus/test/unit/calltool-dispatch.test.ts` — WI-J3 `it.todo` regression test

## Verify
- TypeScript: clean
- Full pre-commit: 5412/5412 + 4 todo
- Behavior: `impact(target="unholdMoney", direction="upstream", file_path=".../CashServiceV2Impl.java")` now resolves to the implementation method (the 8 callers from the cypher reference query become visible)

## Test seam
- WI-J3 todo captures the bug shape; full coverage needs the dispatch test harness to mock the UNION ALL sub-query with multiple rows so the filePath filter is observable. Separate plumbing.

Closes #53.

🤖 Generated with [Claude Code](https://claude.com/claude-code)