### PR TITLE
fix(#10,#75): impact tool surfaces ambiguous candidates and traverses Class→Method edges

### DIFF
--- a/gitnexus/src/mcp/local/local-backend.ts
+++ b/gitnexus/src/mcp/local/local-backend.ts
@@ -3317,49 +3317,88 @@ export class LocalBackend {
 
     if (!sym) {
       try {
+        // (#10) Collect ALL matches across types, not just the first per type.
+        // When a name like "GetOrder" exists in multiple files (e.g., a
+        // service method and a handler method), silently picking the first
+        // candidate gives a misleading blast radius. Mirror the `context`
+        // tool's `status: 'ambiguous'` contract so callers can disambiguate
+        // with `file_path` rather than receive silently-wrong results.
         const rows = await executeParameterized(repo.id, `
           MATCH (n:\`Class\`) WHERE n.name = $targetName
-          RETURN n.id AS id, n.name AS name, n.filePath AS filePath, 0 AS priority LIMIT 1
+          RETURN n.id AS id, n.name AS name, n.filePath AS filePath, 0 AS priority
           UNION ALL
           MATCH (n:\`Interface\`) WHERE n.name = $targetName
-          RETURN n.id AS id, n.name AS name, n.filePath AS filePath, 1 AS priority LIMIT 1
+          RETURN n.id AS id, n.name AS name, n.filePath AS filePath, 1 AS priority
           UNION ALL
           MATCH (n:\`Function\`) WHERE n.name = $targetName
-          RETURN n.id AS id, n.name AS name, n.filePath AS filePath, 2 AS priority LIMIT 1
+          RETURN n.id AS id, n.name AS name, n.filePath AS filePath, 2 AS priority
           UNION ALL
           MATCH (n:\`Method\`) WHERE n.name = $targetName
-          RETURN n.id AS id, n.name AS name, n.filePath AS filePath, 3 AS priority LIMIT 1
+          RETURN n.id AS id, n.name AS name, n.filePath AS filePath, 3 AS priority
           UNION ALL
           MATCH (n:\`Constructor\`) WHERE n.name = $targetName
-          RETURN n.id AS id, n.name AS name, n.filePath AS filePath, 4 AS priority LIMIT 1
+          RETURN n.id AS id, n.name AS name, n.filePath AS filePath, 4 AS priority
         `, { targetName }).catch(() => []);
 
         if (rows.length > 0) {
+          const filePathFilter = params.file_path;
+          const fpLower = filePathFilter?.toLowerCase();
+          // Build a deduplicated, priority-sorted list of candidates. Two
+          // rows with the same id are a single candidate.
+          const uniqueById = new Map<string, any>();
+          for (const r of rows) {
+            const id = r.id || r[0];
+            if (id && !uniqueById.has(id)) uniqueById.set(id, r);
+          }
+          const candidates = Array.from(uniqueById.values()).sort(
+            (a, b) => (a.priority ?? a[3] ?? 99) - (b.priority ?? b[3] ?? 99),
+          );
+
           // (#53) If `file_path` is supplied, prefer the row whose filePath
           // contains it as a suffix. This disambiguates interface-vs-impl
           // overloading (e.g., `unholdMoney` defined in both
-          // CashService.java and CashServiceV2Impl.java). Falls back to
-          // priority-based selection if no file path matches.
-          const filePathFilter = params.file_path;
-          let best: any;
-          if (filePathFilter) {
-            const fpLower = filePathFilter.toLowerCase();
-            const matched = rows.find((r: any) => {
+          // CashService.java and CashServiceV2Impl.java).
+          if (fpLower) {
+            const matched = candidates.find((r: any) => {
               const fp = (r.filePath ?? r[2] ?? '') as string;
               return fp && fp.toLowerCase().endsWith(fpLower);
             });
-            best = matched ?? rows.reduce((a: any, b: any) =>
-              (a.priority ?? a[3] ?? 99) <= (b.priority ?? b[3] ?? 99) ? a : b,
-            );
-          } else {
-            // Pick the row with the lowest priority value (Class wins over Constructor)
-            best = rows.reduce((a: any, b: any) =>
-              (a.priority ?? a[3] ?? 99) <= (b.priority ?? b[3] ?? 99) ? a : b,
-            );
+            if (matched) {
+              sym = matched;
+            }
           }
-          sym = best;
+          if (!sym) {
+            // (#10) When a name matches multiple distinct files (e.g.,
+            // GetOrder in handlers/ vs services/), the result is genuinely
+            // ambiguous — picking one candidate silently mis-states the
+            // blast radius. Surface the ambiguity in a structured shape
+            // the caller can act on (re-run with file_path, or inspect
+            // candidates). Same-file matches (e.g., a Class and its
+            // Constructor with the same name) silently prefer Class via
+            // the priority sort, mirroring #480.
+            const distinctFiles = new Set(
+              candidates.map((r: any) => (r.filePath ?? r[2] ?? '') as string),
+            );
+            if (candidates.length > 1 && distinctFiles.size > 1) {
+              return {
+                status: 'ambiguous',
+                target: targetName,
+                candidates: candidates.map((r: any) => ({
+                  uid: r.id || r[0],
+                  name: r.name || r[1],
+                  kind: ['Class', 'Interface', 'Function', 'Method', 'Constructor'][
+                    r.priority ?? r[3]
+                  ] ?? '',
+                  filePath: r.filePath || r[2],
+                })),
+                suggestion:
+                  'Re-run with file_path parameter to scope impact analysis to a single candidate (matches the context tool contract).',
+              };
+            }
+            sym = candidates[0];
+          }
           const priorityToLabel = ['Class', 'Interface', 'Function', 'Method', 'Constructor'];
-          symType = priorityToLabel[best.priority ?? best[3]] ?? '';
+          symType = priorityToLabel[sym.priority ?? sym[3]] ?? '';
         }
       } catch { /* fall through to unlabeled match */ }
 
@@ -3405,12 +3444,30 @@ export class LocalBackend {
     // upstream dependent. The BFS will discover IMPORTS edges on it naturally.
     if (symType === 'Class' || symType === 'Interface') {
       try {
-        // Run both seed queries in parallel — they are independent.
-        const [ctorRows, fileRows] = await Promise.all([
+        // Run all seed queries in parallel — they are independent.
+        //
+        // (#75) Class nodes have HAS_METHOD edges to BOTH Constructor and
+        // Method nodes. The original seed only collected Constructor (which
+        // is enough for typical Java bean patterns but misses real service
+        // methods like `pricingIConnect` that hold the actual downstream
+        // CALLS edges). Pull both node types so the BFS reaches method-level
+        // edges at depth 2+, making `maxDepth` actually meaningful for
+        // class-level impact analysis.
+        //
+        // Note: Method nodes are added to the BFS frontier but NOT to
+        // `visited` — they must be discoverable as HAS_METHOD results at
+        // depth 1 (the legitimate "direct callers" of the class). Adding
+        // them to `visited` would dedupe those legitimate results away.
+        const [ctorRows, methodRows, fileRows] = await Promise.all([
           executeParameterized(repo.id, `
             MATCH (n)-[hm:CodeRelation]->(c:Constructor)
             WHERE n.id = $symId AND hm.type = 'HAS_METHOD'
             RETURN c.id AS id, c.name AS name, labels(c)[0] AS type, c.filePath AS filePath
+          `, { symId }),
+          executeParameterized(repo.id, `
+            MATCH (n)-[hm:CodeRelation]->(m:Method)
+            WHERE n.id = $symId AND hm.type = 'HAS_METHOD'
+            RETURN m.id AS id, m.name AS name, labels(m)[0] AS type, m.filePath AS filePath
           `, { symId }),
           // Restrict to DEFINES edges only — other File->Class edge types (if
           // any) should not be treated as the owning file relationship.
@@ -3421,9 +3478,19 @@ export class LocalBackend {
           `, { symId }),
         ]);
 
+        // Constructors: add to both visited and frontier (Java class↔ctor
+        // name collision; they have no incoming HAS_METHOD from the class).
         for (const r of ctorRows) {
           const rid = r.id || r[0];
           if (rid && !visited.has(rid)) { visited.add(rid); frontier.push(rid); }
+        }
+        // Methods: add to frontier ONLY (not visited) so the depth-1
+        // HAS_METHOD edges from the Class are still discoverable. The
+        // Methods are already the targets of those edges, so we want to
+        // traverse FROM them at depth 2+ (their outgoing CALLS, etc.).
+        for (const r of methodRows) {
+          const rid = r.id || r[0];
+          if (rid && !frontier.includes(rid)) { frontier.push(rid); }
         }
         for (const r of fileRows) {
           const rid = r.id || r[0];

--- a/gitnexus/test/integration/local-backend-calltool.test.ts
+++ b/gitnexus/test/integration/local-backend-calltool.test.ts
@@ -134,10 +134,15 @@ withTestLbugDB('local-backend-calltool', (handle) => {
     });
 
     it('filters by OVERRIDES only', async () => {
+      // (#10) `authenticate` exists in BOTH `src/auth.ts` and `src/base.ts`,
+      // so the call without disambiguation now returns `status: 'ambiguous'`
+      // to prevent silently picking a single candidate. Disambiguate via
+      // file_path to scope to the AuthService implementation.
       const result = await backend.callTool('impact', {
         target: 'authenticate',
         direction: 'downstream',
         relationTypes: ['OVERRIDES'],
+        file_path: 'src/auth.ts',
       });
       expect(result).not.toHaveProperty('error');
       // AuthService.authenticate overrides BaseService.authenticate
@@ -145,6 +150,22 @@ withTestLbugDB('local-backend-calltool', (handle) => {
       const d1 = result.byDepth[1] || result.byDepth['1'] || [];
       const names = d1.map((d: any) => d.name);
       expect(names).toContain('authenticate');
+    });
+
+    it('returns ambiguous when name matches symbols in multiple files (#10)', async () => {
+      // `authenticate` exists in both `src/auth.ts` and `src/base.ts`.
+      // Without disambiguation, impact should refuse to silently pick
+      // a candidate and instead surface the ambiguity.
+      const result = await backend.callTool('impact', {
+        target: 'authenticate',
+        direction: 'upstream',
+      });
+      expect(result.status).toBe('ambiguous');
+      expect(result.candidates.length).toBeGreaterThanOrEqual(2);
+      const filePaths = result.candidates.map((c: any) => c.filePath).sort();
+      expect(filePaths).toContain('src/auth.ts');
+      expect(filePaths).toContain('src/base.ts');
+      expect(result.suggestion).toContain('file_path');
     });
 
     it('does not return HAS_METHOD results when filtering by CALLS only', async () => {

--- a/gitnexus/test/unit/impact-ambiguous-resolution.test.ts
+++ b/gitnexus/test/unit/impact-ambiguous-resolution.test.ts
@@ -1,0 +1,252 @@
+/**
+ * Unit Tests: #10 ambiguous candidate resolution and #75 Method seed expansion
+ *
+ * Verifies:
+ *   - #10: When a target name matches symbols in MULTIPLE distinct files
+ *     (e.g., GetOrder in handlers/ vs services/), impact() returns the
+ *     same `status: 'ambiguous'` shape as the context tool, instead of
+ *     silently picking the first candidate.
+ *   - #10: When a file_path is supplied, the matching candidate wins.
+ *   - #75: When the target is a Class node, the seed expansion includes
+ *     Method (not just Constructor) nodes, so the BFS can reach method-level
+ *     CALLS at deeper depths.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const executeQueryMock = vi.fn();
+const executeParameterizedMock = vi.fn();
+
+vi.mock('../../src/mcp/core/lbug-adapter.js', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    initLbug: vi.fn(),
+    executeQuery: (...args: any[]) => executeQueryMock(...args),
+    executeParameterized: (...args: any[]) => executeParameterizedMock(...args),
+    closeLbug: vi.fn(),
+    isLbugReady: vi.fn().mockReturnValue(true),
+  };
+});
+
+import { LocalBackend } from '../../src/mcp/local/local-backend';
+
+function makeBackend(repoId = 'test-repo') {
+  const backend = new LocalBackend();
+  const repoHandle = {
+    id: repoId,
+    name: repoId,
+    repoPath: `/tmp/${repoId}`,
+    storagePath: `/tmp/${repoId}/.gitnexus`,
+    lbugPath: `/tmp/${repoId}/.gitnexus/lbug`,
+    indexedAt: 'now',
+    lastCommit: 'c',
+    stats: {},
+  } as any;
+  (backend as any).repos.set(repoHandle.id, repoHandle);
+  (backend as any).ensureInitialized = vi.fn().mockResolvedValue(undefined);
+  return { backend, repoHandle };
+}
+
+function callsWithQuery(substr: string) {
+  return executeParameterizedMock.mock.calls.filter((call: any[]) => {
+    const query = typeof call[1] === 'string' ? call[1] : '';
+    return query.includes(substr);
+  });
+}
+
+// ─── #10: Ambiguous candidate resolution ─────────────────────────────
+
+describe('impact: #10 ambiguous candidate resolution', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    executeQueryMock.mockImplementation(async () => []);
+    executeParameterizedMock.mockImplementation(async () => []);
+  });
+
+  it('A1.1: same name in two different files returns ambiguous status', async () => {
+    const { backend, repoHandle } = makeBackend();
+
+    executeParameterizedMock.mockImplementation(async (...args: any[]) => {
+      const query = typeof args[1] === 'string' ? args[1] : '';
+      // The priority UNION query returns TWO matches across files.
+      if (query.includes('UNION ALL')) {
+        return [
+          { id: 'Method:services/order_service.go:GetOrder', name: 'GetOrder', filePath: 'services/order_service.go', priority: 3 },
+          { id: 'Method:handlers/order_handler.go:GetOrder', name: 'GetOrder', filePath: 'handlers/order_handler.go', priority: 3 },
+        ];
+      }
+      return [];
+    });
+
+    const result = await (backend as any)._impactImpl(repoHandle, {
+      target: 'GetOrder',
+      direction: 'upstream',
+      maxDepth: 3,
+    });
+
+    // Must be the ambiguous shape, NOT silently pick the first candidate.
+    expect(result.status).toBe('ambiguous');
+    expect(result.target).toBe('GetOrder');
+    expect(result.candidates).toHaveLength(2);
+    const filePaths = result.candidates.map((c: any) => c.filePath).sort();
+    expect(filePaths).toEqual(['handlers/order_handler.go', 'services/order_service.go']);
+    expect(result.candidates[0]).toHaveProperty('uid');
+    expect(result.candidates[0]).toHaveProperty('kind');
+    expect(result.suggestion).toContain('file_path');
+  });
+
+  it('A1.2: same name in SAME file (e.g., Class + Constructor) silently prefers Class', async () => {
+    const { backend, repoHandle } = makeBackend();
+
+    executeParameterizedMock.mockImplementation(async (...args: any[]) => {
+      const query = typeof args[1] === 'string' ? args[1] : '';
+      if (query.includes('UNION ALL')) {
+        return [
+          { id: 'Constructor:UserService:UserService', name: 'UserService', filePath: 'svc/UserService.java', priority: 4 },
+          { id: 'Class:UserService', name: 'UserService', filePath: 'svc/UserService.java', priority: 0 },
+        ];
+      }
+      return [];
+    });
+
+    const result = await (backend as any)._impactImpl(repoHandle, {
+      target: 'UserService',
+      direction: 'upstream',
+      maxDepth: 3,
+    });
+
+    // Same file → not ambiguous; Class wins via priority sort.
+    expect(result.status).toBeUndefined();
+    expect(result.target.id).toBe('Class:UserService');
+  });
+
+  it('A1.3: file_path parameter disambiguates and returns the matching candidate', async () => {
+    const { backend, repoHandle } = makeBackend();
+
+    executeParameterizedMock.mockImplementation(async (...args: any[]) => {
+      const query = typeof args[1] === 'string' ? args[1] : '';
+      if (query.includes('UNION ALL')) {
+        return [
+          { id: 'Method:services/order_service.go:GetOrder', name: 'GetOrder', filePath: 'services/order_service.go', priority: 3 },
+          { id: 'Method:handlers/order_handler.go:GetOrder', name: 'GetOrder', filePath: 'handlers/order_handler.go', priority: 3 },
+        ];
+      }
+      return [];
+    });
+
+    const result = await (backend as any)._impactImpl(repoHandle, {
+      target: 'GetOrder',
+      direction: 'upstream',
+      maxDepth: 3,
+      file_path: 'handlers/order_handler.go',
+    });
+
+    // file_path is supplied → not ambiguous; pick the matching candidate.
+    expect(result.status).toBeUndefined();
+    expect(result.target.id).toBe('Method:handlers/order_handler.go:GetOrder');
+  });
+
+  it('A1.4: single candidate does NOT trigger ambiguous even without file_path', async () => {
+    const { backend, repoHandle } = makeBackend();
+
+    executeParameterizedMock.mockImplementation(async (...args: any[]) => {
+      const query = typeof args[1] === 'string' ? args[1] : '';
+      if (query.includes('UNION ALL')) {
+        return [
+          { id: 'Class:OrderService', name: 'OrderService', filePath: 'svc/OrderService.java', priority: 0 },
+        ];
+      }
+      return [];
+    });
+
+    const result = await (backend as any)._impactImpl(repoHandle, {
+      target: 'OrderService',
+      direction: 'upstream',
+      maxDepth: 3,
+    });
+
+    expect(result.status).toBeUndefined();
+    expect(result.target.id).toBe('Class:OrderService');
+  });
+});
+
+// ─── #75: Class seed expansion includes Method nodes ────────────────
+
+describe('impact: #75 Class seed expansion includes Method nodes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    executeQueryMock.mockImplementation(async () => []);
+    executeParameterizedMock.mockImplementation(async () => []);
+  });
+
+  it('A2.1: Class target triggers BOTH Constructor and Method seed queries', async () => {
+    const { backend, repoHandle } = makeBackend();
+
+    executeParameterizedMock.mockImplementation(async (...args: any[]) => {
+      const query = typeof args[1] === 'string' ? args[1] : '';
+      // uid query → return Class
+      if (query.includes('n.id = $targetName')) {
+        return [{ id: 'Class:PricingBackendController', name: 'PricingBackendController', type: 'Class', filePath: 'ctrl/PricingBackendController.java' }];
+      }
+      // Method seed query (HAS_METHOD → Method) — must be present
+      if (query.includes('HAS_METHOD') && query.includes('Method') && !query.includes('Constructor')) {
+        return [
+          { id: 'Method:pricingIConnect', name: 'pricingIConnect', type: 'Method', filePath: 'ctrl/PricingBackendController.java' },
+          { id: 'Method:getQuote', name: 'getQuote', type: 'Method', filePath: 'ctrl/PricingBackendController.java' },
+        ];
+      }
+      // Constructor seed query
+      if (query.includes('HAS_METHOD') && query.includes('Constructor')) {
+        return [];
+      }
+      if (query.includes('DEFINES')) {
+        return [{ id: 'File:PricingBackendController.java', name: 'PricingBackendController.java', type: 'File', filePath: 'ctrl/PricingBackendController.java' }];
+      }
+      return [];
+    });
+
+    await (backend as any)._impactImpl(repoHandle, {
+      target: 'Class:PricingBackendController',
+      direction: 'downstream',
+      maxDepth: 5,
+    });
+
+    // Both seed queries must be invoked.
+    const methodSeedCalls = callsWithQuery('HAS_METHOD').filter(c => c[1].includes('Method') && !c[1].includes('Constructor'));
+    expect(methodSeedCalls.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('A2.2: Method seed nodes are added to the BFS frontier', async () => {
+    const { backend, repoHandle } = makeBackend();
+    const visitedIds: string[] = [];
+    let methodSeedCalled = false;
+
+    executeParameterizedMock.mockImplementation(async (...args: any[]) => {
+      const query = typeof args[1] === 'string' ? args[1] : '';
+      if (query.includes('n.id = $targetName')) {
+        return [{ id: 'Class:MyService', name: 'MyService', type: 'Class', filePath: 'svc/MyService.java' }];
+      }
+      if (query.includes('HAS_METHOD') && query.includes('Method') && !query.includes('Constructor')) {
+        methodSeedCalled = true;
+        return [{ id: 'Method:doWork', name: 'doWork', type: 'Method', filePath: 'svc/MyService.java' }];
+      }
+      if (query.includes('DEFINES')) {
+        return [];
+      }
+      return [];
+    });
+
+    // Capture the frontier by hooking the BFS query (returns empty, so we
+    // can only verify that the seed was invoked).
+    await (backend as any)._impactImpl(repoHandle, {
+      target: 'Class:MyService',
+      direction: 'downstream',
+      maxDepth: 3,
+    });
+
+    expect(methodSeedCalled).toBe(true);
+    // Indirection: we can't directly observe visited without graph
+    // integration, but the fact that the seed query was issued is the
+    // critical contract.
+  });
+});


### PR DESCRIPTION
Fixes two impact-tool bugs in a single PR.

#10: impact silently picks wrong candidate for ambiguous names
- The priority-based name query used LIMIT 1 per type, so a name like GetOrder in both handlers/order_handler.go and services/order_service.go silently resolved to the first candidate — understating blast radius when the second candidate has meaningful upstream callers.
- Now collects ALL matches across types, dedupes by id, sorts by priority (Class wins over Constructor per #480), and returns status: 'ambiguous' with a candidates[] list when multiple distinct files match — mirroring the contract the context tool already uses. The caller can re-run with file_path to scope to a single candidate.
- Same-file matches (e.g., a Class and its Constructor with the same name) still silently prefer Class via the priority sort, preserving #480.

#75: maxDepth has no effect when target is a Class node
- The Class/Interface seed expansion only collected Constructor nodes via HAS_METHOD, missing the regular Method nodes that hold the actual downstream CALLS edges. With maxDepth=10, traversal from a Class would stop after IMPORTS at depth 1, never reaching method-level dependencies.
- The seed now also collects Method nodes. They are added to the BFS frontier but NOT to visited — so depth-1 HAS_METHOD edges from the Class are still discoverable as legitimate 'direct callers', and the Method nodes themselves are traversed at depth 2+ for their outgoing CALLS/IMPORTS/etc.

Tests:
- New impact-ambiguous-resolution.test.ts: 6 unit tests covering the ambiguous / same-file / file_path paths plus the Method seed expansion.
- local-backend-calltool.test.ts: updated OVERRIDES test to disambiguate via file_path (the seed has authenticate in two files); added new test asserting the ambiguous shape for the un-disambiguated case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)