### PR TITLE
fix(#12): endpoints tool supports repos[] parameter for cross-repo queries

### DIFF
--- a/gitnexus/src/mcp/local/local-backend.ts
+++ b/gitnexus/src/mcp/local/local-backend.ts
@@ -598,6 +598,41 @@ export class LocalBackend {
         return aggregated;
       }
 
+      case 'endpoints': {
+        // (#12) Query Route nodes for HTTP endpoints across multiple repos.
+        // Mirrors the single-repo `endpoints` contract: each repo contributes
+        // its EndpointInfo[]; results are tagged with `_repoId`. Failed repos
+        // surface in `errors[]` rather than aborting the whole call.
+        const results = await Promise.all(
+          repoIds.map(async (repoId) => {
+            try {
+              const handle = await this.resolveRepo(repoId);
+              const result = await this.endpoints(handle, params);
+              return { repoId, result, error: null };
+            } catch (err: any) {
+              return { repoId, result: null, error: err.message };
+            }
+          })
+        );
+
+        const aggregated: any = {
+          endpoints: [] as any[],
+          errors: [] as { repoId: string; error: string }[],
+        };
+
+        for (const { repoId, result, error } of results) {
+          if (error) {
+            aggregated.errors.push({ repoId, error });
+          } else if (result?.endpoints) {
+            aggregated.endpoints.push(
+              ...result.endpoints.map((e: any) => ({ ...e, _repoId: repoId })),
+            );
+          }
+        }
+
+        return aggregated;
+      }
+
       case 'impact': {
         // Run impact analysis on multiple repos
         const results = await Promise.all(

--- a/gitnexus/test/unit/calltool-dispatch.test.ts
+++ b/gitnexus/test/unit/calltool-dispatch.test.ts
@@ -1156,6 +1156,91 @@ describe('callTool multi-repo routing', () => {
     });
   });
 
+  describe('endpoints tool with repos[] (#12)', () => {
+    it('routes to multi-repo handler when repos array is provided', async () => {
+      // (#12) Multi-repo `endpoints` should aggregate per-repo EndpointInfo[] with
+      // _repoId attribution — never the "Multiple repositories indexed" error.
+      vi.spyOn(backend as any, 'endpoints').mockImplementation(async (handle: any) => {
+        if (handle.id === 'test-project') {
+          return {
+            endpoints: [
+              { method: 'GET', path: '/api/users', controllerName: 'UserController', filePath: 'UserController.java', line: 25 },
+              { method: 'POST', path: '/api/users', controllerName: 'UserController', filePath: 'UserController.java', line: 42 },
+            ],
+          };
+        }
+        if (handle.id === 'other-project') {
+          return {
+            endpoints: [
+              { method: 'GET', path: '/api/orders/{id}', controllerName: 'OrderController', filePath: 'OrderController.java', line: 30 },
+            ],
+          };
+        }
+        return { endpoints: [] };
+      });
+
+      const result = await backend.callTool('endpoints', {
+        repos: ['test-project', 'other-project'],
+      });
+
+      // Aggregated with _repoId attribution
+      expect((result as any)).toHaveProperty('endpoints');
+      expect((result as any).endpoints).toHaveLength(3);
+      const tagged = (result as any).endpoints.filter((e: any) => e._repoId);
+      expect(tagged).toHaveLength(3);
+      expect((result as any).endpoints.filter((e: any) => e._repoId === 'test-project')).toHaveLength(2);
+      expect((result as any).endpoints.filter((e: any) => e._repoId === 'other-project')).toHaveLength(1);
+    });
+
+    it('filters endpoints by method across multiple repos', async () => {
+      // (#12) The method/path params must pass through to each repo's
+      // single-repo endpoints() call so filters work cross-repo.
+      vi.spyOn(backend as any, 'endpoints').mockImplementation(async (_handle: any, params: any) => {
+        const all = [
+          { method: 'GET', path: '/api/users' },
+          { method: 'POST', path: '/api/users' },
+        ];
+        if (params?.method) {
+          return { endpoints: all.filter(e => e.method === params.method) };
+        }
+        return { endpoints: all };
+      });
+
+      const result = await backend.callTool('endpoints', {
+        method: 'GET',
+        repos: ['test-project', 'other-project'],
+      });
+
+      // Both repos got the GET filter; result contains only GET entries
+      expect((result as any).endpoints.every((e: any) => e.method === 'GET')).toBe(true);
+      expect((result as any).endpoints.length).toBeGreaterThan(0);
+    });
+
+    it('surfaces per-repo errors without aborting the whole call', async () => {
+      // (#12) If one repo's endpoints() throws, the others still contribute.
+      // The failed repo is recorded in `errors[]` so callers can diagnose.
+      vi.spyOn(backend as any, 'endpoints').mockImplementation(async (handle: any) => {
+        if (handle.id === 'test-project') {
+          return { endpoints: [{ method: 'GET', path: '/api/users' }] };
+        }
+        if (handle.id === 'other-project') {
+          throw new Error('LadybugDB not ready');
+        }
+        return { endpoints: [] };
+      });
+
+      const result = await backend.callTool('endpoints', {
+        repos: ['test-project', 'other-project'],
+      });
+
+      expect((result as any).endpoints).toHaveLength(1);
+      expect((result as any).endpoints[0]._repoId).toBe('test-project');
+      expect((result as any).errors).toHaveLength(1);
+      expect((result as any).errors[0].repoId).toBe('other-project');
+      expect((result as any).errors[0].error).toMatch(/LadybugDB not ready/);
+    });
+  });
+
   describe('backward compatibility', () => {
     it('rejects repos[] for tools that do not support it', async () => {
       await expect(backend.callTool('rename', {


### PR DESCRIPTION
Fixes #12

The \`endpoints\` tool previously only supported a single repo via the \`repo\` parameter and rejected any \`repos[]\` call with \`does not support multi-repo queries\`. Users with multiple indexed repos could not list endpoints across repos in one call, unlike \`query\`/\`cypher\`/\`context\`/\`impact\` which already aggregate with \`_repoId\` attribution.

## Changes

- **\`src/mcp/local/local-backend.ts\`**: Add \`endpoints\` case to \`callToolMultiRepo\`. Each repo's \`EndpointInfo[]\` is flattened and tagged with \`_repoId\`; failures surface in \`errors[]\` without aborting.
- **\`test/unit/calltool-dispatch.test.ts\`**: 3 new tests covering aggregation with \`_repoId\`, \`method\` filter passthrough, and per-repo error isolation.

## Behavior

\`\`\`json
// Before:
endpoints(repos=["sample-spring-minimal", "sample-gin"])
  → { "error": "does not support multi-repo queries" }

// After:
endpoints(repos=["sample-spring-minimal", "sample-gin"])
  → { endpoints: [{method, path, ..., _repoId: "sample-spring-minimal"}, ...], errors: [] }
\`\`\`

Pattern matches the existing \`impacted_endpoints\` cross-repo contract.

## Verification

- Full suite: 5429 passed, 50 skipped, 3 todo
- \`tsc --noEmit\`: clean
- New tests: 3/3 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)