### PR TITLE
fix(#28,#49): impacted_endpoints summary uses per-repo Record for all count fields

### DIFF
--- a/gitnexus/src/mcp/local/local-backend.ts
+++ b/gitnexus/src/mcp/local/local-backend.ts
@@ -119,9 +119,9 @@ export interface RepoHandle {
 /** Summary shape for impacted_endpoints — always uses Record<string, number> for per-repo counts. */
 interface ImpactedEndpointsSummary {
   changed_files: Record<string, number>;
+  changed_symbols: Record<string, number>;
   impacted_endpoints: Record<string, number>;
   risk_level: string;
-  changed_symbols?: number;
 }
 
 /** Asserts that a value is a non-null object (Record<string, number>), not a bare number. */
@@ -670,7 +670,17 @@ export class LocalBackend {
         );
 
         const aggregated: any = {
-          summary: { changed_files: {} as Record<string, number>, impacted_endpoints: {} as Record<string, number> },
+          // (#28, #49) Every count field is a per-repo Record so the
+          // single-repo and multi-repo shapes are identical. `changed_symbols`
+          // was previously omitted from the multi-repo summary entirely
+          // (issue #49) and `changed_files` could be a number in the
+          // single-repo path (issue #28). Now both are uniformly
+          // Record<string, number>.
+          summary: {
+            changed_files: {} as Record<string, number>,
+            changed_symbols: {} as Record<string, number>,
+            impacted_endpoints: {} as Record<string, number>,
+          },
           impacted_endpoints: { WILL_BREAK: [] as any[], LIKELY_AFFECTED: [] as any[], MAY_NEED_TESTING: [] as any[] },
           changed_symbols: [] as any[],
           affected_processes: [] as any[],
@@ -688,6 +698,16 @@ export class LocalBackend {
               Object.assign(aggregated.summary.changed_files, cf);
             } else if (typeof cf === 'number') {
               aggregated.summary.changed_files[repoId] = cf;
+            }
+            // (#49) Aggregate changed_symbols into the per-repo summary
+            // Record. Tolerate both the new Record shape and the legacy
+            // bare number for backward compatibility with single-repo
+            // callers that may still return the old shape.
+            const cs = result.summary?.changed_symbols;
+            if (typeof cs === 'object' && cs !== null && !Array.isArray(cs)) {
+              Object.assign(aggregated.summary.changed_symbols, cs);
+            } else if (typeof cs === 'number') {
+              aggregated.summary.changed_symbols[repoId] = cs;
             }
             // Merge impacted_endpoints: Record format or coerce bare number (backward compat)
             const ie = result.summary?.impacted_endpoints;
@@ -1901,7 +1921,10 @@ export class LocalBackend {
       fileLineRanges = new Map(); // empty = whole-file resolution
     } else if (lineDiffResult.length === 0) {
       return {
-        summary: { changed_files: { [repo.id]: 0 }, changed_symbols: 0, impacted_endpoints: { [repo.id]: 0 }, risk_level: 'none' },
+        // (#28, #49) summary fields use per-repo Record<string, number>
+        // consistently — both in the single-repo and multi-repo aggregator
+        // paths, so consumers can rely on a uniform shape.
+        summary: { changed_files: { [repo.id]: 0 }, changed_symbols: { [repo.id]: 0 }, impacted_endpoints: { [repo.id]: 0 }, risk_level: 'none' },
         impacted_endpoints: { WILL_BREAK: [], LIKELY_AFFECTED: [], MAY_NEED_TESTING: [] },
         changed_symbols: [], affected_processes: [], affected_modules: [],
         _meta: { version: '1.0', generated_at: new Date().toISOString() },
@@ -1915,7 +1938,8 @@ export class LocalBackend {
 
     if (changedFiles.length === 0) {
       return {
-        summary: { changed_files: { [repo.id]: 0 }, changed_symbols: 0, impacted_endpoints: { [repo.id]: 0 }, risk_level: 'none' },
+        // (#28, #49) see comment on the lineDiffResult.length === 0 branch
+        summary: { changed_files: { [repo.id]: 0 }, changed_symbols: { [repo.id]: 0 }, impacted_endpoints: { [repo.id]: 0 }, risk_level: 'none' },
         impacted_endpoints: { WILL_BREAK: [], LIKELY_AFFECTED: [], MAY_NEED_TESTING: [] },
         changed_symbols: [], affected_processes: [], affected_modules: [],
         _meta: { version: '1.0', generated_at: new Date().toISOString() },
@@ -1973,9 +1997,10 @@ export class LocalBackend {
 
     if (changedSymbols.length === 0) {
       return {
+        // (#28, #49) see comment on the lineDiffResult.length === 0 branch
         summary: {
           changed_files: { [repo.id]: changedFiles.length },
-          changed_symbols: 0,
+          changed_symbols: { [repo.id]: 0 },
           impacted_endpoints: { [repo.id]: 0 },
           risk_level: 'none',
         },
@@ -2730,9 +2755,13 @@ export class LocalBackend {
 
     // ── 8. Return shape ─────────────────────────────────────────────
     return {
+      // (#28, #49) per-repo Record<string, number> for ALL count fields,
+      // matching the multi-repo aggregator shape. Consumers no longer need
+      // to type-check whether `changed_files` is a number or an object —
+      // it is always an object keyed by repoId.
       summary: {
         changed_files: { [repo.id]: changedFiles.length },
-        changed_symbols: changedSymbols.length,
+        changed_symbols: { [repo.id]: changedSymbols.length },
         impacted_endpoints: { [repo.id]: endpointCount },
         risk_level: risk,
       },

--- a/gitnexus/test/unit/impacted-endpoints-impl.test.ts
+++ b/gitnexus/test/unit/impacted-endpoints-impl.test.ts
@@ -245,7 +245,9 @@ describe('_impactedEndpointsImpl', () => {
 
     expect(result.summary).toBeDefined();
     expect(result.summary.changed_files).toEqual({ 'repo-ie': 2 });
-    expect(result.summary.changed_symbols).toBe(2);
+    // (#28, #49) summary.changed_symbols is now per-repo Record like
+    // changed_files, not a bare number.
+    expect(result.summary.changed_symbols).toEqual({ 'repo-ie': 2 });
     expect(result.summary.impacted_endpoints).toEqual({ 'repo-ie': expect.any(Number) });
     expect((result.summary.impacted_endpoints as Record<string, number>)['repo-ie']).toBeGreaterThanOrEqual(1);
     expect(result.impacted_endpoints).toBeDefined();
@@ -265,7 +267,7 @@ describe('_impactedEndpointsImpl', () => {
     );
 
     expect(result.summary.changed_files).toEqual({ 'repo-ie': 0 });
-    expect(result.summary.changed_symbols).toBe(0);
+    expect(result.summary.changed_symbols).toEqual({ 'repo-ie': 0 });
     expect(result.summary.impacted_endpoints).toEqual({ 'repo-ie': 0 });
     expect(result.summary.risk_level).toBe('none');
     expect(result.impacted_endpoints.WILL_BREAK).toEqual([]);
@@ -285,7 +287,7 @@ describe('_impactedEndpointsImpl', () => {
     );
 
     expect(result.summary.changed_files).toEqual({ 'repo-ie': 1 });
-    expect(result.summary.changed_symbols).toBe(0);
+    expect(result.summary.changed_symbols).toEqual({ 'repo-ie': 0 });
     expect(result.summary.risk_level).toBe('none');
   });
 
@@ -1283,7 +1285,7 @@ describe('_impactedEndpointsImpl', () => {
       expect(result).toBeDefined();
       expect(result.summary.changed_files).toEqual({ 'repo-ie': 1 });
       // changed_symbols includes only the initial changed file symbol
-      expect(result.summary.changed_symbols).toBeGreaterThanOrEqual(1);
+      expect((result.summary.changed_symbols as Record<string, number>)['repo-ie']).toBeGreaterThanOrEqual(1);
     });
 
     // U-IMPL01: IMPLEMENTS resolution discovers interface callers in BFS
@@ -1442,7 +1444,7 @@ describe('_impactedEndpointsImpl', () => {
       expect(result).toBeDefined();
       expect(result.summary.changed_files).toEqual({ 'repo-ie': 1 });
       // Direct caller is still found via normal BFS
-      expect(result.summary.changed_symbols).toBeGreaterThanOrEqual(1);
+      expect((result.summary.changed_symbols as Record<string, number>)['repo-ie']).toBeGreaterThanOrEqual(1);
     });
 
     // U-IMPL03: Depth cap prevents IMPLEMENTS resolution beyond depth 2
@@ -2750,7 +2752,7 @@ describe('_impactedEndpointsImpl', () => {
       // No changed symbols → no BFS → no cross-repo query
       expect(mockCrossRepo.listDepRepos).not.toHaveBeenCalled();
       expect(mockCrossRepo.queryMultipleRepos).not.toHaveBeenCalled();
-      expect(result.summary.changed_symbols).toBe(0);
+      expect(result.summary.changed_symbols).toEqual({ 'repo-ie': 0 });
     });
 
     it('works without crossRepo (backward compatible)', async () => {
@@ -3523,7 +3525,7 @@ describe('_impactedEndpointsImpl', () => {
       expect(result).not.toHaveProperty('error');
       expect(result.summary.risk_level).toBe('none');
       expect(result.summary.changed_files).toEqual({ 'repo-ie': 0 });
-      expect(result.summary.changed_symbols).toBe(0);
+      expect(result.summary.changed_symbols).toEqual({ 'repo-ie': 0 });
     });
 
     // U-E03: scope=compare without base_ref
@@ -3641,7 +3643,7 @@ describe('_impactedEndpointsImpl', () => {
       );
 
       expect(result.summary.changed_files).toEqual({ 'repo-ie': 3 });
-      expect(result.summary.changed_symbols).toBe(0);
+      expect(result.summary.changed_symbols).toEqual({ 'repo-ie': 0 });
       expect(result.summary.risk_level).toBe('none');
     });
 
@@ -3664,7 +3666,7 @@ describe('_impactedEndpointsImpl', () => {
 
       expect(result).not.toHaveProperty('error');
       expect(result.summary.changed_files).toEqual({ 'repo-ie': 1 });
-      expect(result.summary.changed_symbols).toBe(1);
+      expect(result.summary.changed_symbols).toEqual({ 'repo-ie': 1 });
       expect(result.changed_symbols[0].filePath).toBe(longPath);
     });
   });
@@ -3810,9 +3812,39 @@ describe('_impactedEndpointsImpl', () => {
       // Pipeline should still produce results even if health check errors
       expect(result.summary).toBeDefined();
       expect(result.summary.changed_files).toEqual({ 'repo-ie': 1 });
-      expect(result.summary.changed_symbols).toBe(1);
+      expect(result.summary.changed_symbols).toEqual({ 'repo-ie': 1 });
       // Health check error was caught silently — diagnostics may or may not be present
       // depending on which checks failed before the catch, but result is never blocked
+    });
+
+    // (#28, #49) The single-repo summary now uses per-repo Record for ALL
+    // count fields. This test pins the contract so a future "optimization"
+    // doesn't regress it back to a bare number.
+    it('summary uses per-repo Record for changed_files, changed_symbols, AND impacted_endpoints', async () => {
+      setupGitDiff(['Single.java']);
+      setupFileSymbols({
+        'Single.java': [
+          { id: 'sym-single', name: 'doWork', type: 'Method', filePath: 'Single.java' },
+        ],
+      });
+
+      // Empty BFS — all counts end up at 0/1
+      executeQueryMock.mockImplementation(async () => []);
+
+      const result = await (backend as any)._impactedEndpointsImpl(
+        (backend as any).repos.get('repo-ie'),
+        { scope: 'unstaged' },
+      );
+
+      // Every count field must be a Record (not a bare number)
+      expect(typeof result.summary.changed_files).toBe('object');
+      expect(result.summary.changed_files).toEqual({ 'repo-ie': 1 });
+      expect(typeof result.summary.changed_symbols).toBe('object');
+      expect(result.summary.changed_symbols).toEqual({ 'repo-ie': 1 });
+      expect(typeof result.summary.impacted_endpoints).toBe('object');
+      expect(result.summary.impacted_endpoints).toEqual({ 'repo-ie': 0 });
+      // risk_level stays a scalar
+      expect(typeof result.summary.risk_level).toBe('string');
     });
   });
 


### PR DESCRIPTION
Fixes two response-format consistency bugs in a single PR.

#49 (cross-repo summary omits changed_symbols):
The multi-repo aggregator's summary initializer declared only `changed_files` and `impacted_endpoints` — `changed_symbols` was silently absent from the cross-repo summary, even though the per-repo body had the array of changed_symbols with _repoId attribution.

#28 (changed_files type inconsistent):
The single-repo path returned `changed_files: {repoId: N}` (object) but `changed_symbols: N` (bare number) in the same summary. Clients consuming the summary had to type-check the changed_files field because it could be a number, an object with one repo key, or an object with multiple repo keys depending on the parameter combination.

Fix:
- Single-repo path: `changed_symbols` is now `{ [repo.id]: N }` like the other count fields. Updated all 4 early-return summary constructors (no-changed-files, no-changed-symbols, success path).
- Multi-repo aggregator: `changed_symbols` is now initialized as `Record<string, number>` and populated from each per-repo result, with backward-compat coercion for any caller that still returns the bare-number shape.
- `ImpactedEndpointsSummary` type: `changed_symbols` is now required and a Record, not optional/number.

Tests:
- New 'summary uses per-repo Record for changed_files, changed_symbols, AND impacted_endpoints' test pins the unified contract.
- Updated 10 existing tests that asserted the bare-number shape for `changed_symbols`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)