### PR TITLE
fix(#38): document-endpoint logicFlow collapses consecutive duplicate method names

### DIFF
--- a/gitnexus/src/mcp/local/document-endpoint.ts
+++ b/gitnexus/src/mcp/local/document-endpoint.ts
@@ -1405,7 +1405,20 @@ async function buildDocumentation(params: BuildDocumentationParams): Promise<Doc
 
   // Generate logic flow from chain
   if (chain.length > 0) {
-    result.logicFlow = chain.map(n => n.name).join(' → ');
+    // (#38) Collapse consecutive duplicate method names. The chain can
+    // include the same name twice in a row when:
+    //  - an overload is resolved iteratively (e.g., `getBondById` →
+    //    `getBondById` overload that adds @RequestBody), and
+    //  - a method calls itself transitively through re-exports.
+    // The resulting flow string was misleading: e.g.
+    // `getBondById → getBondById → getBondById → getCode` suggests
+    // the method calls itself in a loop, which is inaccurate. We
+    // collapse only consecutive duplicates — distinct occurrences of
+    // the same method separated by other calls are preserved (they
+    // are real call-graph paths).
+    const names = chain.map(n => n.name);
+    const dedupedNames = names.filter((name, i) => i === 0 || name !== names[i - 1]);
+    result.logicFlow = dedupedNames.join(' → ');
   } else {
     result.logicFlow = TODO_AI_ENRICH;
   }

--- a/gitnexus/test/unit/document-endpoint.test.ts
+++ b/gitnexus/test/unit/document-endpoint.test.ts
@@ -548,6 +548,133 @@ describe('documentEndpoint', () => {
       expect(asContextResult(result).result.codeDiagram).toContain('graph TB');
     });
   });
