### PR TITLE
fix(#39): document-endpoint classifies Map<String,Object> response body as 'container' not 'primitive'

### DIFF
--- a/gitnexus/src/core/openapi/schema-builder.ts
+++ b/gitnexus/src/core/openapi/schema-builder.ts
@@ -10,7 +10,7 @@ export interface BodySchemaField {
   name: string;
   type: string;
   annotations: string[];
-  source?: 'indexed' | 'external' | 'primitive';
+  source?: 'indexed' | 'external' | 'primitive' | 'container';
   fields?: BodySchemaField[];
   isContainer?: boolean;
 }
@@ -18,7 +18,7 @@ export interface BodySchemaField {
 /** Source types from document-endpoint.ts */
 export interface BodySchema {
   typeName: string;
-  source: 'indexed' | 'external' | 'primitive';
+  source: 'indexed' | 'external' | 'primitive' | 'container';
   fields?: BodySchemaField[];
   repoId?: string;
   isContainer?: boolean;

--- a/gitnexus/src/mcp/local/document-endpoint.ts
+++ b/gitnexus/src/mcp/local/document-endpoint.ts
@@ -304,7 +304,7 @@ export interface ResponseCode {
 
 export interface BodySchema {
   typeName: string;
-  source: 'indexed' | 'external' | 'primitive';
+  source: 'indexed' | 'external' | 'primitive' | 'container';
   fields?: BodySchemaField[];
   /** Attribution for cross-repo resolution — repoId where the type was found */
   repoId?: string;
@@ -3363,8 +3363,20 @@ async function resolveTypeSchema(
     if (COLLECTION_TYPES.has(baseType)) {
       const innerSchema = await resolveTypeSchema(innerType, executeQuery, repoId, visited, crossRepo);
       // Preserve the original generic type name (e.g., 'Map<String, Object>')
-      // so the OpenAPI converter can distinguish Map from List
-      return { ...innerSchema, typeName, isContainer: true };
+      // so the OpenAPI converter can distinguish Map from List.
+      // (#39) The outer source must reflect "container" — not inherit
+      // the inner type's source. `Map<String, Object>` was being
+      // reported as `source: 'primitive'` because the inner Object is
+      // in SKIP_SCHEMA_TYPES, and we used to spread `innerSchema`
+      // verbatim, so the inner's `source: 'primitive'` clobbered the
+      // outer container status. A Map is not a primitive — it's a
+      // key-value container that wraps whatever the inner type is.
+      return {
+        ...innerSchema,
+        typeName,
+        isContainer: true,
+        source: 'container',
+      };
     }
 
     // Generic DTOs (e.g., PageDataDto<TransactionViewDto>): resolve the outer type
@@ -5236,6 +5248,18 @@ export function bodySchemaToJsonExample(
   // Primitive types - return null (no body)
   if (schema.source === 'primitive') {
     return null;
+  }
+
+  // Container types wrapping a primitive/skip-schema inner (e.g.,
+  // `Map<String, Object>`): return an empty-map/object placeholder so
+  // the example is still visible in the generated docs. (#39) Before
+  // this fix, the source was incorrectly 'primitive' so this branch
+  // never executed and the whole response body came out as null.
+  if (schema.source === 'container') {
+    if (schema.typeName.startsWith('Map') || schema.typeName.startsWith('HashMap') || schema.typeName.startsWith('TreeMap') || schema.typeName.startsWith('LinkedHashMap')) {
+      return { _type: schema.typeName, _example: {} };
+    }
+    return [{}];
   }
 
   // Indexed type with fields - generate example

--- a/gitnexus/test/unit/body-schema-container-source.test.ts
+++ b/gitnexus/test/unit/body-schema-container-source.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Unit Tests: Body schema source/container classification (#39)
+ *
+ * When `document-endpoint` documented a `Map<String, Object>` response body,
+ * the source was reported as `primitive` even though the schema is a
+ * container. That contradiction (source: 'primitive' + isContainer: true)
+ * is misleading — downstream consumers reading the source field would treat
+ * the response as a scalar and miss that it is a key-value container.
+ *
+ * Root cause: `resolveTypeSchema` spread the inner type's `source` verbatim
+ * when wrapping it in a known collection type. For `Map<String, Object>`,
+ * the inner is `Object`, which is in `SKIP_SCHEMA_TYPES` and resolves to
+ * `source: 'primitive'`. The spread clobbered the outer container status.
+ *
+ * Fix: the outer source is now set explicitly to `'container'` (a new
+ * variant) for all known collection wrappers. The Map/List/etc. handling
+ * in `bodySchemaToJsonExample` and `bodySchemaToOpenAPISchema` honors it.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { bodySchemaToJsonExample, type BodySchema } from '../../src/mcp/local/document-endpoint.js';
+
+describe('BodySchema source classification (#39)', () => {
+  describe('bodySchemaToJsonExample', () => {
+    it('returns a Map-shaped example for source: "container" with a Map type', () => {
+      // (#39) `Map<String, Object>` should yield a non-null example
+      // that signals "this is a map" rather than a primitive. The
+      // previous behavior returned `null` because source was
+      // 'primitive' and the function exited early.
+      const schema: BodySchema = {
+        typeName: 'Map<String, Object>',
+        source: 'container',
+        isContainer: true,
+      };
+
+      const example = bodySchemaToJsonExample(schema);
+
+      expect(example).not.toBeNull();
+      // A Map example is an object with a _type marker and an empty
+      // _example object — visible in the generated docs as a "map
+      // placeholder" rather than a missing body.
+      expect(example).toHaveProperty('_type', 'Map<String, Object>');
+      expect(example).toHaveProperty('_example');
+    });
+
+    it('returns a List-shaped example for source: "container" with a List type', () => {
+      // (#39) A List wrapper has the same wrapping concern — a
+      // `List<String>` returning null because the inner String is a
+      // primitive would be wrong.
+      const schema: BodySchema = {
+        typeName: 'List<String>',
+        source: 'container',
+        isContainer: true,
+      };
+
+      const example = bodySchemaToJsonExample(schema);
+
+      expect(example).not.toBeNull();
+      // Lists are emitted as a single-element array of an empty object
+      // — distinct from the Map placeholder, so the doc generator can
+      // render a list vs. a map differently.
+      expect(Array.isArray(example)).toBe(true);
+    });
+
+    it('returns null for source: "primitive" (unchanged behavior)', () => {
+      // Backward compatibility: a plain primitive should still return
+      // null. The new 'container' source does not change this path.
+      const schema: BodySchema = {
+        typeName: 'String',
+        source: 'primitive',
+      };
+
+      expect(bodySchemaToJsonExample(schema)).toBeNull();
+    });
+
+    it('returns a placeholder for source: "external" (unchanged behavior)', () => {
+      const schema: BodySchema = {
+        typeName: 'com.example.ExternalType',
+        source: 'external',
+      };
+
+      const example = bodySchemaToJsonExample(schema);
+
+      expect(example).toEqual({ _type: 'com.example.ExternalType' });
+    });
+
+    it('generates a field-driven example for source: "indexed" with fields', () => {
+      // Sanity: indexed schemas with fields still produce a proper
+      // example. The container branch must not interfere.
+      const schema: BodySchema = {
+        typeName: 'UserDto',
+        source: 'indexed',
+        fields: [
+          { name: 'id', type: 'Long', annotations: [] },
+          { name: 'name', type: 'String', annotations: [] },
+        ],
+      };
+
+      const example = bodySchemaToJsonExample(schema);
+
+      expect(example).toMatchObject({
+        id: expect.anything(),
+        name: expect.anything(),
+      });
+    });
+  });
+});


### PR DESCRIPTION
Fixes #39

`document-endpoint` previously reported `Map<String, Object>` response bodies with `source: 'primitive'` while simultaneously setting `isContainer: true`. The two fields contradicted each other.

## Changes

- **New `'container'` source variant** in `BodySchema`/`BodySchemaField` (document-endpoint.ts and schema-builder.ts) — represents "wrapper around an inner type whose own source is irrelevant".
- **`resolveTypeSchema`** now sets `source: 'container'` explicitly for all known collection wrappers (Map, List, Set, Optional, etc.) rather than inheriting the inner's source.
- **`bodySchemaToJsonExample`** gets a new branch for `source: 'container'`: Map-like types emit a `_type` + `_example: {}` placeholder, List-like types emit `[{}]`. Response bodies are no longer dropped to `null`.
- Existing Map handling in `bodySchemaToOpenAPISchema` (which keys on `isContainer: true`) is unchanged — the `{type: 'object', additionalProperties: ...}` shape was already correct; only the `source` label was wrong.

## Behavior

```
// Before:
{ typeName: 'Map<String, Object>', source: 'primitive', isContainer: true }

// After:
{ typeName: 'Map<String, Object>', source: 'container', isContainer: true }
```

## Verification

- Pre-commit hook: full suite + tsc passed
- New tests: 5/5 in `body-schema-container-source.test.ts` covering Map/List container examples + unchanged primitive/external/indexed behaviors
- Full unit suite: 3443 passed
- `tsc --noEmit`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)