### PR TITLE
fix(#42): document-endpoint detects HTTP method mismatch and returns Did you mean X?

### DIFF
--- a/gitnexus/src/mcp/local/document-endpoint.ts
+++ b/gitnexus/src/mcp/local/document-endpoint.ts
@@ -820,7 +820,7 @@ export async function documentEndpoint(
 
   // Step 1: Try to find the Route node (may fail if Route table doesn't exist)
   let route: EndpointInfo | undefined;
-  
+
   try {
     const endpointsResult = await queryEndpoints(repo, { method, path });
     if (endpointsResult.endpoints && endpointsResult.endpoints.length > 0) {
@@ -830,6 +830,42 @@ export async function documentEndpoint(
   } catch (err: any) {
     if (DEBUG) console.error('[GitNexus DEBUG] Route query failed:', err);
     // Fall back to handler search
+  }
+
+  // (#42) When the user provided both method+path and the exact-match Route
+  // query returned nothing, the most likely cause is an HTTP-method mismatch
+  // (the path exists, but for a different method). Before falling through to
+  // the broader handler-pattern search — which may return a sibling route
+  // with a similar path and silently mis-document the wrong endpoint — do a
+  // path-only sweep to detect the mismatch and surface a "Did you mean X?"
+  // error. This is a hard fail: the caller asked for `GET /x` and there is
+  // no `GET /x`, only `POST /x`. Silent acceptance generated `get:` and
+  // `operationId: get_x` for a POST handler, which is the bug.
+  if (!route && method && path) {
+    try {
+      const pathOnlyResult = await queryEndpoints(repo, { path });
+      const mismatched = (pathOnlyResult.endpoints || []).filter(
+        (e) => e.method && e.method.toUpperCase() !== upperMethod,
+      );
+      if (mismatched.length > 0) {
+        // Dedupe by method (a path may have multiple Route nodes for the
+        // same method from inherited @RequestMapping etc.) and present the
+        // distinct alternatives. This is the user-facing "Did you mean?" hint.
+        const suggestions = Array.from(
+          new Set(mismatched.map((e) => e.method.toUpperCase())),
+        ).sort();
+        const suggestionList = suggestions.join(', ');
+        return {
+          error:
+            `No ${upperMethod} endpoint found at ${path}. ` +
+            `Did you mean ${suggestionList}? ` +
+            `Available methods at this path: ${suggestionList}.`,
+        };
+      }
+    } catch (err: any) {
+      if (DEBUG) console.error('[GitNexus DEBUG] Path-only sweep failed:', err);
+      // Fall through to the handler search
+    }
   }
 
   // Fallback: If no Route nodes exist, search for handler methods directly

--- a/gitnexus/test/unit/document-endpoint.test.ts
+++ b/gitnexus/test/unit/document-endpoint.test.ts
@@ -113,6 +113,93 @@ describe('documentEndpoint', () => {
       expect(asContextResult(result).result).toBeUndefined();
     });
 
+    it('returns "Did you mean X?" error when HTTP method mismatches (#42)', async () => {
+      // (#42) When the user asks for GET /i/v1/orders/{id}/confirm but the
+      // actual route is POST, the tool used to silently fall through to
+      // handler-pattern search and produce a `get:` operationId for a POST
+      // handler. The fix: after the exact-match query returns empty, do a
+      // path-only sweep to detect the mismatch and surface a clear error.
+      // The first mock is the user's exact-match call (empty); the second
+      // is the path-only follow-up sweep that reveals the actual POST route.
+      vi.mocked(endpointQuery.queryEndpoints)
+        .mockResolvedValueOnce({ endpoints: [] })
+        .mockResolvedValueOnce({
+          endpoints: [{
+            method: 'POST',
+            path: '/i/v1/orders/{id}/confirm',
+            controller: 'OrderController',
+            handler: 'confirmOrder',
+            filePath: 'src/controllers/OrderController.java',
+            line: 88,
+          }],
+        });
+
+      const result = await documentEndpoint(mockRepo, {
+        method: 'GET',
+        path: '/i/v1/orders/{id}/confirm',
+        mode: 'ai_context',
+      });
+
+      // The tool must surface the mismatch — not generate a phantom doc
+      // for a non-existent GET route.
+      expect(asContextResult(result).error).toMatch(/No GET endpoint found/);
+      expect(asContextResult(result).error).toMatch(/Did you mean POST/);
+      expect(asContextResult(result).error).toContain('/i/v1/orders/{id}/confirm');
+      expect(asContextResult(result).result).toBeUndefined();
+
+      // Verify both queries were issued in the right order: exact-match
+      // first (with method), then path-only sweep.
+      const calls = vi.mocked(endpointQuery.queryEndpoints).mock.calls;
+      expect(calls[0][1]).toEqual({ method: 'GET', path: '/i/v1/orders/{id}/confirm' });
+      expect(calls[1][1]).toEqual({ path: '/i/v1/orders/{id}/confirm' });
+    });
+
+    it('lists all available methods when path has multiple routes (#42)', async () => {
+      // (#42) A path may have GET, POST, PUT, DELETE. The error must list
+      // every distinct method so the caller can pick the right one.
+      vi.mocked(endpointQuery.queryEndpoints)
+        .mockResolvedValueOnce({ endpoints: [] })
+        .mockResolvedValueOnce({
+          endpoints: [
+            { method: 'GET', path: '/api/users', controller: 'A', handler: 'h' },
+            { method: 'POST', path: '/api/users', controller: 'A', handler: 'h' },
+            { method: 'POST', path: '/api/users', controller: 'A', handler: 'h' }, // duplicate method
+            { method: 'PUT', path: '/api/users', controller: 'A', handler: 'h' },
+          ],
+        });
+
+      const result = await documentEndpoint(mockRepo, {
+        method: 'DELETE',
+        path: '/api/users',
+        mode: 'ai_context',
+      });
+
+      expect(asContextResult(result).error).toMatch(/No DELETE endpoint found/);
+      // Distinct methods sorted, dupes collapsed
+      expect(asContextResult(result).error).toMatch(/GET, POST, PUT/);
+    });
+
+    it('falls through to handler search when path-only sweep is empty (#42)', async () => {
+      // (#42) When the path-only sweep is ALSO empty, the fix must not
+      // break the existing fallback path: it should still surface a
+      // generic "No endpoint found" error after findHandlerByPathPattern
+      // fails. (findHandlerByPathPattern is not mocked here, so the
+      // executeParameterized mock returning [] for all queries makes it
+      // resolve to undefined.)
+      vi.mocked(endpointQuery.queryEndpoints)
+        .mockResolvedValueOnce({ endpoints: [] })
+        .mockResolvedValueOnce({ endpoints: [] });
+
+      const result = await documentEndpoint(mockRepo, {
+        method: 'GET',
+        path: '/totally/missing',
+        mode: 'ai_context',
+      });
+
+      expect(asContextResult(result).error).toContain('No endpoint found');
+      expect(asContextResult(result).result).toBeUndefined();
+    });
+
     it('returns valid JSON structure for found endpoint', async () => {
       vi.mocked(endpointQuery.queryEndpoints).mockResolvedValue({
         endpoints: [{


### PR DESCRIPTION
Fixes #42

When `document-endpoint` was called with the wrong HTTP method (e.g. `GET` for an actual `POST` endpoint), the tool silently fell through to the broader handler-pattern search and produced a `get:` OpenAPI operation for a POST handler — including a misleading `operationId: get_x` that did not match the actual controller method.

## Changes

- **Path-only Route sweep between exact-match query and handler-pattern fallback.** When the user provides both `method` and `path` and the exact-match query returns nothing, but a path-only sweep finds routes for a different method, the tool now returns a hard-fail error:

  ```
  No GET endpoint found at /i/v1/orders/{id}/confirm.
  Did you mean POST?
  Available methods at this path: POST.
  ```

- No phantom `result` object, no misleading documentation.
- Suggestion list deduplicated and sorted (a path may have multiple inherited `@RequestMapping` nodes for the same method).

## Behavior

| User call | Before | After |
|---|---|---|
| `document-endpoint(method: "GET", path: "/x")` where `/x` is POST only | Returns `get:` OpenAPI for POST handler | Returns `No GET endpoint found at /x. Did you mean POST?` |
| `document-endpoint(method: "GET", path: "/missing")` | "No endpoint found" (after fallback) | "No endpoint found" (unchanged — path-only sweep is also empty) |
| `document-endpoint(method: "GET", path: "/x")` where `/x` is GET | Returns `get:` OpenAPI for GET handler | Unchanged — exact-match succeeded, no sweep |

## Verification

- Pre-commit hook: full suite + tsc passed
- New tests: 3/3 in `document-endpoint.test.ts` covering (a) single-method mismatch, (b) multi-method path with duplicate method collapse, (c) graceful fallthrough when both queries are empty
- Existing 185 document-endpoint tests: all pass
- `tsc --noEmit`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)