### PR TITLE
fix(#64): impacted_endpoints honors max_depth=0 instead of coercing it to 3

### DIFF
--- a/gitnexus/src/mcp/local/local-backend.ts
+++ b/gitnexus/src/mcp/local/local-backend.ts
@@ -1869,7 +1869,12 @@ export class LocalBackend {
   ): Promise<any> {
     await this.ensureInitialized(repo.id);
 
-    const maxDepth = params.max_depth || 3;
+    // (#64) Use `??` (nullish coalescing) instead of `||` so that a user-
+    // supplied `max_depth=0` is honored as "no upstream traversal" rather
+    // than coerced to the default 3. The `||` operator treats 0 as falsy,
+    // which silently turned `max_depth=0` into `max_depth=3` and made all
+    // four documented values (0/1/5/10) return identical results.
+    const maxDepth = params.max_depth ?? 3;
     const minConfidence = params.min_confidence ?? 0.7;
 
     // ── 1. Git diff → changed files with line ranges ─────────────────

--- a/gitnexus/test/unit/impacted-endpoints-impl.test.ts
+++ b/gitnexus/test/unit/impacted-endpoints-impl.test.ts
@@ -1193,6 +1193,45 @@ describe('_impactedEndpointsImpl', () => {
       expect(bfsCallCount).toBe(6);
     });
 
+    // U-BFS10a: max_depth=0 should disable upstream traversal (#64)
+    it('honors max_depth=0 and skips upstream traversal entirely', async () => {
+      setupGitDiff(['FormatUtil.java']);
+      const fileSymbols: Record<string, any[]> = {
+        'FormatUtil.java': [
+          { id: 'sym-format', name: 'formatUser', type: 'Method', filePath: 'FormatUtil.java' },
+        ],
+      };
+      setupFileSymbols(fileSymbols);
+
+      let bfsCallCount = 0;
+      executeQueryMock.mockImplementation(async (...args: any[]) => {
+        const query = typeof args[1] === 'string' ? args[1] : String(args[0] ?? '');
+        if (query.includes('r.type IN')) {
+          bfsCallCount++;
+          // Should never be called when max_depth=0
+          return [{ sourceId: 'sym-format', id: 'sym-service', name: 'getUser', type: 'Method', filePath: 'UserService.java', relType: 'CALLS', confidence: 0.9 }];
+        }
+        return [];
+      });
+
+      executeParameterizedMock.mockImplementation(async (...args: any[]) => {
+        const query = typeof args[1] === 'string' ? args[1] : String(args[0] ?? '');
+        if (query.includes('n.filePath CONTAINS')) {
+          return fileSymbols[args[2]?.filePath] || [];
+        }
+        return [];
+      });
+
+      await (backend as any)._impactedEndpointsImpl(
+        (backend as any).repos.get('repo-ie'),
+        { scope: 'unstaged', max_depth: 0 },
+      );
+
+      // (#64) Before the fix, `0 || 3` coerced max_depth=0 to 3, so the
+      // BFS would run. Now it must run ZERO times.
+      expect(bfsCallCount).toBe(0);
+    });
+
     // U-BFS11: OVERRIDES edge traversal
     it('follows OVERRIDES edges during BFS traversal and records them in expandedMeta', async () => {
       setupGitDiff(['CashServiceV2Impl.java']);


### PR DESCRIPTION
The `_impactedEndpointsImpl` BFS used `params.max_depth || 3` to apply the default, but the `||` operator treats 0 as falsy. So a user explicitly passing `max_depth=0` got 3 instead — making the parameter appear to have no effect (0, 1, 5, 10 all produced identical results because 0 was silently bumped to 3 and the others were all large enough to traverse the same shallow graph).

Switched to `??` (nullish coalescing) so a deliberate 0 means 'no upstream traversal' — the route discovery then only finds Routes directly attached to changed files (via DEFINES, HANDLES_ROUTE, or annotation-fallback on Controller methods in changed files).

The interface-resolution step already filters by depth (<= 2), and the route discovery queries operate on the full expanded set, so the fix is purely at the default-coercion boundary.

Added U-BFS10a test: max_depth=0 must run ZERO BFS queries (was running 1+ before the fix due to the falsy coercion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)