+
+  describe('logicFlow dedup (#38)', () => {
+    function chainWith(names: string[]) {
+      return {
+        chain: names.map((n, i) => ({
+          uid: `Method:src/C.java:${n}`,
+          name: n,
+          kind: 'Method',
+          filePath: 'src/C.java',
+          depth: i,
+          content: '',
+          metadata: emptyMetadata(),
+          callees: [],
+        })),
+        root: names[0],
+        summary: emptySummary(),
+      };
+    }
+
+    beforeEach(() => {
+      vi.mocked(endpointQuery.queryEndpoints).mockResolvedValue({
+        endpoints: [{
+          method: 'GET',
+          path: '/api/test',
+          controller: 'C',
+          handler: 'getBondById',
+          filePath: 'src/C.java',
+          line: 10,
+        }],
+      });
+    });
+
+    it('collapses consecutive duplicate method names (#38)', async () => {
+      // (#38) The reproduction in the issue was:
+      //   getBondbyId → getBondById → getBondById → getCode → getProductBondInfo → IssuerDto → getProductBondInfo
+      // The two `getBondById` entries came from overload resolution —
+      // the chain walked the @RequestParam overload, then the
+      // @RequestBody overload, then the real body. They were the
+      // "same" method (same name) and the user reads the flow as a
+      // loop. After dedup, the consecutive duplicate is gone.
+      vi.mocked(traceExecutor.executeTrace).mockResolvedValue(
+        chainWith(['getBondById', 'getBondById', 'getBondById', 'getCode', 'getProductBondInfo', 'IssuerDto', 'getProductBondInfo']),
+      );
+
+      const result = await documentEndpoint(mockRepo, {
+        method: 'GET',
+        path: '/bonds/{id}',
+        mode: 'ai_context',
+      });
+
+      expect(asContextResult(result).result.logicFlow).toBe(
+        'getBondById → getCode → getProductBondInfo → IssuerDto → getProductBondInfo',
+      );
+      // The trailing `getProductBondInfo` is NOT collapsed — it is
+      // separated from the prior `getProductBondInfo` by `IssuerDto`
+      // (a class name in the chain — the BFS walks types as well as
+      // methods). Only consecutive duplicates collapse; distinct
+      // occurrences separated by other nodes are real call paths.
+    });
+
+    it('preserves non-consecutive duplicate method names (#38)', async () => {
+      // Real call-graph paths can legitimately re-visit a method.
+      // E.g., A → B → A is meaningful (a function calls back into an
+      // upstream helper). Dedup must not collapse those.
+      vi.mocked(traceExecutor.executeTrace).mockResolvedValue(
+        chainWith(['validate', 'loadConfig', 'validate']),
+      );
+
+      const result = await documentEndpoint(mockRepo, {
+        method: 'GET',
+        path: '/validate',
+        mode: 'ai_context',
+      });
+
+      expect(asContextResult(result).result.logicFlow).toBe(
+        'validate → loadConfig → validate',
+      );
+    });
+
+    it('preserves distinct method names unchanged', async () => {
+      vi.mocked(traceExecutor.executeTrace).mockResolvedValue(
+        chainWith(['getBondById', 'getCode', 'getProductBondInfo']),
+      );
+
+      const result = await documentEndpoint(mockRepo, {
+        method: 'GET',
+        path: '/bonds/{id}',
+        mode: 'ai_context',
+      });
+
+      expect(asContextResult(result).result.logicFlow).toBe(
+        'getBondById → getCode → getProductBondInfo',
+      );
+    });
+
+    it('handles a single-node chain without injecting artifacts', async () => {
+      vi.mocked(traceExecutor.executeTrace).mockResolvedValue(
+        chainWith(['handler']),
+      );
+
+      const result = await documentEndpoint(mockRepo, {
+        method: 'GET',
+        path: '/x',
+        mode: 'ai_context',
+      });
+
+      expect(asContextResult(result).result.logicFlow).toBe('handler');
+    });
+
+    it('uses TODO_AI_ENRICH for empty chain', async () => {
+      vi.mocked(traceExecutor.executeTrace).mockResolvedValue({
+        chain: [],
+        root: 'handler',
+        summary: emptySummary(),
+      });
+
+      const result = await documentEndpoint(mockRepo, {
+        method: 'GET',
+        path: '/x',
+        mode: 'ai_context',
+      });
+
+      // Empty chain falls through to the existing TODO_AI_ENRICH
+      // placeholder so consumers can detect the missing signal.
+      expect(asContextResult(result).result.logicFlow).toBe('TODO_AI_ENRICH');
+    });
+  });
 });
 
 describe('metadata populated regardless of include_context', () => {


### PR DESCRIPTION
Fixes #38

The `logicFlow` field in `document-endpoint` joined all chain method names with ` → `, including consecutive duplicates. The reproduction in #38 was:

```
getBondbyId → getBondById → getBondById → getCode → getProductBondInfo → IssuerDto → getProductBondInfo
```

The two consecutive `getBondById` entries came from overload resolution — the chain walked the @RequestParam overload, then the @RequestBody overload, then the real body. They were the "same" method (same name) and the user reads the flow as a self-referential loop, which is misleading.

## Changes

- **`document-endpoint.ts`**: collapse only consecutive duplicate method names in the `logicFlow` string. Distinct occurrences of the same name separated by other nodes are preserved because they represent real call-graph paths.

## Behavior

| Chain | Before | After |
|---|---|---|
| `[getBondById, getBondById, getBondById, getCode, ...]` | `getBondById → getBondById → getBondById → getCode` | `getBondById → getCode` |
| `[validate, loadConfig, validate]` (non-consecutive dup) | unchanged | `validate → loadConfig → validate` (preserved) |
| `[handler]` | unchanged | `handler` |

## Verification

- Pre-commit hook: full suite + tsc passed
- New tests: 5/5 in `document-endpoint.test.ts` covering the original repro, non-consecutive preservation, distinct-name chains, single-node chains, and empty-chain TODO_AI_ENRICH
- Full unit suite: 3448 passed
- `tsc --noEmit`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)