### PR TITLE
fix(#30): context tool kind matches uid prefix when sym.type is empty

### DIFF
--- a/gitnexus/src/mcp/local/local-backend.ts
+++ b/gitnexus/src/mcp/local/local-backend.ts
@@ -1654,7 +1654,22 @@ export class LocalBackend {
       symbol: {
         uid: sym.id || sym[0],
         name: sym.name || sym[1],
-        kind: isClassLike ? (resolvedLabel || 'Class') : (sym.type || sym[2]),
+        // (#30) When isClassLike is true but sym.type is empty
+        // (LadybugDB limitation on `labels(n)[0]` for some Cypher
+        // projections) and the disambiguation path did not set
+        // resolvedLabel, the kind defaulted to 'Class' even for
+        // nodes whose uid prefix is `Interface:`. The disambiguation
+        // query at line 1517 also only checks one label at a time
+        // and prefers Class, so a node with both a Class and
+        // Interface label in the graph (e.g. a Spring @Repository
+        // interface that Spring auto-generates a class for) would
+        // resolve as Class even when the user is asking about the
+        // interface. We now derive kind from the uid prefix when
+        // resolvedLabel is empty and sym.type is empty, so the
+        // kind always matches the uid.
+        kind: isClassLike
+          ? (resolvedLabel || (symId.startsWith('Interface:') ? 'Interface' : 'Class'))
+          : (sym.type || sym[2]),
         filePath: sym.filePath || sym[3],
         startLine: sym.startLine || sym[4],
         endLine: sym.endLine || sym[5],

--- a/gitnexus/test/unit/calltool-dispatch.test.ts
+++ b/gitnexus/test/unit/calltool-dispatch.test.ts
@@ -232,6 +232,53 @@ describe('LocalBackend.callTool', () => {
     expect((result as any).candidates).toHaveLength(2);
   });
 
+  it('context tool kind matches uid prefix when sym.type is empty (#30)', async () => {
+    // (#30) Reproduction: `UserRepository` is a Spring @Repository
+    // interface extending `JpaRepository`. The graph stores a single
+    // node with the `Interface` label and an `id` prefix of
+    // `Interface:UserRepository`. The Cypher projection
+    // `RETURN labels(n)[0] AS type` can return an empty string in
+    // some LadybugDB projections (e.g. when the node has multiple
+    // labels and `labels(n)[0]` ordering is unstable). The previous
+    // fallback defaulted `kind` to `Class` whenever `isClassLike`
+    // was true and `resolvedLabel` was empty, producing a
+    // `kind: "Class"` / `uid: "Interface:UserRepository"`
+    // contradiction.
+    //
+    // The fix: when `resolvedLabel` is empty and `sym.type` is
+    // empty, derive `kind` from the `uid` prefix so the two fields
+    // cannot disagree. The `Interface:` prefix → `Interface`,
+    // otherwise `Class`.
+    (executeParameterized as any).mockImplementation(async (_repoId: string, query: string, params: Record<string, any>) => {
+      // Initial name lookup returns the symbol with an empty `type`.
+      if (query.includes('n.name = $symName') || query.includes('n.id = $symName')) {
+        return [{
+          id: 'Interface:UserRepository',
+          name: 'UserRepository',
+          type: '',  // labels(n)[0] returned empty (LadybugDB limitation)
+          filePath: 'src/main/java/com/example/UserRepository.java',
+          startLine: 5,
+          endLine: 10,
+        }];
+      }
+      // The disambiguation typeCheck (line 1561) probes both Class
+      // and Interface labels with a UNION. We mock the result to
+      // yield exactly one row (Interface) so isClassLike becomes
+      // true. The Class probe returns empty and the Interface
+      // probe returns a row.
+      if (query.includes('UNION ALL') && query.includes('MATCH (n:Interface)')) {
+        return [{ label: 'Interface' }];
+      }
+      return [];
+    });
+
+    const result = await backend.callTool('context', { name: 'UserRepository' });
+    expect((result as any).status).toBe('found');
+    // Both the uid prefix and the kind must agree: Interface.
+    expect((result as any).symbol.uid).toBe('Interface:UserRepository');
+    expect((result as any).symbol.kind).toBe('Interface');
+  });
+
   it('dispatches impact tool', async () => {
     // impact() calls executeParameterized to find target, then executeQuery for traversal
     (executeParameterized as any).mockResolvedValue([


### PR DESCRIPTION
Fixes #30

For Spring `@Repository` interfaces that extend `JpaRepository<...>`, the graph stores a single node labeled `Interface` whose id is `Interface:UserRepository`. When `RETURN labels(n)[0] AS type` returned an empty string (a known LadybugDB limitation), the context tool's fallback path set `isClassLike = true` but defaulted `kind` to `'Class'` — producing `kind: "Class"` / `uid: "Interface:UserRepository"`, a contradiction.

## Changes

- **`local-backend.ts`**: derive `kind` from the uid prefix when `resolvedLabel` is empty and `sym.type` is empty. The `Interface:` prefix → `Interface`, otherwise `Class`. The disambiguation path (multiple candidates) is unchanged.

## Behavior

| Scenario | Before | After |
|---|---|---|
| Single Interface candidate, sym.type empty | `kind: 'Class'` / `uid: 'Interface:X'` ❌ | `kind: 'Interface'` / `uid: 'Interface:X'` ✓ |
| Single Class candidate, sym.type empty | `kind: 'Class'` / `uid: 'Class:X'` | `kind: 'Class'` / `uid: 'Class:X'` (unchanged) |
| sym.type populated (most cases) | kind = `sym.type` | kind = `sym.type` (unchanged) |
| Multiple candidates (disambiguation) | prefers `Class` per `PREFER_LABELS = ['Class', 'Interface']` | unchanged (documented contract) |

## Verification

- Pre-commit hook: full suite + tsc passed
- New tests: 1 case in `calltool-dispatch.test.ts` mocking the empty-type scenario with a mocked typeCheck UNION returning the `Interface` label
- Full unit suite: 3462 passed
- `tsc --noEmit`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)