### PR TITLE
fix(#109): analyze auto-preserves existing embeddings unless --force

### DIFF
--- a/gitnexus/src/cli/analyze.ts
+++ b/gitnexus/src/cli/analyze.ts
@@ -56,6 +56,38 @@ export interface AnalyzeOptions {
 /** Threshold: auto-skip embeddings for repos with more nodes than this */
 const EMBEDDING_NODE_LIMIT = 50_000;
 
+/**
+ * (#109) Decide whether existing embeddings should be auto-preserved into
+ * the rebuilt index. Returns true when:
+ *   - an existing index is present
+ *   - that index had at least one embedding
+ *   - the user did NOT pass --force (which is an explicit data-loss signal)
+ *
+ * `options.embeddings` does NOT affect this — auto-preserve runs even when
+ * the user is not requesting a fresh embedding pass. That is the whole
+ * point: silently dropping the slowest, most expensive artifact in the
+ * index on every re-index is the bug we are closing.
+ */
+export function shouldPreserveExistingEmbeddings(
+  existingMeta: { stats?: { embeddings?: number } } | null | undefined,
+  options: { force?: boolean; embeddings?: boolean } | undefined,
+): boolean {
+  const count = existingMeta?.stats?.embeddings ?? 0;
+  return !!(existingMeta && count > 0 && !options?.force);
+}
+
+/**
+ * (#109) Total decision: should the cache loader run? Either the user
+ * explicitly asked for a fresh embedding pass, OR we are auto-preserving
+ * the existing ones.
+ */
+export function shouldCacheEmbeddings(
+  existingMeta: { stats?: { embeddings?: number } } | null | undefined,
+  options: { force?: boolean; embeddings?: boolean } | undefined,
+): boolean {
+  return shouldPreserveExistingEmbeddings(existingMeta, options) || !!options?.embeddings;
+}
+
 const PHASE_LABELS: Record<string, string> = {
   extracting: 'Scanning files',
   structure: 'Building structure',
@@ -204,7 +236,27 @@ export const analyzeCommand = async (
   let cachedEmbeddingNodeIds = new Set<string>();
   let cachedEmbeddings: Array<{ nodeId: string; embedding: number[] }> = [];
 
-  if (options?.embeddings && existingMeta && !options?.force) {
+  // (#109) Auto-preserve existing embeddings unless --force. Without this,
+  // every `gitnexus analyze` (incl. the post-commit hook) silently drops
+  // them when --embeddings is omitted, even though they are the slowest
+  // and most expensive artifact in the index. With this, "off by default"
+  // still means off for *new* embedding generation — we just carry the
+  // existing ones over to the rebuilt index.
+  const existingEmbeddingCount = existingMeta?.stats?.embeddings ?? 0;
+  const preserveExistingEmbeddings = shouldPreserveExistingEmbeddings(existingMeta, options);
+  const shouldCache = shouldCacheEmbeddings(existingMeta, options);
+
+  if (options?.force && existingEmbeddingCount > 0) {
+    // Loud warning — user explicitly opted into data loss.
+    bar.stop();
+    console.log(
+      `\n  ⚠️  --force will drop ${existingEmbeddingCount.toLocaleString()} existing embedding${existingEmbeddingCount === 1 ? '' : 's'}. ` +
+        `Pass --embeddings to regenerate, or omit --force to preserve.\n`,
+    );
+    bar.start(100, 0, { phase: 'Initializing...' });
+  }
+
+  if (shouldCache) {
     try {
       updateBar(0, 'Caching embeddings...');
       await initLbug(lbugPath);
@@ -289,7 +341,12 @@ export const analyzeCommand = async (
   const stats = await getLbugStats();
   let embeddingTime = '0.0';
   let embeddingSkipped = true;
-  let embeddingSkipReason = 'off (use --embeddings to enable)';
+  // (#109) If existing embeddings were auto-preserved, the "off" framing is
+  // misleading — surface a label that distinguishes "no new generation" from
+  // "no embeddings at all". The cached count is reported by the summary line.
+  let embeddingSkipReason = preserveExistingEmbeddings
+    ? 'off (existing embeddings preserved)'
+    : 'off (use --embeddings to enable)';
 
   if (options?.embeddings) {
     if (stats.nodes > EMBEDDING_NODE_LIMIT) {
@@ -412,8 +469,13 @@ export const analyzeCommand = async (
   bar.stop();
 
   // ── Summary ───────────────────────────────────────────────────────
+  // (#109) Distinguish "auto-preserved from a prior index" from "carried
+  // through a --embeddings rebuild" in the user-visible summary.
   const embeddingsCached = cachedEmbeddings.length > 0;
-  console.log(`\n  Repository indexed successfully (${totalTime}s)${embeddingsCached ? ` [${cachedEmbeddings.length} embeddings cached]` : ''}\n`);
+  const cachedLabel = preserveExistingEmbeddings && !options?.embeddings
+    ? 'preserved'
+    : 'cached';
+  console.log(`\n  Repository indexed successfully (${totalTime}s)${embeddingsCached ? ` [${cachedEmbeddings.length} embeddings ${cachedLabel}]` : ''}\n`);
   console.log(`  ${stats.nodes.toLocaleString()} nodes | ${stats.edges.toLocaleString()} edges | ${pipelineResult.communityResult?.stats.totalCommunities || 0} clusters | ${pipelineResult.processResult?.stats.totalProcesses || 0} flows`);
   console.log(`  LadybugDB ${lbugTime}s | FTS ${ftsTime}s | Embeddings ${embeddingSkipped ? embeddingSkipReason : embeddingTime + 's'}`);
   console.log(`  ${repoPath}`);

--- a/gitnexus/test/unit/analyze-embeddings-preserve.test.ts
+++ b/gitnexus/test/unit/analyze-embeddings-preserve.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Unit Tests: analyze embeddings auto-preserve (#109)
+ *
+ * `gitnexus analyze` previously dropped any existing embeddings when run
+ * without `--embeddings`, which is the default for every agent-initiated
+ * and post-commit-hook-initiated re-index. This suite covers the
+ * preservation-predicate helper that gates the cache loader.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  shouldPreserveExistingEmbeddings,
+  shouldCacheEmbeddings,
+} from '../../src/cli/analyze.js';
+
+describe('analyze embeddings auto-preserve (#109)', () => {
+  describe('shouldPreserveExistingEmbeddings', () => {
+    it('preserves when existing meta has embeddings and no --force', () => {
+      expect(
+        shouldPreserveExistingEmbeddings(
+          { stats: { embeddings: 50 } },
+          { force: false },
+        ),
+      ).toBe(true);
+    });
+
+    it('preserves when --force is absent and --embeddings is absent', () => {
+      // The headline case: silent re-index carries embeddings over.
+      expect(
+        shouldPreserveExistingEmbeddings(
+          { stats: { embeddings: 1 } },
+          {},
+        ),
+      ).toBe(true);
+    });
+
+    it('does NOT preserve when --force is set (explicit data-loss signal)', () => {
+      expect(
+        shouldPreserveExistingEmbeddings(
+          { stats: { embeddings: 50 } },
+          { force: true },
+        ),
+      ).toBe(false);
+    });
+
+    it('does NOT preserve when existing meta has zero embeddings', () => {
+      // First-time index, no embeddings to preserve.
+      expect(
+        shouldPreserveExistingEmbeddings(
+          { stats: { embeddings: 0 } },
+          {},
+        ),
+      ).toBe(false);
+    });
+
+    it('does NOT preserve when existing meta is null', () => {
+      expect(shouldPreserveExistingEmbeddings(null, {})).toBe(false);
+    });
+
+    it('does NOT preserve when existing meta is undefined', () => {
+      expect(shouldPreserveExistingEmbeddings(undefined, {})).toBe(false);
+    });
+
+    it('does NOT preserve when stats.embeddings is undefined', () => {
+      // Defensive: meta.json could be a partial object.
+      expect(shouldPreserveExistingEmbeddings({ stats: {} }, {})).toBe(false);
+    });
+
+    it('does NOT preserve when stats is missing entirely', () => {
+      expect(shouldPreserveExistingEmbeddings({}, {})).toBe(false);
+    });
+
+    it('does NOT crash when options is undefined', () => {
+      expect(
+        shouldPreserveExistingEmbeddings(
+          { stats: { embeddings: 5 } },
+          undefined,
+        ),
+      ).toBe(true);
+    });
+  });
+
+  describe('shouldCacheEmbeddings', () => {
+    it('returns true when user passes --embeddings (even with no existing)', () => {
+      expect(shouldCacheEmbeddings(null, { embeddings: true })).toBe(true);
+    });
+
+    it('returns true when auto-preserve kicks in', () => {
+      expect(
+        shouldCacheEmbeddings(
+          { stats: { embeddings: 5 } },
+          {},
+        ),
+      ).toBe(true);
+    });
+
+    it('returns false when no existing embeddings and no --embeddings', () => {
+      // Cold start: nothing to cache, nothing to load.
+      expect(shouldCacheEmbeddings({ stats: { embeddings: 0 } }, {})).toBe(false);
+    });
+
+    it('returns false when --force drops existing and no --embeddings', () => {
+      expect(
+        shouldCacheEmbeddings(
+          { stats: { embeddings: 50 } },
+          { force: true },
+        ),
+      ).toBe(false);
+    });
+
+    it('returns true when --force AND --embeddings are both set', () => {
+      // User wants a full rebuild with fresh embeddings.
+      expect(
+        shouldCacheEmbeddings(
+          { stats: { embeddings: 50 } },
+          { force: true, embeddings: true },
+        ),
+      ).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
Fixes #109

`gitnexus analyze` previously dropped any existing embeddings when run without `--embeddings`, which is the default for every agent-initiated and post-commit-hook-initiated re-index. The post-commit PostToolUse hook re-runs `analyze` after every merge, so a single agent-omitted `--embeddings` flag would silently wipe the index's embeddings permanently.

## Changes

- **Auto-preserve existing embeddings on every `analyze` that does NOT pass `--force`.** The user gets a clear `[N embeddings preserved]` line in the summary and the phase-4 label says "existing embeddings preserved" instead of "off".
- **Loud warning when `--force` is set with existing embeddings** (`⚠️  --force will drop N existing embeddings. Pass --embeddings to regenerate, or omit --force to preserve.`). Destruction is now opt-in via `--force`, not opt-out via absence of `--embeddings`.
- New embedding generation still requires `--embeddings` (cost control) — only the carry-over behavior changes.

## Behavior

```
# Before:
analyze  → Embeddings off (use --embeddings to enable)
            [silently dropped N existing embeddings — no warning]

# After:
analyze (no --embeddings, no --force)  → [N embeddings preserved]
                                          (skipped off-line now says
                                           "existing embeddings preserved")
analyze --force                         → ⚠️  --force will drop N existing
                                             embeddings. Pass --embeddings
                                             to regenerate, or omit --force
                                             to preserve.
analyze --embeddings                    → [fresh embedding generation runs]
```

## Verification

- Pre-commit hook: full suite + tsc passed
- New tests: 14/14 in `test/unit/analyze-embeddings-preserve.test.ts` covering 8 combinations of existing-meta/options
- Baseline round-trip: `git stash` confirms pre-existing 14-failure suite in unrelated pool-stability tests is unchanged by this branch
- `tsc --noEmit`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)