### PR TITLE
fix(#56): context tool aggregates method-level CALLS into Class incoming refs

### DIFF
--- a/gitnexus/src/mcp/local/local-backend.ts
+++ b/gitnexus/src/mcp/local/local-backend.ts
@@ -1577,11 +1577,18 @@ export class LocalBackend {
       LIMIT 30
     `, { symId });
 
-    // Expand incoming refs for Class/Interface nodes: callers via Constructor/File
+    // Expand incoming refs for Class/Interface nodes: callers via Constructor/File/Method
     if (isClassLike) {
       try {
-        // Run both incoming-ref queries in parallel — they are independent.
-        const [ctorIncoming, fileIncoming] = await Promise.all([
+        // Run all three incoming-ref queries in parallel — they are
+        // independent. The third query (#56) covers callers of the
+        // class's METHODS — without it, a query like
+        // `context(name="CashServiceV2Impl")` returns no incoming
+        // refs even though 8 controllers call its methods at the
+        // method level. We aggregate those method-level CALLS edges
+        // into the class context, similar to how outgoing
+        // `has_method` already shows method-level outgoing edges.
+        const [ctorIncoming, fileIncoming, methodIncoming] = await Promise.all([
           executeParameterized(repo.id, `
             MATCH (n)-[hm:CodeRelation]->(ctor:Constructor)
             WHERE n.id = $symId AND hm.type = 'HAS_METHOD'
@@ -1598,6 +1605,22 @@ export class LocalBackend {
             RETURN r.type AS relType, caller.id AS uid, caller.name AS name, caller.filePath AS filePath, labels(caller)[0] AS kind
             LIMIT 30
           `, { symId }),
+          executeParameterized(repo.id, `
+            // (#56) Find callers of the class's methods. This walks
+            // HAS_METHOD from the class to its Method nodes, then
+            // finds CALLS edges from any caller to those methods. The
+            // relation type is reported as CALLS so it sorts into
+            // the same incoming.calls bucket as direct method-level
+            // context queries. The caller.uid, name, filePath come
+            // from the caller (the source of the CALLS edge), and
+            // targetMethod identifies which method on the class was
+            // called — useful for the consumer to show a backtrace.
+            MATCH (n)-[hm:CodeRelation {type: 'HAS_METHOD'}]->(target:Method)
+            WHERE n.id = $symId
+            MATCH (caller)-[r:CodeRelation {type: 'CALLS'}]->(target)
+            RETURN r.type AS relType, caller.id AS uid, caller.name AS name, caller.filePath AS filePath, labels(caller)[0] AS kind, target.name AS targetMethod
+            LIMIT 30
+          `, { symId }),
         ]);
 
         // Deduplicate by (relType, uid) — a caller can have multiple relation
@@ -1606,7 +1629,7 @@ export class LocalBackend {
         const seenKeys = new Set(
           incomingRows.map((r: any) => `${r.relType || r[0]}:${r.uid || r[1]}`),
         );
-        for (const r of [...ctorIncoming, ...fileIncoming]) {
+        for (const r of [...ctorIncoming, ...fileIncoming, ...methodIncoming]) {
           const key = `${r.relType || r[0]}:${r.uid || r[1]}`;
           if (!seenKeys.has(key)) { seenKeys.add(key); incomingRows.push(r); }
         }

--- a/gitnexus/test/unit/calltool-dispatch.test.ts
+++ b/gitnexus/test/unit/calltool-dispatch.test.ts
@@ -232,6 +232,53 @@ describe('LocalBackend.callTool', () => {
     expect((result as any).candidates).toHaveLength(2);
   });
 
+  it('context tool aggregates method-level CALLS into Class incoming (#56)', async () => {
+    // (#56) Reproduction: `CashServiceV2Impl` had no incoming refs
+    // because the previous expansion only looked at callers via the
+    // class's Constructor and File nodes, not its Method nodes. The
+    // graph has CALLS edges from controllers → service methods, but
+    // the class context view missed them. The fix adds a third
+    // parallel query that walks HAS_METHOD from the class to its
+    // methods, then finds CALLS edges from any caller to those
+    // methods, and reports the callers under `incoming.calls`.
+    const SYM_ID = 'Class:CashServiceV2Impl';
+    (executeParameterized as any).mockImplementation(async (_repoId: string, query: string) => {
+      // Initial name lookup
+      if (query.includes('n.name = $symName') || query.includes('n.id = $symName')) {
+        return [{
+          id: SYM_ID,
+          name: 'CashServiceV2Impl',
+          type: 'Class',
+          filePath: 'src/main/java/CashServiceV2Impl.java',
+          startLine: 1, endLine: 50,
+        }];
+      }
+      // Constructor / File / Method incoming queries
+      if (query.includes('UNION ALL') && query.includes('MATCH (n:Interface)')) {
+        return [{ label: 'Class' }]; // typeCheck union → isClassLike
+      }
+      if (query.includes(':Constructor')) return []; // ctorIncoming
+      if (query.includes(':File') && query.includes('rel.type = \'DEFINES\'')) return []; // fileIncoming
+      if (query.includes('HAS_METHOD') && query.includes('MATCH (caller)-[r:CodeRelation {type: \'CALLS\'}]->(target)')) {
+        // The new method-incoming query: return 2 callers.
+        return [
+          { relType: 'CALLS', uid: 'Method:OrderIntController:cancel', name: 'cancel', filePath: 'OrderIntController.java', kind: 'Method', targetMethod: 'unholdMoney' },
+          { relType: 'CALLS', uid: 'Method:SigningIConnectFacadeImpl:signContractIConnect', name: 'signContractIConnect', filePath: 'SigningIConnectFacadeImpl.java', kind: 'Method', targetMethod: 'unholdMoney' },
+        ];
+      }
+      // Incoming/outgoing/process queries → empty
+      return [];
+    });
+
+    const result = await backend.callTool('context', { name: 'CashServiceV2Impl' });
+    expect((result as any).status).toBe('found');
+    // The 2 method-level callers should be aggregated under incoming.calls.
+    expect((result as any).incoming.calls).toBeInstanceOf(Array);
+    expect((result as any).incoming.calls).toHaveLength(2);
+    const names = (result as any).incoming.calls.map((c: any) => c.name).sort();
+    expect(names).toEqual(['cancel', 'signContractIConnect']);
+  });
+
   it('context tool kind matches uid prefix when sym.type is empty (#30)', async () => {
     // (#30) Reproduction: `UserRepository` is a Spring @Repository
     // interface extending `JpaRepository`. The graph stores a single


### PR DESCRIPTION
Fixes #56

`context(name="CashServiceV2Impl")` previously returned `incoming: {}` despite 8+ controllers calling its methods (verified by Cypher). The class expansion only looked at callers via the class's Constructor and File nodes — not its Method nodes.

## Changes

- **`local-backend.ts`**: added a third parallel query in the class expansion that walks `HAS_METHOD` from the class to its Method nodes, then finds `CALLS` edges from any caller to those methods. Callers are reported under `incoming.calls`. The relation type is `CALLS` so it sorts into the same incoming bucket as direct method-level context queries. The target method name is surfaced as `targetMethod` so consumers can show a backtrace.

## Behavior

```
// Before:
context(name="CashServiceV2Impl")
  → { "incoming": {} }   // 8+ method-level callers invisible

// After:
context(name="CashServiceV2Impl")
  → { "incoming": { "calls": [{uid: "Method:OrderIntController:cancel", ...}, ...] } }
```

## Verification

- Pre-commit hook: full suite + tsc passed
- New tests: 1 case in `calltool-dispatch.test.ts` mocking 2 method-level callers and asserting they appear in `incoming.calls`
- Full unit suite: 3463 passed
- `tsc --noEmit`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)