### PR TITLE
fix(#91): standalone Spring route extractor handles element_value_array_initializer and @PatchMapping

### DIFF
--- a/gitnexus/src/core/ingestion/route-extractors/spring.ts
+++ b/gitnexus/src/core/ingestion/route-extractors/spring.ts
@@ -24,6 +24,12 @@ const MAPPING_ANNOTATIONS = [
   { regex: /@PostMapping\(([^)]*)\)/, method: 'POST' },
   { regex: /@PutMapping\(([^)]*)\)/, method: 'PUT' },
   { regex: /@DeleteMapping\(([^)]*)\)/, method: 'DELETE' },
+  // (#91) @PatchMapping was missing from the standalone extractor.
+  // The production pipeline (workers/spring-route-extractor.ts) handled
+  // it correctly, but the standalone extractRoutesFromClass in this
+  // file was emitting `ANY` for every @PatchMapping endpoint. Add it
+  // here so the standalone extractor and the pipeline agree.
+  { regex: /@PatchMapping\(([^)]*)\)/, method: 'PATCH' },
   { regex: /@RequestMapping\(([^)]*)\)/, method: 'ANY' },
 ];
 
@@ -329,8 +335,14 @@ export async function extractSpringRoutes(
         if (annName === 'PostMapping') { httpMethods = ['POST']; }
         if (annName === 'PutMapping') { httpMethods = ['PUT']; }
         if (annName === 'DeleteMapping') { httpMethods = ['DELETE']; }
+        // (#91) @PatchMapping was missing from the inline check below.
+        // The MAPPING_ANNOTATIONS regex at the top of the file is only
+        // used by the regex-based extractors; extractRoutesFromClass
+        // dispatches by name explicitly. Add the dispatch here so
+        // @PatchMapping produces a PATCH route, not ANY.
+        if (annName === 'PatchMapping') { httpMethods = ['PATCH']; }
         if ([
-          'GetMapping','PostMapping','PutMapping','DeleteMapping','RequestMapping'
+          'GetMapping','PostMapping','PutMapping','DeleteMapping','PatchMapping','RequestMapping'
         ].includes(annName)) {
           methodLevelPath = getAnnotationValue(ann, 'value') || getAnnotationValue(ann, 'path') || getAnnotationValue(ann) || '';
           if (methodLevelPath.startsWith('/')) methodLevelPath = methodLevelPath.slice(1);
@@ -346,7 +358,16 @@ export async function extractSpringRoutes(
                       if (val && val.startsWith('RequestMethod.')) {
                         httpMethods = [val.replace('RequestMethod.', '')];
                       }
-                    } else if (valNode.type === 'array_initializer') {
+                    // (#91) tree-sitter-java wraps `{RequestMethod.X}`
+                    // (and `{RequestMethod.X, RequestMethod.Y}`) in an
+                    // `element_value_array_initializer` node, NOT an
+                    // `array_initializer`. The previous check only
+                    // matched `array_initializer`, so single-element and
+                    // multi-element method arrays both fell through to
+                    // the default `['ANY']`. Match the real node type
+                    // and also keep the bare `array_initializer` check
+                    // for robustness across tree-sitter versions.
+                    } else if (valNode.type === 'element_value_array_initializer' || valNode.type === 'array_initializer') {
                       httpMethods = valNode.namedChildren
                         .filter((n: any) => n.type === 'field_access' && n.text.startsWith('RequestMethod.'))
                         .map((n: any) => n.text.replace('RequestMethod.', ''));

--- a/gitnexus/test/unit/spring-route-extractor-standalone.test.ts
+++ b/gitnexus/test/unit/spring-route-extractor-standalone.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Unit Tests: Standalone Spring route extractor (#91)
+ *
+ * The standalone `extractSpringRoutes` in
+ * `src/core/ingestion/route-extractors/spring.ts` had three bugs that
+ * the production pipeline (workers/spring-route-extractor.ts) handled
+ * correctly, so production index quality was unaffected. The standalone
+ * variant is used for direct invocation, unit testing, and as a
+ * reference implementation. This suite covers:
+ *  1. `@RequestMapping(method = {RequestMethod.GET})` (single-element
+ *     bracket array) → method = GET, not ANY.
+ *  2. `@RequestMapping(method = {RequestMethod.GET, RequestMethod.POST})`
+ *     (multi-element bracket array) → two separate routes, not one ANY.
+ *  3. `@PatchMapping("/{id}")` → method = PATCH, not ANY.
+ *  4. The bare `@RequestMapping(value = "/x")` (no method attr) → still
+ *     ANY (the documented contract for "matches all methods").
+ */
+
+import { describe, it, expect } from 'vitest';
+import { extractSpringRoutes } from '../../src/core/ingestion/route-extractors/spring.js';
+
+describe('Standalone Spring route extractor (#91)', () => {
+  describe('@RequestMapping method array', () => {
+    it('parses single-element bracket array as the named HTTP method', async () => {
+      // (#91) The reproduction: ContractIntController has
+      //   @RequestMapping(value = "/x", method = {RequestMethod.GET})
+      // The previous check matched `array_initializer` but tree-sitter
+      // emits `element_value_array_initializer` for the bracket form,
+      // so the method fell through to the default `['ANY']`.
+      const code = `
+        @RestController
+        public class ContractIntController {
+          @RequestMapping(value = "/x", method = {RequestMethod.GET})
+          public String get() { return ""; }
+        }
+      `;
+      const routes = await extractSpringRoutes(code);
+      const getRoute = routes.find(r => r.path === '/x');
+      expect(getRoute).toBeDefined();
+      expect(getRoute?.method).toBe('GET');
+      // Single-element array must produce exactly one route, not two.
+      expect(routes.filter(r => r.path === '/x').length).toBe(1);
+    });
+
+    it('parses multi-element bracket array as one route per method', async () => {
+      // (#91) For `@RequestMapping(method = {RequestMethod.GET, RequestMethod.POST})`
+      // we expect TWO separate routes — one GET, one POST — not a single
+      // route with method=ANY. The for-loop on httpMethods already
+      // produces one route per method; the bug was the parser never
+      // populating httpMethods in the first place.
+      const code = `
+        @RestController
+        public class MultiMethodController {
+          @RequestMapping(value = "/x", method = {RequestMethod.GET, RequestMethod.POST})
+          public String getOrCreate() { return ""; }
+        }
+      `;
+      const routes = await extractSpringRoutes(code);
+      const xRoutes = routes.filter(r => r.path === '/x');
+      expect(xRoutes).toHaveLength(2);
+      const methods = xRoutes.map(r => r.method).sort();
+      expect(methods).toEqual(['GET', 'POST']);
+    });
+
+    it('still emits ANY when @RequestMapping has no method attribute', async () => {
+      // Backward compat: bare `@RequestMapping(value = "/x")` with no
+      // method attr matches any HTTP method. The contract is unchanged
+      // — the fix only adds the array-parse path, it does not
+      // alter the default.
+      const code = `
+        @RestController
+        public class AnyMethodController {
+          @RequestMapping(value = "/x")
+          public String any() { return ""; }
+        }
+      `;
+      const routes = await extractSpringRoutes(code);
+      const anyRoute = routes.find(r => r.path === '/x');
+      expect(anyRoute).toBeDefined();
+      expect(anyRoute?.method).toBe('ANY');
+    });
+  });
+
+  describe('@PatchMapping recognition', () => {
+    it('recognizes @PatchMapping as PATCH (not ANY)', async () => {
+      // (#91) The reproduction: `@PatchMapping("/{id}")` was
+      // unrecognized — MAPPING_ANNOTATIONS had Get/Post/Put/Delete but
+      // not Patch. Every PATCH endpoint extracted with method=ANY.
+      const code = `
+        @RestController
+        public class PatchController {
+          @PatchMapping("/{id}")
+          public String patch() { return ""; }
+        }
+      `;
+      const routes = await extractSpringRoutes(code);
+      const patchRoute = routes.find(r => r.path === '/{id}');
+      expect(patchRoute).toBeDefined();
+      expect(patchRoute?.method).toBe('PATCH');
+    });
+
+    it('recognizes @PatchMapping with class-level @RequestMapping prefix', async () => {
+      // Class-level prefix must combine with the method-level path.
+      // Mirrors the AuthController / ProjectsController test
+      // structure at test/unit/spring.extract.test.ts.
+      const code = `
+        @RestController
+        @RequestMapping("/api")
+        public class PatchController {
+          @PatchMapping("/v1/{id}")
+          public String patch() { return ""; }
+        }
+      `;
+      const routes = await extractSpringRoutes(code);
+      const patchRoute = routes.find(r => r.method === 'PATCH');
+      expect(patchRoute).toBeDefined();
+      expect(patchRoute?.path).toBe('/api/v1/{id}');
+    });
+  });
+
+  describe('regression — other methods unchanged', () => {
+    it('still recognizes @GetMapping / @PostMapping / @PutMapping / @DeleteMapping', async () => {
+      const code = `
+        @RestController
+        public class AllController {
+          @GetMapping("/g") public String g() { return ""; }
+          @PostMapping("/p") public String p() { return ""; }
+          @PutMapping("/u") public String u() { return ""; }
+          @DeleteMapping("/d") public String d() { return ""; }
+        }
+      `;
+      const routes = await extractSpringRoutes(code);
+      const byMethod = Object.fromEntries(routes.map(r => [r.method, r.path]));
+      expect(byMethod.GET).toBe('/g');
+      expect(byMethod.POST).toBe('/p');
+      expect(byMethod.PUT).toBe('/u');
+      expect(byMethod.DELETE).toBe('/d');
+    });
+  });
+});


### PR DESCRIPTION
Fixes #91

The standalone `extractSpringRoutes` in `src/core/ingestion/route-extractors/spring.ts` had three bugs that the production pipeline handled correctly — production index quality was unaffected, but the standalone variant (used for direct invocation and unit testing) was emitting `ANY` for many real Spring controllers.

## Bugs fixed

1. `@RequestMapping(method = {RequestMethod.GET})` (single-element bracket array) → method=ANY instead of GET. tree-sitter emits `element_value_array_initializer` for the bracket form, but the check matched `array_initializer` only.
2. `@RequestMapping(method = {RequestMethod.GET, RequestMethod.POST})` (multi-element bracket array) → single route with method=ANY instead of two separate routes. Same root cause.
3. `@PatchMapping` was completely unrecognized — every PATCH endpoint extracted with method=ANY.

Real Spring controllers in tcbs-bond-trading (ContractIntController, ContractExtController, CustomerExtControllerV4) use the bracket-array syntax for 5+ methods.

## Changes

- `spring.ts` MAPPING_ANNOTATIONS: add `@PatchMapping` entry.
- `spring.ts` extractRoutesFromClass: add `PatchMapping` branch to inline dispatch; add to method-level annotation list; add `element_value_array_initializer` to the array parser check.
- Bare `@RequestMapping(value = "/x")` (no method attr) still emits ANY — backward compat preserved.

## Verification

- Pre-commit hook: full suite + tsc passed
- New tests: 6 cases in `spring-route-extractor-standalone.test.ts` covering all three bugs + regression for existing methods
- Full unit suite: 3460 passed
- `tsc --noEmit`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)