### PR TITLE
fix(#14): Java method return types are now captured at ingestion

### DIFF
--- a/gitnexus/src/core/ingestion/utils/ast-helpers.ts
+++ b/gitnexus/src/core/ingestion/utils/ast-helpers.ts
@@ -721,6 +721,28 @@ export const extractMethodSignature = (node: SyntaxNode | null | undefined): Met
     }
   }
 
+  // Java: `public Order getOrder()` — tree-sitter-java exposes the return
+  // type via the `type` field on method_declaration, and the actual node
+  // is `type_identifier` (or `generic_type` for `List<Order>`,
+  // `array_type` for `Order[]`, `void_type` for `void`).
+  // The generic `type_annotation`/`return_type` loop above does NOT match
+  // Java's child layout (Java doesn't wrap the return type in either
+  // node). Without this, Java methods silently lose their return type
+  // and downstream consumers (document-endpoint) can't resolve the
+  // response shape — they fall back to `type: string` for an entity
+  // return (#14).
+  //
+  // Note: this block is also reached for C++ `function_definition`
+  // (which shares the `type` field shape) and would clobber the C++
+  // void filter above, so we mirror that filter and skip `void`
+  // return types. (#14)
+  if (!returnType) {
+    const javaReturn = node.childForFieldName?.('type');
+    if (javaReturn && javaReturn.text !== 'void') {
+      returnType = javaReturn.text;
+    }
+  }
+
   if (isVariadic) parameterCount = undefined;
 
   // Only include parameterTypes when at least one type was successfully extracted.

--- a/gitnexus/test/unit/method-signature.test.ts
+++ b/gitnexus/test/unit/method-signature.test.ts
@@ -163,6 +163,59 @@ describe('extractMethodSignature', () => {
       expect(sig2.parameterCount).toBe(2);
       expect(sig2.parameterTypes).toEqual(['int', 'String']);
     });
+
+    it('extracts return type for a Java entity method (#14)', () => {
+      // (#14) Java method return types were silently dropped because
+      // tree-sitter-java exposes the return type via the `type` field
+      // on `method_declaration`, but the existing extractor only
+      // matched `type_annotation` (TS/Python) and `return_type`
+      // (Rust/TS) child types — neither of which Java uses. Without
+      // a captured return type, document-endpoint could not resolve
+      // the response body and Spring entity endpoints reported
+      // `type: string`.
+      parser.setLanguage(Java);
+      const code = `class OrderController {
+  public Order getOrder(Long id) { return null; }
+}`;
+      const tree = parser.parse(code);
+      const classBody = tree.rootNode.child(0)!.childForFieldName('body')!;
+      const sig = extractMethodSignature(classBody.namedChild(0)!);
+
+      expect(sig.returnType).toBe('Order');
+    });
+
+    it('extracts generic return type for a Java entity method (#14)', () => {
+      // (#14) `ResponseEntity<List<Order>>` is a common Spring pattern.
+      // The `type` field returns the full `ResponseEntity<List<Order>>`
+      // text — the wrapper unwrapping in document-endpoint handles the
+      // rest. We just need the captured `returnType` to be present.
+      parser.setLanguage(Java);
+      const code = `class OrderController {
+  public ResponseEntity<List<Order>> getOrder(Long id) { return null; }
+}`;
+      const tree = parser.parse(code);
+      const classBody = tree.rootNode.child(0)!.childForFieldName('body')!;
+      const sig = extractMethodSignature(classBody.namedChild(0)!);
+
+      expect(sig.returnType).toBe('ResponseEntity<List<Order>>');
+    });
+
+    it('returns undefined for a void Java method', () => {
+      // Mirrors the C++ contract at line ~457: void return types are
+      // filtered out. Callers (document-endpoint) treat undefined the
+      // same as a missing return type and skip response-body
+      // construction, which is the right behavior for a controller
+      // method that returns nothing.
+      parser.setLanguage(Java);
+      const code = `class C {
+  public void run() {}
+}`;
+      const tree = parser.parse(code);
+      const classBody = tree.rootNode.child(0)!.childForFieldName('body')!;
+      const sig = extractMethodSignature(classBody.namedChild(0)!);
+
+      expect(sig.returnType).toBeUndefined();
+    });
   });
 
   describe('Kotlin', () => {


### PR DESCRIPTION
Fixes #14

`document-endpoint` reported `type: string` for Spring entity endpoints (`GET /api/orders/{id}`) even though the controller method returned an `Order` DTO. The real problem was upstream — the method-signature extractor in `ast-helpers.ts` silently lost Java's return type at ingestion.

## Root cause

`extractMethodSignature` had a generic loop looking for child nodes of type `type_annotation` (TS/Python) or `return_type` (Rust/TS). Java's tree-sitter `method_declaration` does NOT wrap the return type in either — it's a direct child named via the `type` field, with the actual node being `type_identifier`, `generic_type`, `array_type`, or `void_type`. So Java methods silently lost their return type, and `document-endpoint` saw `handler.returnType === undefined`.

## Changes

- **`ast-helpers.ts`**: add a `childForFieldName('type')` lookup with a `void` filter, mirroring the existing C++ pattern. Runs after all language-specific fallbacks.
- Generic returns like `ResponseEntity<List<Order>>` round-trip intact for `document-endpoint`'s wrapper-unwrap step.

## Behavior

| Java method | Before | After |
|---|---|---|
| `public Order getOrder(...)` | `returnType: undefined` | `returnType: 'Order'` |
| `public ResponseEntity<List<Order>> getOrder(...)` | `undefined` | `ResponseEntity<List<Order>>` (unwrapped downstream to `List<Order>`) |
| `public void run() {}` | `undefined` | `undefined` (filtered, same as C++ contract) |

## Verification

- Pre-commit hook: full suite + tsc passed
- New tests: 3 cases in `method-signature.test.ts` covering entity return, generic return, and void
- Full unit suite: 3452 passed
- `tsc --noEmit`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)