### PR TITLE
fix(#55): annotation extractor handles Kotlin AST shape (constructor_invocation + value_argument)

### DIFF
--- a/gitnexus/src/core/ingestion/annotation-extractor.ts
+++ b/gitnexus/src/core/ingestion/annotation-extractor.ts
@@ -56,16 +56,47 @@ export function extractSingleAnnotation(node: Parser.SyntaxNode): AnnotationInfo
     return null;
   }
 
-  // Get annotation name - in tree-sitter-java, name is first identifier child
-  const nameNode = node.children.find(c => c.type === 'identifier' || c.type === 'scoped_identifier');
+  // (#55) Kotlin wraps the annotation name in a `constructor_invocation`
+  // node: annotation > constructor_invocation > user_type > type_identifier.
+  // Java keeps the identifier as a direct child of `annotation`. Kotlin
+  // marker annotations skip the constructor_invocation layer and go
+  // directly: annotation > user_type > type_identifier. Handle all
+  // three shapes so the extractor works for Java + Kotlin.
+  let nameNode = node.children.find(c => c.type === 'identifier' || c.type === 'scoped_identifier');
+  if (!nameNode) {
+    // Kotlin full annotation: annotation > constructor_invocation > user_type > type_identifier
+    const ctor = node.children.find(c => c.type === 'constructor_invocation');
+    if (ctor) {
+      const userType = ctor.children.find(c => c.type === 'user_type' || c.type === 'scoped_identifier');
+      if (userType) {
+        nameNode = userType.children.find(c => c.type === 'type_identifier' || c.type === 'scoped_identifier') ?? userType;
+      }
+    }
+  }
+  if (!nameNode) {
+    // Kotlin marker annotation: annotation > user_type > type_identifier
+    const userType = node.children.find(c => c.type === 'user_type' || c.type === 'scoped_identifier');
+    if (userType) {
+      nameNode = userType.children.find(c => c.type === 'type_identifier' || c.type === 'scoped_identifier') ?? userType;
+    }
+  }
   if (!nameNode) return null;
 
   const name = '@' + nameNode.text;
   const annInfo: AnnotationInfo = { name };
 
-  // If it's a full annotation, extract arguments
+  // If it's a full annotation, extract arguments. Java uses
+  // `annotation_argument_list`; Kotlin uses `value_arguments` (nested
+  // inside `constructor_invocation`).
   if (node.type === 'annotation') {
-    const argsList = node.childForFieldName('arguments') ?? node.children.find(c => c.type === 'annotation_argument_list');
+    let argsList = node.childForFieldName('arguments')
+      ?? node.children.find(c => c.type === 'annotation_argument_list');
+    if (!argsList) {
+      const ctor = node.children.find(c => c.type === 'constructor_invocation');
+      if (ctor) {
+        argsList = ctor.children.find(c => c.type === 'value_arguments');
+      }
+    }
     if (argsList) {
       annInfo.attrs = extractAnnotationArgs(argsList);
     }
@@ -77,7 +108,7 @@ export function extractSingleAnnotation(node: Parser.SyntaxNode): AnnotationInfo
 /**
  * Extracts key-value pairs from an annotation_argument_list.
  * Handles:
- * - Named args: key = value
+ * - Named args: key = value (Java `element_value_pair` or Kotlin `value_argument`)
  * - Unnamed args: value (stored with numeric index as key)
  * - Nested annotations: @Backoff(delay = 1000)
  */
@@ -85,20 +116,38 @@ function extractAnnotationArgs(argsList: Parser.SyntaxNode): Record<string, stri
   const attrs: Record<string, string> = {};
 
   for (const child of argsList.children) {
-    // element_value_pair: key = value
-    if (child.type === 'element_value_pair') {
-      const keyNode = child.children.find(c => c.type === 'identifier');
+    // Java: element_value_pair: key = value (key is `identifier`)
+    // Kotlin: value_argument: key = value (key is `simple_identifier`)
+    if (child.type === 'element_value_pair' || child.type === 'value_argument') {
+      // Detect named vs unnamed: Kotlin unnamed args like
+      // `@GetMapping("/users")` produce value_argument without a `simple_identifier`
+      // key (just a string literal value). Use the presence of `=` as the
+      // marker for named args.
+      const hasEquals = child.children.some(c => c.type === '=');
+      if (!hasEquals) {
+        // Unnamed Kotlin value_argument: the value is its first non-trivial child.
+        const value = extractArgValue(child.children.find(c =>
+          c.type !== '(' && c.type !== ')' && !c.text.match(/^\s*$/)
+        ));
+        if (value !== null) {
+          const idx = Object.keys(attrs).filter(k => k.match(/^\d+$/)).length;
+          attrs[String(idx)] = value;
+        }
+        continue;
+      }
+      const keyNode = child.children.find(c => c.type === 'identifier' || c.type === 'simple_identifier');
       if (!keyNode) continue;
 
       const key = keyNode.text;
       const value = extractArgValue(child.children.find(c =>
-        c.type !== 'identifier' && c.type !== '=' && !c.text.match(/^\s*$/)
+        c.type !== 'identifier' && c.type !== 'simple_identifier' &&
+        c.type !== '=' && !c.text.match(/^\s*$/)
       ));
       if (value !== null) {
         attrs[key] = value;
       }
     }
-    // Unnamed argument: single value (e.g., @GetMapping("/users"))
+    // Unnamed argument: single value (e.g., @GetMapping("/users") in Java)
     else if (child.type === 'string_literal' || child.type === 'number' || child.type === 'true' || child.type === 'false' || child.type === 'identifier') {
       // Store with numeric index - first unnamed arg gets key "0"
       const idx = Object.keys(attrs).filter(k => k.match(/^\d+$/)).length;
@@ -147,6 +196,7 @@ function extractArgValue(node: Parser.SyntaxNode | undefined): string | null {
 
     case 'true':
     case 'false':
+    case 'boolean_literal':
       return node.text;
 
     case 'identifier':

--- a/gitnexus/test/unit/annotation-extraction.test.ts
+++ b/gitnexus/test/unit/annotation-extraction.test.ts
@@ -222,10 +222,14 @@ describe('extractAnnotations', () => {
       expect(() => extractAnnotations(declNode!)).not.toThrow();
     });
 
-    // TODO(#55): deeper Kotlin annotation assertions pending a real Kotlin extractor fix.
-    // Verified red on 2026-06-03: extractAnnotations returns [] for @Transactional / @GetMapping
-    // / @Transactional(readOnly = true) on Kotlin AST nodes. Keep skipped until extractor fix lands.
-    describe.skip('deep Kotlin annotation assertions (pending #55)', () => {
+    // (#55) Kotlin annotation extraction is now wired up. The
+    // extractor was previously Java-only — it expected an `identifier`
+    // child directly under `annotation`, but Kotlin's tree-sitter grammar
+    // wraps the name in `annotation > constructor_invocation >
+    // user_type > type_identifier` and the args in
+    // `constructor_invocation > value_arguments`. The extractor now
+    // handles both shapes.
+    describe('deep Kotlin annotation assertions', () => {
       it('extracts marker annotation (@Transactional)', () => {
         const code = `
           @Transactional


### PR DESCRIPTION
The Kotlin annotation extractor was hardcoded to Java's tree-sitter AST shape. The 3 'deep Kotlin annotation assertions' tests in annotation-extraction.test.ts were skipped because:

- Java:    annotation > identifier, annotation_argument_list
- Kotlin:  annotation > @, constructor_invocation > user_type > type_identifier
           constructor_invocation > value_arguments > value_argument
- Marker:  annotation > @, user_type > type_identifier (no constructor_invocation)

The Java extractor looked for a direct `identifier` child of the `annotation` node, never found it for Kotlin, and returned [].

Fix in extractSingleAnnotation:
- Java shape:  annotation > identifier / scoped_identifier (existing path)
- Kotlin full: annotation > constructor_invocation > user_type > type_identifier
- Kotlin marker: annotation > user_type > type_identifier (no ctor layer)

Fix in extractAnnotationArgs:
- Look for `value_arguments` inside `constructor_invocation` (Kotlin) in addition to the Java `annotation_argument_list`.
- Accept `value_argument` node type (Kotlin) alongside Java's `element_value_pair`; use the presence of `=` to distinguish named vs unnamed args. Unnamed Kotlin value_argument holds a literal directly (e.g., @GetMapping("/users")) — store under numeric index.
- Accept `simple_identifier` (Kotlin) as the key alongside Java's `identifier`.
- `extractArgValue`: added `boolean_literal` (Kotlin wraps true/false in this node) to the boolean case.

Tests:
- Un-skipped `describe.skip('deep Kotlin annotation assertions ...')` block. The 3 tests now pass (19/19 in the file).
- Full suite: 5426 passed, 50 skipped, 3 todo (no Java regressions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)