### PR TITLE
feat(ingestion): Java large-repo LSP augmentation — readiness + coverage + pre-filter (ADR-002 P0/P1)

### DIFF
--- a/gitnexus/docs/adr/ADR-002-lsp-augmentation-at-scale.md
+++ b/gitnexus/docs/adr/ADR-002-lsp-augmentation-at-scale.md
@@ -1,0 +1,217 @@
+# ADR-002: Scaling LSP Augmentation to Large Repos and Monorepos
+
+**Status:** Proposed
+**Date:** 2026-06-15
+**Deciders:** repository maintainers, arch
+**Context source:** all-language LSP benchmark (2026-06-15) on real TCBS bond-trading repos + scout audit of the Mode-A engine.
+
+---
+
+## Context
+
+GitNexus's Mode-A LSP augmentation works well on small/medium repos but **collapses on the user's real workload** — production services of 760–1490 Java files, with monorepos of millions of LOC on the horizon. The 2026-06-15 benchmark + a code audit pinned six root causes; the exact cap value differs across runs but the *shape* of every problem is verified in source.
+
+| # | Problem | Evidence | Current design (file:line) |
+|---|---|---|---|
+| **P1** | **Premature readiness** (correctness) | `tcbs-bond-trading`: 30 s phase, 0.86 %, 57 k *instant* empty responses — reproduced byte-identically | jdtls `awaitReady` settles on `language/status` `ServiceReady` = **server-up, not index-complete**; Maven import/classpath indexing continues after (`language-adapter.ts:318`) |
+| **P2** | **Wasted external probes** (efficiency) | 57,583 refusals = 57,583 wasted round-trips on one repo | Only `isUnindexablePath` pre-filter; external targets (jdt://, site-packages, cargo registry) are probed, then tagged `external:true` *after* the round-trip (`mode-a-reconciler.ts:654`, `location-mapper.ts:591`) |
+| **P3** | **Serial probing** (throughput) | `tcbs-bond-trading-core`: 2,985 s for ~3 k probes ≈ 0.92 s/probe | pool=8 is bookkeeping only; `LspClient` serializes all requests through a one-in-flight promise chain (`lsp-client.ts:296`) |
+| **P4** | **Value-blind cap** (coverage) | huge `skipped(cap)`; arbitrary slice augmented | cap = deterministic *prefix* after stable-sort by `(sourceId, calledName, line, character)` — no correlation to value (`mode-a-reconciler.ts:409,539`) |
+| **P5** | **No incrementality** (steady state) | full re-probe every run | provenance (`source` column) persisted but never reused; no changed-files path (`pipeline.ts:307`, `analyze.ts:173`) |
+| **P6** | **Per-call-site, not per-symbol** (redundancy) | 100 calls to `foo()` = 100 probes | no symbol-level definition memoization (`mode-a-reconciler.ts:705`) |
+
+**The reframe that drives the decision:** the benchmark proved `corrected` ≈ 0 (the heuristic is rarely *wrong*), so *confirmation* of confident edges has low marginal value, and the bulk of candidates on real services are external-framework calls the LSP **correctly refuses**. The high-value LSP questions — **ambiguous internal calls** and **internal calls the heuristic missed (recall)** — are a small subset of the feed. The current engine spends ~100× of its budget on low/zero-value probes. **Scaling the brute force is the wrong goal; shrinking the question set is the right one.**
+
+---
+
+## Decision
+
+Adopt a **tiered, evolutionary architecture**, sequenced so each phase is independently shippable and the cheapest, highest-leverage correctness/efficiency work lands first. Right-size to the *current* workload (single large repos) before building the monorepo tier; gate the expensive batch-indexing bet behind a spike.
+
+- **Live-LSP, fixed** — for small / medium / large *single* repos (the user's typical world). Phases 0–3.
+- **Batch index (SCIP/LSIF) + module decomposition** — for huge / monorepo (millions of LOC), where a per-query model is fundamentally infeasible. Phase 4, **spike-gated**.
+
+### Phased roadmap
+
+| Phase | Goal | Fixes | Size | Why this order |
+|---|---|---|---|---|
+| **0 — Correct & honest** | stop silently-wrong augmentation | P1 readiness (jdtls: wait for project-import/index-complete, not `ServiceReady`; per-adapter audit) · P4-lite: replace silent `skip(cap)` with a **budget + coverage report** (never silently drop) | **S** (days) | no point optimizing throughput of garbage; restores trust on every large repo |
+| **1 — Shrink the question set** ⭐ | probe only high-value candidates | P2: **pre-filter provably-external callees** before probing (reuse the heuristic's import resolution) · P4: **value-prioritized ordering** (fan-in/out, ambiguity, critical-path) so the budget buys the best edges · target **ambiguous-internal + internal-recall**, skip confident-confirmations · P6: per-symbol definition memoization | **M** (1–2 wk) | **highest leverage** — collapses the 113 k feed to its few-k valuable core; makes everything downstream cheap |
+| **2 — Make it fast** | 4–10× throughput | P3: **pipelined/multiplexed JSON-RPC** (bounded in-flight concurrency, deterministic result assembly) | **M** (2–3 wk) | once the feed is small *and* high-value, concurrency turns minutes into seconds |
+| **3 — Scale over time** | steady-state cost ∝ change size | P5: **incremental augmentation** — persist a probe manifest (callsite-hash, commit); on re-analyze re-probe only changed files + dependents, reuse persisted `lsp-*` edges | **M–L** (3–4 wk) | the ongoing-use scaler; first index expensive, re-index cheap |
+| **4 — Monorepo tier** | million-LOC tractable | **batch SCIP/LSIF** (`scip-java`/`scip-typescript`/`scip-go` + `rust-analyzer scip`) for the initial full index instead of N live probes · **module-aware decomposition** (per build-root LSP/index) | **L** (months) | **decision-gated**: a 1-wk spike on the largest monorepo measures SCIP index-time + coverage vs live-LSP before committing |
+
+**Recommended commit now:** Phases **0 → 1 → 2** (they compound: correct → small → fast) and likely lift `tcbs-bond-trading` from 0.86 %/garbage to meaningful augmentation in bounded time. Then **3** for steady state. **Spike 4** to choose the monorepo strategy with data, not speculation.
+
+---
+
+## Options Considered
+
+| Option | Description | Pros | Cons |
+|---|---|---|---|
+| **A — Patch readiness only** | fix the jdtls `ServiceReady` bug, nothing else | tiny; fixes the headline symptom | large repos become *correct but still infeasibly slow* (P2/P3/P4/P5 untouched); monorepos still impossible |
+| **B — Fix the live model** | Phases 0–3 | makes single large repos fast, correct, incremental; no new heavy toolchain | per-query model still has a ceiling; truly huge monorepos may remain impractical |
+| **C — Batch SCIP wholesale** | replace live-LSP with SCIP indexers everywhere | scales to millions of LOC; complete xref | heavy per-language toolchains; loses live/incremental ergonomics on small repos; big up-front build before any value |
+| **D — Tiered (chosen)** | B for single repos + spike-gated C for monorepos | right tool per scale; value lands incrementally; the expensive bet is data-gated | two code paths to maintain long-term; cross-tier consistency to manage |
+
+**Chosen: D.** B alone leaves the monorepo case unsolved; C alone over-builds for the common case and delays all value. D delivers correctness + 10–100× efficiency for the *typical* repo immediately (Phases 0–2) while de-risking the monorepo bet with a spike before any heavy investment.
+
+---
+
+## Consequences
+
+**Positive**
+- Large single repos go from ~1 % silently-wrong augmentation to meaningful, bounded-time, *honestly-reported* coverage.
+- The candidate-set reduction (Phase 1) is multiplicative with concurrency (Phase 2) and incrementality (Phase 3): a small, high-value feed, probed concurrently, only on what changed.
+- Every phase is independently shippable and individually valuable; no big-bang.
+- The monorepo decision is made with spike data, not a speculative months-long build.
+
+**Negative / costs**
+- Two resolution backends long-term (live-LSP + SCIP) if Phase 4 proceeds — cross-backend determinism and the byte-identical golden contract must hold across both.
+- Incremental augmentation (P5) adds an invalidation-correctness burden (stale cache when a callee moves) — a classic incremental-compiler hazard; needs dependency-aware invalidation + a periodic full-rebuild safety net.
+- Value-prioritized ordering (P4) changes which edges land first under a budget — the deterministic golden tests must pin the new ordering.
+
+**Risks mitigated**
+- Silent degradation on large repos (the current trap — looks like "LSP ran," actually ~1 %).
+- Unbounded analyze time on big repos (budget + coverage reporting makes it predictable and honest).
+
+---
+
+## Fitness Functions
+
+1. **No silent large-repo collapse.** On `tcbs-bond-trading` (the repro), post-Phase-0 the run must report coverage and not return 57 k instant empties from a half-indexed server. CI/benchmark gate.
+2. **External-probe waste ≤ 5 %.** Post-Phase-1, `refused-external / total-probes` on a framework-heavy repo must drop from ~99 % toward ≤ 5 % (we stopped *asking* the external questions). Benchmark metric.
+3. **Throughput.** Post-Phase-2, probes/second up ≥ 4× on a real repo; golden outputs remain byte-identical (determinism preserved).
+4. **Incremental steady state.** Post-Phase-3, re-analyze after a 1-file change completes in seconds (≪ full-index time).
+5. **Budget honesty.** Augmentation never silently drops candidates — coverage (`augmented X of N, prioritized by P`) is always surfaced in the funnel.
+6. **Monorepo decision is data-backed.** Phase-4 gate: a written spike comparing SCIP index-time + coverage vs live-LSP on the largest available monorepo, before any backend build.
+
+---
+
+## Implementation notes (for the eventual plans)
+- **Reuse-first:** P2's external pre-filter reuses the heuristic's existing import resolution (it already knows external vs internal); P5 reuses the persisted `source` provenance column and `analyze.ts`'s `lastCommit` check.
+- **Determinism contract:** every change touching candidate ordering or concurrency must keep the mode-a golden byte-identity tests green (the I-9 invariant) — value-only updates, never coalesced.
+- **Per-adapter readiness audit (Phase 0):** Go's `$/progress` "Setting up workspace" end is the closest-to-correct model; Rust's `serverStatus quiescent` is good; jdtls needs an index-complete signal (wait on `$/progress` "Importing…"/"Building…" end + a settle-until-stable canary); TS/Python no-op `awaitReady` is acceptable (fast servers) but should be re-validated on large repos.
+- **Confirm the effective cap path** in the large-repo run (the reconciler default is 2 000 but the observed feed reached ~113 k) — the cap redesign (P4) supersedes it regardless.
+
+---
+
+## Phase 0 + Phase 1 Implementation Plan (adr002-java-large-repo-augmentation)
+
+**Status:** Design-complete, pending implementation. Full plan: `docs/plans/adr002-p0-lsp-large-repo-readiness.md`. Prior plan: `docs/designs/adr002-p0-lsp-large-repo-readiness.md`.
+**Scope:** P1 (jdtls readiness — settle-until-quiet) + P4-lite (coverage honesty) + P2-partial (external pre-filter). All other phases deferred.
+
+### Spike outcome — settle-until-quiet (supersedes title-matching)
+
+Spike executed 2026-06-15 against `tcbs-bond-trading` (760 files) with real jdtls at `/opt/homebrew/bin/jdtls`:
+- `language/status` ServiceReady fires at ~3.5 s — server-up only.
+- `$/progress` "Building…" tokens run 3.6–7.8 s; "Searching…" runs 7.8–19.3 s.
+- Token titles are **generic and multi-instance** — AND-over-named-titles matching (R2-5) is fragile and environment-dependent.
+- jdtls is **quiet after ~19.3 s** and canary textDocument/definition returns non-empty at that point.
+
+**Decision:** Replace title-matching with **SETTLE-UNTIL-QUIET**: resolve ready when `$/progress` has been silent for a configurable quiet interval (5 s default) AND the canary returns non-empty. `JDTLS_IMPORT_PROGRESS_TITLES` is not needed; WI-0 spike gate is eliminated. Expected ready time: ~24–27 s — well under the 600 s deadline.
+
+### Design
+
+Phase 0 has two file-disjoint work-streams (A: jdtls readiness; B: coverage honesty). Phase 1 adds Work-stream C (external-callee pre-filter). All three land in one PR.
+
+**Work-stream A — jdtls awaitReady — settle-until-quiet (P1)**
+
+Root cause: `JAVA_ADAPTER.awaitReady` settles on `language/status ServiceReady`, which fires when jdtls's JVM is up (~3.5 s) but before Maven project import and classpath indexing finish (spike: ~19.3 s on `tcbs-bond-trading`). On `tcbs-bond-trading` this produced 0.86% augmentation and 57,583 instant refusals.
+
+Fix:
+
+Add `clientCapabilities: { window: { workDoneProgress: true } }` to `JAVA_ADAPTER`. This activates the `$/progress` seam (`progressTokenTitles` Map, `progressEndedTokens` Set, `onProgressEnd` subscriber) that already exists in `LspClient` (capability-gated) and is already used by `GO_ADAPTER`. `TS_SERVER_CAPABILITIES` is never touched (C0-2 / I-1 invariant).
+
+The `awaitReady` body implements **settle-until-quiet**:
+
+1. **Quiet-interval timer:** on each `$/progress` end event (via `ctx.onProgressEnd`), reset a `setTimeout` for the quiet interval (5 s). When the timer fires, run a canary probe; if non-empty, settle true immediately.
+2. **Periodic self-rescheduling canary:** the quiet-interval callback is self-rescheduling — it does NOT fire only once at the hard deadline. Canary fires every quiet_interval/2 (2.5 s) independently as a liveness check so a server that emits zero `$/progress` events still gets probed periodically.
+3. **No title matching required.** The `onProgressEnd` callback simply resets the quiet timer regardless of title; no `JDTLS_IMPORT_PROGRESS_TITLES` list.
+4. Register a **no-op consumer** for `language/status` to consume-and-ignore ServiceReady — arrival MUST NOT settle `awaitReady`.
+5. On deadline (`JDTLS_READY_DEADLINE_MS = 600_000`): settle false; dispose all handlers and timers. `awaitReady` never rejects.
+
+Disposition of `language/status ServiceReady`: **removed entirely** as a settlement gate. ServiceReady fires before index-complete; keeping it as any fallback re-introduces the race.
+
+Key constants:
+- `JDTLS_READY_DEADLINE_MS = 600_000` (10 min) — exported named constant, overridable via `ctx.deadlineMs`. Differs from `GOPLS_READY_DEADLINE_MS = 30_000`.
+- `JDTLS_QUIET_INTERVAL_MS = 5_000` — single fixed constant; unit tests pin it with fake timers.
+- Canary reschedule interval = `JDTLS_QUIET_INTERVAL_MS / 2 = 2_500`.
+
+`AdapterReadyCtx` comment annotations (currently "Go only") updated to reflect Java also populates the `$/progress` seam fields.
+
+**Work-stream B — coverage honesty (P4-lite)**
+
+Gaps: `SessionMeta` lacks `totalCandidates` (N before cap slice); `ReconciliationReport` lacks `probed` (true dispatch count, distinct from `selected.length`); the funnel line never reports N vs B; no `--lsp-budget` CLI flag; the funnel line is silent on gate-failure, error, dry-run, and `awaitReady=false` paths.
+
+Fixes:
+- Add `totalCandidates: number` to `SessionMeta` (captured as `sorted.length` before `sorted.slice(0, cap)`). Additive — no call-site breaks. Note: `totalCandidates >= cap` is FALSE when N < B (small repos) — do not assert it.
+- Add `probed: number` to `ReconciliationReport` — count of candidates for which `textDocument/definition` was actually dispatched. P=0 on probe-refusal; P=selected.length on all-probed.
+- Capture N (`dedupedCandidates.length`) and B (`options?.lsp?.budget ?? DEFAULT_CANDIDATE_CAP`) in pipeline scope BEFORE `withReconciliationSession` so they survive gate-failure and error paths.
+- Extend the existing `pipeline.ts:962` line **in-place** (NOT a second line): `lsp: confirmed C, corrected X, recall +R, refused F, skipped S (budget B of N candidates)`.
+- Emit the funnel line on dry-run, gate-failure (`sessionResult===null`), and error path before rethrow. On `awaitReady(false)` emit: `"LSP augmentation skipped: jdtls not ready after <deadline>s"`.
+- Register `--lsp-budget <n>` on the analyze command in `src/cli/index.ts` (commander, NOT yargs; NOT `analyze.ts`). Three wiring edits required: (1) `budget?: number` on `PipelineOptions.lsp`; (2) `AnalyzeOptions.lspBudget → PipelineOptions.lsp.budget`; (3) `cap: options?.lsp?.budget` in the deps literal at `pipeline.ts:815`. Reject `--lsp-budget <= 0` at the commander action with a descriptive error (`0 ?? DEFAULT` does NOT coalesce on zero).
+
+I-9 safety: these changes add fields and expand a log line. They do NOT touch `sortCandidates`, `candidateCompare`, or `sorted.slice(0, cap)`. Mode-A golden byte-identity tests are unaffected.
+
+**Work-stream B — coverage honesty (P4-lite)**
+
+Gaps: `ReconciliationReport` lacks `probed` (true dispatch count, distinct from `selected.length`); the funnel line never reports N vs B; no `--lsp-budget` CLI flag; the funnel line is silent on gate-failure, error, dry-run, and `awaitReady=false` paths.
+
+Fixes:
+- Add `probed: number` to `ReconciliationReport` — count of candidates for which `textDocument/definition` was actually dispatched. Incremented inside the `runWithConcurrency` dispatch loop (after `canSkipCandidate` check, not inside `fetchDefinitionForCandidate`). Defaults to 0 when no dispatch occurs.
+- Add `preFilteredExternal: number` to `ReconciliationReport` — count of candidates skipped by the external pre-filter. Distinct from `refused`.
+- Capture N (`dedupedCandidates.length`) and B (`options?.lsp?.budget ?? DEFAULT_CANDIDATE_CAP`) in pipeline scope BEFORE `withReconciliationSession` so they survive gate-failure and error paths.
+- Extend the existing `pipeline.ts:962` line **in-place** (NOT a second line): `lsp: confirmed C, corrected X, recall +R, refused F, pre-filtered-external E, skipped S (budget B of N candidates)`.
+- Emit the funnel line on dry-run, gate-failure (`sessionResult===null`), and error path before rethrow. On `awaitReady(false)` emit: `"LSP augmentation skipped: jdtls not ready after <deadline>s"`.
+- Register `--lsp-budget <n>` on the analyze command in `src/cli/index.ts` (commander, NOT yargs; NOT `analyze.ts`). Three wiring edits required: (1) `budget?: number` on `PipelineOptions.lsp`; (2) `AnalyzeOptions.lspBudget → PipelineOptions.lsp.budget`; (3) `cap: options?.lsp?.budget` in the deps literal at `pipeline.ts:815`. Reject `--lsp-budget <= 0` at the commander action with a descriptive error (`0 ?? DEFAULT` does NOT coalesce on zero).
+
+**Work-stream C — external-callee pre-filter (P2-partial)**
+
+Before each `textDocument/definition` dispatch, classify the callee as PROVABLY EXTERNAL and skip (conservative: uncertain = probe, no false skips).
+
+- Add optional `canSkipCandidate?: (candidate: Candidate) => boolean` to `WithReconciliationSessionDeps`. The dispatch loop in `withReconciliationSession` checks it per-candidate before `fetchDefinitionForCandidate`. When absent, default per-import classification runs.
+- For **correction candidates**: check `oldTargetId` via `JAVA_ADAPTER.classifyUri` — `jdt://` prefix → `'external'` → skip. O(1) string prefix, conservative.
+- For **recall candidates**: check whether the callee/receiver name binds to an external import. External classification uses `isUnindexablePath` on the resolved path (already gates `node_modules`/`.d.ts`/`dist`). For Java, where `namedImportMap` is empty (Java uses FQN imports, not named-binding extractor), the `jdt://`-based classifyUri path is not applicable at recall time — classify on candidate.file via `isUnindexablePath` only; uncertain = probe.
+- Classify on `candidate.file` (raw, not realpath'd) per macOS symlink hazard (`location-mapper.ts:490–510`).
+- The `canSkipCandidate` closure in `pipeline.ts` captures `lspAdapter.classifyUri` and `ctx.namedImportMap` — no new field on `WithReconciliationSessionDeps` for those (closure injection is cleaner and keeps the reconciler decoupled).
+
+### Work Items
+
+| WI | Title | Files | Size | Risk | Sequence |
+|----|-------|-------|------|------|----------|
+| WI-1 | Add `JDTLS_READY_DEADLINE_MS`, `JDTLS_QUIET_INTERVAL_MS` + `JAVA_ADAPTER.clientCapabilities` | `language-adapter.ts` | S | MEDIUM | First (WS-A foundation) |
+| WI-2 | Replace `JAVA_ADAPTER.awaitReady` body — settle-until-quiet + no-op language/status | `language-adapter.ts` | M | MEDIUM | After WI-1 |
+| WI-3 | Update `AdapterReadyCtx` JSDoc + stale "Go only" comments | `language-adapter.ts`, `lsp-client.ts` | S | LOW | After WI-1, parallel with WI-2 |
+| WI-4 | Tests: rewrite ~29 Java `awaitReady` unit tests for settle-until-quiet; update C0-4, C0-10; update `java-jdtls-real.test.ts` AC-4 | `language-adapter-java.test.ts`, `language-adapter-java-canary-backstop.test.ts`, `language-adapter.test.ts`, `lsp-client.test.ts`, `java-jdtls-real.test.ts` | L | MEDIUM | After WI-2 + WI-3 |
+| WI-5 | Add `ReconciliationReport.probed` + `ReconciliationReport.preFilteredExternal` + expand funnel line (all paths) | `mode-a-reconciler.ts`, `pipeline.ts` | S | LOW | Independent (WS-B) |
+| WI-6 | Add `--lsp-budget` CLI flag + three threading edits | `src/cli/index.ts`, `analyze.ts`, `pipeline.ts` | S | LOW | After WI-5 |
+| WI-7 | Tests: `--lsp-budget` wiring + funnel line format + I-9 golden non-regression | `mode-a-session.test.ts` | S | LOW | After WI-6 |
+| WI-8 | Add `canSkipCandidate` seam + external pre-filter default impl | `mode-a-reconciler.ts`, `pipeline.ts` | M | MEDIUM | After WI-5 (WS-C) |
+| WI-9 | Tests: pre-filter unit tests (correction jdt:// skip; recall isUnindexablePath skip; uncertain = probe; canary symlink safety) | new test file under `test/unit/lsp/` | M | LOW | After WI-8 |
+| WI-VER | Verification: full suite gate + real-binary E2E (guarded) | full vitest suite, real jdtls (opt-in) | — | — | After all |
+
+### Key Design Decisions (post-spike adjudication)
+
+1. **Settle-until-quiet supersedes title-matching** — spike confirmed jdtls tokens are generic/multi-instance; `JDTLS_IMPORT_PROGRESS_TITLES` eliminated. WI-0 gate removed. Expected ready: ~24 s on `tcbs-bond-trading` (well under 600 s deadline).
+2. **`ServiceReady` removed entirely** — no dual-signal, no fast-path fallback. ServiceReady fires before index-complete; keeping it re-introduces the race on every large repo.
+3. **Periodic self-rescheduling canary** — canary fires every `JDTLS_QUIET_INTERVAL_MS / 2` (2.5 s) independently of `$/progress` events so a never-progressing server settles false in bounded time, not after a full 600 s wait.
+4. **`--lsp-budget` via commander in `src/cli/index.ts`** — codebase uses commander, not yargs. Three explicit threading edits required or the flag is a silent no-op.
+5. **Single funnel line extended in-place** — the existing `pipeline.ts:962` line already prints skipped; a second line would double-report. Only N, B, and pre-filtered-external are new signal; appended in-place.
+6. **Funnel emitted on ALL paths** — gate-failure, error before rethrow, dry-run, and `awaitReady(false)`. N and B captured in pipeline scope before `withReconciliationSession` so they survive a null result.
+7. **Conservative external pre-filter** — uncertain = probe; false skips of internal candidates are prohibited. Java recall candidates use `isUnindexablePath` (not namedImportMap, which is empty for Java FQN imports).
+8. **`canSkipCandidate` closure captures classifyUri** — no new typed field on `WithReconciliationSessionDeps` for `classifyUri`; pipeline.ts closure closes over `lspAdapter.classifyUri` directly, keeping the reconciler decoupled from adapter specifics.
+9. **Validation thresholds** — smoke floors: augmented% ≥ 4.3% (5× baseline); instant-refusals ≤ 28,791 (50% baseline); `pre-filtered-external` high on `tcbs-bond-trading` (57 k recall vs external Spring/JDK targets); `bond-exception-handler` confirmed+recall ≥ baseline (66%). E2E gate is manual / opt-in CI.
+
+### Fitness Functions (Phase 0 + Phase 1 specific)
+
+1. `cd gitnexus && npm test` — all mode-a golden byte-identity tests pass with zero modification (I-9). Re-run with NO `--lsp-budget` flag as a positive test (WI-7).
+2. `npx tsc --noEmit` — zero type errors.
+3. Unit: settle-until-quiet resolves true after `JDTLS_QUIET_INTERVAL_MS` of `$/progress` silence AND non-empty canary; resolves false at `JDTLS_READY_DEADLINE_MS`.
+4. Unit: `ServiceReady` notification does NOT settle `awaitReady` (negative AC).
+5. Unit: periodic canary invoked ≥2× before deadline when no `$/progress` events arrive (fake timers, interval = `JDTLS_QUIET_INTERVAL_MS / 2`).
+6. Unit: `--lsp-budget 0` or negative rejected with descriptive error; `--lsp-budget 500` with N=5000 → `selected.length === 500`.
+7. Unit: funnel line emitted on gate-failure with `N > 0, P = 0, pre-filtered-external = 0`.
+8. Unit: `canSkipCandidate` returning true increments `preFilteredExternal`; candidate is not dispatched.
+9. Unit: uncertain classification returns false from `canSkipCandidate` → candidate is probed.
+10. E2E (guarded): `awaitReady` resolves true at ~24 s (not at 3.5 s) on `tcbs-bond-trading`; augmented% ≥ 4.3%; `pre-filtered-external` high for Spring/JDK calls; `bond-exception-handler` confirmed+recall ≥ 66% baseline.

--- a/gitnexus/src/cli/analyze.ts
+++ b/gitnexus/src/cli/analyze.ts
@@ -69,6 +69,12 @@ export interface AnalyzeOptions {
    * decision but never mutates the graph.
    */
   lspDryRun?: boolean;
+  /**
+   * WI-6 (#159 P3): when set, overrides the default candidate cap (2000)
+   * passed to `withReconciliationSession`. Must be a positive integer.
+   * Requires `--lsp`; silently ignored (with a warning) when `lsp` is false.
+   */
+  lspBudget?: number;
 }
 
 /** Threshold: auto-skip embeddings for repos with more nodes than this */
@@ -130,6 +136,26 @@ export const analyzeCommand = async (
 
   if (options?.verbose) {
     process.env.GITNEXUS_VERBOSE = '1';
+  }
+
+  // WI-6: validate --lsp-budget before any I/O. Commander passes option values
+  // as strings; Number() coerces them. We require a positive integer — zero,
+  // negative, fractional, and non-numeric values are all rejected here so no
+  // bad cap ever reaches withReconciliationSession.
+  // WS-B: validation is placed here in the action callback so it fires both
+  // from the CLI path (via commander) and from programmatic callers. This is
+  // the sole guard point; pipeline.ts receives only valid values.
+  if (options?.lspBudget !== undefined) {
+    const n = options.lspBudget;
+    if (!Number.isInteger(n) || n <= 0) {
+      console.error(`  Error: --lsp-budget must be a positive integer (got ${n})`);
+      process.exitCode = 1;
+      return;
+    }
+    if (!options?.lsp && !options?.lspDryRun) {
+      // Warn but don't crash — the run proceeds without LSP.
+      console.warn('  Warning: --lsp-budget ignored: --lsp not enabled');
+    }
   }
 
   console.log('\n  GitNexus Analyzer\n');
@@ -302,6 +328,10 @@ export const analyzeCommand = async (
     lsp: {
       enabled: options?.lsp === true || options?.lspDryRun === true,
       dryRun: options?.lspDryRun === true,
+      // WI-6: thread the validated budget (positive integer) through to the
+      // session cap. undefined when --lsp-budget was not supplied; the
+      // pipeline falls back to DEFAULT_CANDIDATE_CAP=2000 via ?? fallback.
+      budget: options?.lspBudget,
     },
   });
 

--- a/gitnexus/src/cli/index.ts
+++ b/gitnexus/src/cli/index.ts
@@ -32,6 +32,7 @@ program
    .option('-v, --verbose', 'Enable verbose ingestion warnings (default: false)')
    .option('--lsp', 'Augment CALLS resolution with the TypeScript language server (TS-only, CALLS-only, confidence 0.70)')
    .option('--lsp-dry-run', 'Preview every LSP reconciliation decision and write nothing; implies --lsp')
+   .option('--lsp-budget <n>', 'Limit LSP candidate cap to n (positive integer; default 2000); requires --lsp', (v) => Number(v))
    .addHelpText('after', '\nEnvironment variables:\n  GITNEXUS_NO_GITIGNORE=1  Skip .gitignore parsing (still reads .gitnexusignore)')
    .action(createLazyAction(() => import('./analyze.js'), 'analyzeCommand'));
 

--- a/gitnexus/src/core/ingestion/lsp/language-adapter.ts
+++ b/gitnexus/src/core/ingestion/lsp/language-adapter.ts
@@ -95,13 +95,17 @@ export interface AdapterReadyCtx {
    */
   backstopProbe?: () => Promise<boolean>;
 
-  // ── WI-2a: progress read-seam (Go only) ──────────────────────────────
+  // ── WI-2: progress read-seam (Go + Java) ────────────────────────────
   //
-  // The three fields below are OPTIONAL. TS/Java/Python adapters receive an
+  // The three fields below are OPTIONAL. TS/Python adapters receive an
   // `AdapterReadyCtx` where all three are `undefined` — their `awaitReady`
-  // implementations must not touch them. Only `GO_ADAPTER.awaitReady` reads
-  // them; `LspClient.spawnAndInitialize` populates them by reference when the
-  // adapter has `clientCapabilities?.window?.workDoneProgress` set.
+  // implementations must not touch them. Both `GO_ADAPTER.awaitReady` and
+  // `JAVA_ADAPTER.awaitReady` read them; `LspClient.spawnAndInitialize`
+  // populates them by reference when the adapter has
+  // `clientCapabilities?.window?.workDoneProgress` set (truthy).
+  //
+  // Go: `workDoneProgress: true` (WI-2a — gopls progress gate).
+  // Java: `workDoneProgress: true` (WI-1 — jdtls settle-until-quiet gate).
   //
   // Design: threaded by reference (same Map/Set instance as `LspClient`) so
   // `awaitReady` can observe tokens buffered BEFORE it is called (the
@@ -113,8 +117,8 @@ export interface AdapterReadyCtx {
    * pre-`initialize` `$/progress` handler). Keys are progress token ids;
    * values are the stored `begin.value.title` strings.
    *
-   * Populated only for Go (Go adapter sets `clientCapabilities?.window?.workDoneProgress`).
-   * `undefined` for TS/Java/Python.
+   * Populated for Go and Java (both set `clientCapabilities?.window?.workDoneProgress`).
+   * `undefined` for TS/Python.
    */
   progressTokenTitles?: ReadonlyMap<string | number, string>;
 
@@ -123,7 +127,7 @@ export interface AdapterReadyCtx {
    * pre-`initialize` `$/progress` handler). Contains every token that has
    * received its `end` notification.
    *
-   * Populated only for Go. `undefined` for TS/Java/Python.
+   * Populated for Go and Java. `undefined` for TS/Python.
    */
   progressEndedTokens?: ReadonlySet<string | number>;
 
@@ -133,9 +137,9 @@ export interface AdapterReadyCtx {
    * processes a new `end` notification. The returned disposable removes `cb`
    * from the registry.
    *
-   * Populated only for Go. `undefined` for TS/Java/Python.
+   * Populated for Go and Java. `undefined` for TS/Python.
    *
-   * Usage pattern in `GO_ADAPTER.awaitReady`:
+   * Usage pattern in `GO_ADAPTER.awaitReady` / `JAVA_ADAPTER.awaitReady`:
    *   const sub = ctx.onProgressEnd?.((token) => { … });
    *   // …
    *   sub?.dispose();
@@ -423,142 +427,226 @@ export const JAVA_ADAPTER: LanguageAdapter = {
 
   initializationOptions: {},
 
+  /**
+   * WI-1: tells jdtls the client supports `$/progress` notifications,
+   * enabling the progress-based readiness heuristic used by the WI-4
+   * `awaitReady` implementation (ADR-002).
+   *
+   * This object is a FRESH literal — it does NOT reference or spread the
+   * module-private `TS_SERVER_CAPABILITIES` const (C0-2 / I-1 identity
+   * discipline). `lsp-client.ts` uses
+   * `adapter.clientCapabilities ?? TS_SERVER_CAPABILITIES` so adapters
+   * that omit this field still send the byte-identical TS payload.
+   */
+  clientCapabilities: { window: { workDoneProgress: true } },
+
   awaitReady(ctx: AdapterReadyCtx): Promise<boolean> {
-    // KD-1: wait for jdtls `language/status` / `ServiceReady` notification.
-    // On hard deadline: attempt one canary re-probe (KD-1 backstop).
-    // Contract: never rejects; always disposes the notification handler (no leak).
+    // WI-2: settle-until-quiet strategy for jdtls.
+    //
+    // Algorithm:
+    //   1. Register a no-op consumer for `language/status` — jdtls sends
+    //      `ServiceReady` here but we intentionally IGNORE it (I-2: ServiceReady
+    //      MUST NOT trigger settle(true)). The handler is registered to consume
+    //      the notification and prevent unhandled-message warnings; it disposes
+    //      on settle.
+    //   2. Subscribe to `ctx.onProgressEnd` (populated by lsp-client.ts because
+    //      JAVA_ADAPTER.clientCapabilities.window.workDoneProgress = true).
+    //      Each `$/progress end` event resets a JDTLS_QUIET_INTERVAL_MS (5 s)
+    //      quiet timer. When the quiet timer fires, run a canary probe:
+    //        - non-empty Location[] → settle(true)
+    //        - empty → keep waiting (reset pending next event)
+    //   3. Self-rescheduling periodic canary (fires at JDTLS_QUIET_INTERVAL_MS/2
+    //      intervals). Guards the zero-progress-events path: if jdtls never emits
+    //      any `$/progress end`, the canary still fires ≥2× before deadline,
+    //      allowing non-empty results to settle(true) without the quiet path.
+    //   4. Hard deadline: ctx.deadlineMs ?? JDTLS_READY_DEADLINE_MS → settle(false).
+    //
+    // All four resources {language/status handler, progressEnd sub, quiet timer,
+    // deadline timer, canary rescheduler} are disposed under a single `settled`
+    // guard on EVERY settle path (I-2e). The settled boolean prevents double-
+    // resolution on concurrent timer races.
+    //
+    // Never rejects — all throws caught; degrade to settle(false).
     //
     // Capture canary at call time (not via JAVA_ADAPTER self-reference) so
     // tests and clones can patch the adapter copy and observe the backstop.
     const capturedCanary = JAVA_ADAPTER.canary;
     const capturedWorkspaceRoot = ctx.workspaceRoot;
+    const conn = ctx.connection as MessageConnection;
 
     return new Promise<boolean>((resolve) => {
-      const deadline = ctx.deadlineMs ?? 120_000;
-      const conn = ctx.connection as MessageConnection;
+      const deadline = ctx.deadlineMs ?? JDTLS_READY_DEADLINE_MS;
+      const CANARY_INTERVAL_MS = JDTLS_QUIET_INTERVAL_MS / 2; // 2 500 ms
 
       let settled = false;
-      let handler: { dispose(): void } | null = null;
-      // Hoisted before `settle` to avoid TDZ when onNotification throws synchronously.
-      let timer: ReturnType<typeof setTimeout> | null = null;
+      let langStatusHandler: { dispose(): void } | null = null;
+      let progressSub: { dispose(): void } | null = null;
+      let quietTimer: ReturnType<typeof setTimeout> | null = null;
+      let canaryTimer: ReturnType<typeof setTimeout> | null = null;
+      let deadlineTimer: ReturnType<typeof setTimeout> | null = null;
+
+      function dispose(): void {
+        if (langStatusHandler !== null) {
+          try { langStatusHandler.dispose(); } catch { /* ignore */ }
+          langStatusHandler = null;
+        }
+        if (progressSub !== null) {
+          try { progressSub.dispose(); } catch { /* ignore */ }
+          progressSub = null;
+        }
+        if (quietTimer !== null) { clearTimeout(quietTimer); quietTimer = null; }
+        if (canaryTimer !== null) { clearTimeout(canaryTimer); canaryTimer = null; }
+        if (deadlineTimer !== null) { clearTimeout(deadlineTimer); deadlineTimer = null; }
+      }
 
       function settle(value: boolean): void {
         if (settled) return;
         settled = true;
-        if (timer !== null) { clearTimeout(timer); timer = null; }
-        try {
-          handler?.dispose();
-        } catch {
-          // ignore dispose errors — best-effort cleanup
-        }
+        dispose();
         resolve(value);
       }
 
-      // Register a one-shot notification handler for language/status.
-      try {
-        handler = conn.onNotification(
-          'language/status',
-          (params: unknown) => {
-            // jdtls sends { type: 'ServiceReady', message: '...' } when ready.
-            // Accept any truthy ServiceReady type regardless of extra fields.
-            if (
-              params !== null &&
-              typeof params === 'object' &&
-              (params as Record<string, unknown>)['type'] === 'ServiceReady'
-            ) {
+      /**
+       * Run a single canary probe. Resolves settle(true) when the probe
+       * returns a non-empty result. Otherwise a no-op (caller decides what
+       * to do next — quiet path resets the timer; periodic path reschedules).
+       * Returns true iff the probe produced a non-empty result.
+       */
+      async function runCanary(): Promise<boolean> {
+        try {
+          if (ctx.backstopProbe) {
+            // Injected probe — used in tests to supply a controlled verdict.
+            const ready = await ctx.backstopProbe();
+            return ready;
+          }
+          // Inline probe: build samples + didOpen + textDocument/definition.
+          const samples = await buildCanarySamples(capturedWorkspaceRoot, {
+            strategy: capturedCanary,
+            maxFiles: 1,
+          });
+          if (samples.length === 0) return false;
+          const sample = samples[0];
+          // Open the file before requesting definition — jdtls requires an
+          // open document to resolve definitions (returns empty otherwise).
+          try {
+            let fileContent = '';
+            try {
+              fileContent = await fs.promises.readFile(
+                fileURLToPath(sample.textDocument.uri),
+                'utf8',
+              );
+            } catch { /* unreadable — send empty content */ }
+            await conn.sendNotification('textDocument/didOpen', {
+              textDocument: {
+                uri: sample.textDocument.uri,
+                languageId: JAVA_ADAPTER.languageId,
+                version: 1,
+                text: fileContent,
+              },
+            });
+          } catch { /* best-effort: proceed even if didOpen fails */ }
+          const result = await conn.sendRequest<unknown>(
+            'textDocument/definition',
+            { textDocument: sample.textDocument, position: sample.position },
+          );
+          return (
+            result !== null &&
+            result !== undefined &&
+            !(Array.isArray(result) && result.length === 0)
+          );
+        } catch {
+          return false;
+        }
+      }
+
+      /**
+       * Quiet-interval handler: fires JDTLS_QUIET_INTERVAL_MS after the last
+       * `$/progress end` event. Runs the canary; settles true on non-empty,
+       * otherwise waits for the next progress event (quiet timer not reset here
+       * — the progressEnd subscriber resets it on the next end event).
+       */
+      function onQuietInterval(): void {
+        quietTimer = null;
+        if (settled) return;
+        void runCanary().then((ready) => {
+          if (settled) return;
+          if (ready) {
+            settle(true);
+          }
+          // Empty canary — do not settle; wait for next $/progress end event
+          // or the periodic canary backstop.
+        });
+      }
+
+      /**
+       * Self-rescheduling periodic canary — guards the zero-progress-events path.
+       * Fires at CANARY_INTERVAL_MS intervals. On a non-empty probe result,
+       * settle(true). Otherwise reschedule.
+       */
+      function schedulePeriodicCanary(): void {
+        if (settled) return;
+        canaryTimer = setTimeout(() => {
+          canaryTimer = null;
+          if (settled) return;
+          void runCanary().then((ready) => {
+            if (settled) return;
+            if (ready) {
               settle(true);
+            } else {
+              // Reschedule — keep polling until deadline or quiet-path settles.
+              schedulePeriodicCanary();
             }
-            // Non-ready notifications (Starting, Error, etc.) are ignored;
-            // the handler stays registered until ready or deadline.
+          });
+        }, CANARY_INTERVAL_MS);
+        canaryTimer.unref?.();
+      }
+
+      // ── Step 1: no-op language/status consumer ─────────────────────────
+      // ServiceReady MUST NOT trigger settle (I-2). Register a consumer so
+      // jdtls's notification is acknowledged and not logged as unhandled.
+      try {
+        langStatusHandler = conn.onNotification(
+          'language/status',
+          (_params: unknown) => {
+            // Intentional no-op — ServiceReady must not settle awaitReady.
+            // All other types (Starting, Building, Error) also ignored here;
+            // the quiet-timer / canary path governs readiness.
           },
         );
       } catch {
-        // Connection already disposed or registration failed — degrade gracefully.
+        // Connection already disposed or registration failed — degrade.
         settle(false);
         return;
       }
 
-      // Hard deadline: fall back to one canary re-probe (KD-1 backstop).
-      timer = setTimeout(() => {
-        if (settled) return;
-        // KD-1 backstop: invoke the probe and settle based on its result.
-        // Never assume readiness without verification (AC-4 / Invariant I-2).
-        //
-        // Two paths to the probe — both must call settle() exactly once:
-        //
-        // (A) Injected probe via ctx.backstopProbe — used in unit tests to
-        //     supply a controlled readiness verdict without a real server.
-        //     The injected function is authoritative; if present, it is the
-        //     only probe invoked.
-        //
-        // (B) Inline probe via buildCanarySamples + conn.sendNotification +
-        //     conn.sendRequest — the production path when no injected probe is
-        //     provided. MUST send `textDocument/didOpen` before the definition
-        //     request: jdtls requires a file to be open in the workspace before
-        //     it will serve definitions for it; a request on an unopened file
-        //     returns an empty array, which we would incorrectly interpret as
-        //     not-ready even when the workspace IS indexed.
-        void (async () => {
-          try {
-            if (ctx.backstopProbe) {
-              // (A) Injected probe — caller is responsible for the full
-              // probe logic (build samples, issue definition request, etc.).
-              const ready = await ctx.backstopProbe();
-              settle(ready);
-              return;
-            }
-            // (B) Inline probe.
-            const samples = await buildCanarySamples(capturedWorkspaceRoot, {
-              strategy: capturedCanary,
-              maxFiles: 1,
-            });
-            if (samples.length === 0) {
-              // No candidate files found — cannot verify; degrade.
-              settle(false);
-              return;
-            }
-            const sample = samples[0];
-            // Open the file in the workspace BEFORE requesting its definition.
-            // jdtls will return an empty array for an unopened file, which
-            // would be misread as not-ready. Best-effort: if didOpen fails
-            // we still proceed with the definition request.
-            try {
-              let fileContent = '';
-              try {
-                fileContent = await fs.promises.readFile(
-                  fileURLToPath(sample.textDocument.uri),
-                  'utf8',
-                );
-              } catch { /* unreadable — send empty content */ }
-              await conn.sendNotification('textDocument/didOpen', {
-                textDocument: {
-                  uri: sample.textDocument.uri,
-                  languageId: JAVA_ADAPTER.languageId,
-                  version: 1,
-                  text: fileContent,
-                },
-              });
-            } catch { /* best-effort: proceed even if didOpen fails */ }
-            const result = await conn.sendRequest<unknown>(
-              'textDocument/definition',
-              { textDocument: sample.textDocument, position: sample.position },
-            );
-            // A non-null, non-empty response means the server resolved the
-            // definition — the workspace is ready.
-            const ready =
-              result !== null &&
-              result !== undefined &&
-              !(Array.isArray(result) && result.length === 0);
-            settle(ready);
-          } catch {
-            // Any error during the backstop probe — degrade gracefully.
-            settle(false);
-          }
-        })();
-      }, deadline);
+      // ── Step 2: subscribe to $/progress end events ─────────────────────
+      // Each end event resets the JDTLS_QUIET_INTERVAL_MS quiet timer.
+      if (ctx.onProgressEnd) {
+        try {
+          progressSub = ctx.onProgressEnd((_token) => {
+            if (settled) return;
+            // Reset the quiet timer — silence must persist for the full interval
+            // after the LAST end event before we probe.
+            if (quietTimer !== null) { clearTimeout(quietTimer); }
+            quietTimer = setTimeout(onQuietInterval, JDTLS_QUIET_INTERVAL_MS);
+            quietTimer.unref?.();
+          });
+        } catch {
+          // Subscribe failed — quiet path unavailable; periodic canary backstop
+          // will still fire ≥2× before deadline.
+        }
+      }
 
-      // Prevent the timer from keeping the Node.js event loop alive past teardown.
-      timer.unref?.();
+      // ── Step 3: periodic canary backstop ───────────────────────────────
+      // Fires at CANARY_INTERVAL_MS even when no progress events arrive.
+      // Ensures ≥2 canary invocations before the deadline (I-2b).
+      schedulePeriodicCanary();
+
+      // ── Step 4: hard deadline ──────────────────────────────────────────
+      deadlineTimer = setTimeout(() => {
+        settle(false);
+      }, deadline);
+      deadlineTimer.unref?.();
     });
   },
 
@@ -767,6 +855,31 @@ export const PYTHON_ADAPTER: LanguageAdapter = {
     return 'unmappable';
   },
 };
+
+// ─── JDTLS_READY_DEADLINE_MS / JDTLS_QUIET_INTERVAL_MS ──────────────
+
+/**
+ * Hard deadline for `JAVA_ADAPTER.awaitReady` (milliseconds from call time).
+ *
+ * 600 s (10 min) — jdtls performs Maven/Gradle workspace indexing on cold
+ * start which is significantly slower than other LSPs. ADR-002 spike data:
+ * Maven indexing runs to ~19.3 s on a mid-size repo; 600 s provides ample
+ * margin for large enterprise Java codebases.
+ *
+ * Exported so callers and tests can override via `AdapterReadyCtx.deadlineMs`.
+ */
+export const JDTLS_READY_DEADLINE_MS = 600_000;
+
+/**
+ * Quiet-interval for jdtls `$/progress` readiness heuristic (milliseconds).
+ *
+ * After the last `$/progress` end notification, jdtls is considered ready
+ * when no new progress events have arrived within this interval. 5 s is
+ * sufficient to distinguish the Maven-indexing burst from true idle.
+ *
+ * Exported for use by the WI-4 `awaitReady` implementation and its tests.
+ */
+export const JDTLS_QUIET_INTERVAL_MS = 5_000;
 
 // ─── GOPLS_READY_DEADLINE_MS ─────────────────────────────────────────
 

--- a/gitnexus/src/core/ingestion/lsp/lsp-client.ts
+++ b/gitnexus/src/core/ingestion/lsp/lsp-client.ts
@@ -255,8 +255,8 @@ export class LspClient {
    * confirmed for gopls), so the matcher MUST look up the stored title from this
    * map — never read `end.title` directly.
    *
-   * Read by `GO_ADAPTER.awaitReady` (WI-2).  Cleared on each `spawnAndInitialize`
-   * call so restarts start with a clean buffer.
+   * Read by `GO_ADAPTER.awaitReady` and `JAVA_ADAPTER.awaitReady` (WI-2).
+   * Cleared on each `spawnAndInitialize` call so restarts start with a clean buffer.
    */
   readonly progressTokenTitles = new Map<string | number, string>();
 
@@ -267,6 +267,10 @@ export class LspClient {
    * `$/progress` handler.  `awaitReady` checks this set to detect a
    * begin+end pair that arrived BEFORE `awaitReady` was invoked (the
    * begin-before-awaitReady buffering guarantee).
+   *
+   * Populated for Go and Java (both set `workDoneProgress: true`).
+   * `undefined`-equivalent (empty) for TS/Python — their handlers never
+   * register, so this set is never populated from those code paths.
    */
   readonly progressEndedTokens = new Set<string | number>();
 
@@ -279,8 +283,8 @@ export class LspClient {
    * Cleared at the start of each `spawnAndInitialize` (restart-clean) along
    * with `progressTokenTitles` and `progressEndedTokens`.
    *
-   * Non-Go adapters never register the `$/progress` handler (capability-gated),
-   * so this set is never notified from their code paths.
+   * Only adapters with `clientCapabilities?.window?.workDoneProgress = true`
+   * (Go, Java) register the `$/progress` handler; TS/Python never notify this set.
    */
   private readonly _progressEndSubs = new Set<(token: string | number) => void>();
 
@@ -813,7 +817,7 @@ export class LspClient {
     // backstop (the #172 bug class). We MUST register before sending `initialize`.
     //
     // Capability-gated: only when `adapter.clientCapabilities?.window?.workDoneProgress`
-    // is truthy.  TS/Java/Python adapters omit `clientCapabilities` → they skip
+    // is truthy. Go and Java set this; TS/Python omit `clientCapabilities` → they skip
     // this block entirely → zero new handlers registered, zero wire-behavior change.
     if (this.adapter.clientCapabilities?.window?.workDoneProgress) {
       try {
@@ -948,10 +952,10 @@ export class LspClient {
     // leak into the caller), matching the surrounding handshake
     // discipline above.
     try {
-      // WI-2a: thread progress read-seam fields only for adapters that registered
+      // WI-2: thread progress read-seam fields only for adapters that registered
       // the $/progress handler (capability-gated: workDoneProgress === true).
-      // TS/Java/Python receive undefined for all three fields — their awaitReady
-      // implementations do not read them, so the ctx is structurally unchanged.
+      // Go and Java both set workDoneProgress: true and receive all three fields.
+      // TS/Python receive undefined — their awaitReady implementations do not read them.
       const progressSeam: Pick<AdapterReadyCtx, 'progressTokenTitles' | 'progressEndedTokens' | 'onProgressEnd'> =
         this.adapter.clientCapabilities?.window?.workDoneProgress
           ? {

--- a/gitnexus/src/core/ingestion/mode-a-reconciler.ts
+++ b/gitnexus/src/core/ingestion/mode-a-reconciler.ts
@@ -139,6 +139,21 @@ export interface SessionMeta {
   requestTimeoutMs: number;
   /** Cap actually applied (default 2000; overridable via deps). */
   cap: number;
+  /**
+   * Count of candidates for which a `textDocument/definition` request
+   * was actually issued (i.e. passed the `isUnindexablePath` pre-filter
+   * and the `line`/`character` bounds gate). Populated by the dispatch
+   * loop BEFORE calling the work fn; zero if no requests were issued.
+   */
+  probed: number;
+  /**
+   * Count of candidates skipped by the `isUnindexablePath` pre-filter
+   * inside `fetchDefinitionForCandidate`. Distinct from `refused`
+   * (post-probe refusal when LSP returns no node or a non-callable
+   * node) and from `skipped` (cap-trimmed candidates that never
+   * entered the dispatch loop). Populated before calling the work fn.
+   */
+  preFilteredExternal: number;
 }
 
 /**
@@ -260,6 +275,53 @@ export interface WithReconciliationSessionDeps {
    * reads it from the discover result.
    */
   serverVersion?: string;
+  /**
+   * External pre-filter seam (WI-8).
+   *
+   * Called once per candidate BEFORE `fetchDefinitionForCandidate`.
+   * Return `true` ONLY when the candidate is PROVABLY EXTERNAL via
+   * a graph node-lookup — i.e. `graph.getNode(candidate.oldTargetId)`
+   * returns a node with `properties.isExternal === true`, OR the node
+   * is absent (undefined) for a correction candidate whose oldTargetId
+   * targets a known external-zone node id.
+   *
+   * Invariants (I-2c — no false skips):
+   *   - MUST return `false` for recall candidates (no `oldTargetId`).
+   *   - MUST return `false` for ambiguous/uncertain correction candidates.
+   *   - MUST return `false` when the lookup result is inconclusive.
+   *   - Return `true` only for correction candidates with a graph node
+   *     that is definitively external-zone.
+   *
+   * When absent from the deps bag, the session defaults to `() => false`
+   * (never-skip) — preserving pre-WI-8 behaviour exactly (backward compat).
+   *
+   * Skipped candidates increment `meta.preFilteredExternal` (not `meta.probed`);
+   * they are NOT handed to `handToEngine` and do NOT receive an LSP request.
+   */
+  canSkipCandidate?: (candidate: Candidate) => boolean;
+  /**
+   * WS-B / I-2d: discriminated gate-failure side-channel.
+   *
+   * Called (at most once) when the session refuses WITHOUT running the
+   * work fn. The `reason` distinguishes the three failure modes so the
+   * caller (pipeline.ts) can emit the correct per-path funnel message:
+   *
+   *   'no-server'      — `discoverServers` returned no entry for this adapter,
+   *                      OR `client.start()` threw.
+   *   'not-ready'      — probe returned `{ ready: false }`.
+   *   'dispatch-error' — an error was thrown inside the try block
+   *                      (per-candidate dispatch or fn threw) BEFORE
+   *                      the work fn completed.
+   *
+   * `elapsedS` is the formatted elapsed seconds string (e.g. `'2.5'`)
+   * measured from session entry to the gate failure, so the caller can
+   * embed it in messages like `'jdtls not ready after Xs'` without a
+   * separate timer.
+   *
+   * Optional — omitting it preserves the existing null-return contract
+   * exactly, so all existing tests that never pass this dep are unaffected.
+   */
+  onGateFailure?: (reason: 'no-server' | 'not-ready' | 'dispatch-error', elapsedS: string) => void;
 }
 
 // ─── Defaults (KD-9, KD-10) ────────────────────────────────────────────
@@ -392,6 +454,11 @@ export async function withReconciliationSession<T>(
   //   LanguageAdapter → use the supplied adapter (TS, Java, …).
   const adapter: LanguageAdapter | null =
     deps.adapter !== undefined ? deps.adapter : TYPESCRIPT_ADAPTER;
+  // WS-B / I-2d: gate-failure side-channel. Extract early so all failure
+  // branches below can call it. Callers that need per-reason funnel messages
+  // (e.g. pipeline.ts) pass this dep; others (existing unit tests) omit it —
+  // preserving the null-return contract exactly.
+  const onGateFailure = deps.onGateFailure;
   if (adapter === null) {
     // No supported language detected — skip the funnel cleanly.
     return null;
@@ -423,6 +490,8 @@ export async function withReconciliationSession<T>(
   const serverEntry = (discovered as Record<string, { path: string; version: string } | null | undefined>)[adapter.id] ?? null;
   if (!serverEntry) {
     // No server for this adapter's language. No client was created → no stop needed.
+    // I-2d: notify with 'no-server' so callers can emit the correct funnel message.
+    onGateFailure?.('no-server', '0.0');
     return null;
   }
   const serverVersion = deps.serverVersion ?? serverEntry.version;
@@ -441,6 +510,9 @@ export async function withReconciliationSession<T>(
     // start() threw (e.g. spawn failed). We have no client we
     // can stop — the client was either never constructed or
     // was torn down internally. Return null.
+    // I-2d: classify as 'no-server' (the server binary is unavailable or
+    // crashed on start — indistinguishable from "no binary found" at this level).
+    onGateFailure?.('no-server', '0.0');
     return null;
   }
 
@@ -454,10 +526,22 @@ export async function withReconciliationSession<T>(
   const probe = deps.probe ?? defaultProbe;
   const requestTimeoutMs = deps.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
   const handToEngine = deps.handToEngine ?? defaultHandToEngine;
-  const meta: SessionMeta = { serverVersion, requestTimeoutMs, cap };
+  // WI-8: external pre-filter seam. Defaults to () => false (never-skip)
+  // when not injected — preserving pre-WI-8 behaviour exactly.
+  const canSkipCandidate = deps.canSkipCandidate ?? (() => false);
+  // WI-5: probed/preFilteredExternal start at 0 and are incremented
+  // in the dispatch loop below. meta is built here so the fields
+  // exist; values are written before fn() is called.
+  const meta: SessionMeta = { serverVersion, requestTimeoutMs, cap, probed: 0, preFilteredExternal: 0 };
+  // Measure elapsed time from here so the not-ready message can carry
+  // a meaningful duration (the probe itself may spin for up to 600s on
+  // a slow jdtls workspace build).
+  const sessionStart = Date.now();
   try {
     const probeResult = await probe(client);
     if (!probeResult.ready) {
+      const elapsedS = ((Date.now() - sessionStart) / 1000).toFixed(1);
+      onGateFailure?.('not-ready', elapsedS);
       return null;
     }
     // Per-candidate dispatch loop. Each iteration issues ONE
@@ -492,8 +576,28 @@ export async function withReconciliationSession<T>(
       selected,
       CONCURRENT_DEFINITION_REQUESTS,
       async (candidate) => {
-        const locations = await fetchDefinitionForCandidate(client, candidate, requestTimeoutMs, uriCache, repo.repoPath);
-        await handToEngine(candidate, locations);
+        // WI-8: external pre-filter seam fires BEFORE the LSP request.
+        // Return true ONLY for provably-external correction candidates
+        // (I-2c: no false skips). Recall candidates must always probe.
+        if (canSkipCandidate(candidate)) {
+          meta.preFilteredExternal++;
+          // Do NOT call handToEngine — the candidate is excluded from
+          // the locations map; reconcileDecisions will see locs=[] →
+          // NO_NODE → keep (I-8-replay invariant preserved).
+          return;
+        }
+        const result = await fetchDefinitionForCandidate(client, candidate, requestTimeoutMs, uriCache, repo.repoPath);
+        if (result.preFiltered) {
+          // WI-5: isUnindexablePath pre-filter fired — count as
+          // preFilteredExternal (NOT probed).
+          meta.preFilteredExternal++;
+        } else {
+          // WI-5: a `textDocument/definition` request was actually
+          // issued (or would have been, before a position/URI error
+          // short-circuit — those are still not pre-filter).
+          meta.probed++;
+        }
+        await handToEngine(candidate, result.locations);
       },
     );
     return await fn(selected, meta, skipped);
@@ -503,6 +607,9 @@ export async function withReconciliationSession<T>(
     // crash must not abort the index — it must yield a coherent
     // heuristic result). The finally below still runs to stop
     // the client.
+    // I-2d: classify as 'dispatch-error' so callers can log the error path.
+    const elapsedS = ((Date.now() - sessionStart) / 1000).toFixed(1);
+    onGateFailure?.('dispatch-error', elapsedS);
     return null;
   } finally {
     // I-5: once we have a started client, we ALWAYS stop it on
@@ -648,13 +755,15 @@ async function fetchDefinitionForCandidate(
   // resolves against `process.cwd()` and the LSP server (rooted
   // at the repo) sees a non-existent / out-of-workspace path.
   repoRoot: string,
-): Promise<Location[]> {
+): Promise<{ locations: Location[]; preFiltered: boolean }> {
   // M8: validate the file path is one the engine would ever
   // index. Vendored / declaration / dist paths are
   // unindexable per the location-mapper's predicate; we
   // refuse before we spend a request budget.
+  // WI-5: callers that hit this branch are counted as
+  // `preFilteredExternal` (NOT `probed`) — see dispatch loop.
   if (isUnindexablePath(candidate.file)) {
-    return [];
+    return { locations: [], preFiltered: true };
   }
 
   // security-3 (polish MAJOR): gate `line` / `character`
@@ -671,13 +780,15 @@ async function fetchDefinitionForCandidate(
   // fractional floats, and string-encoded numbers. The
   // `< 0` clause rejects negative offsets. Both are
   // cheap (constant time) and run before any I/O.
+  // WI-5: bad-position candidates are NOT pre-filtered and
+  // NOT probed — they contribute to `refused` via NO_NODE.
   if (
     !Number.isInteger(candidate.line) ||
     !Number.isInteger(candidate.character) ||
     candidate.line < 0 ||
     candidate.character < 0
   ) {
-    return [];
+    return { locations: [], preFiltered: false };
   }
 
   // Build the `textDocument/definition` params. The file
@@ -720,7 +831,7 @@ async function fetchDefinitionForCandidate(
         // `pathToFileURL` can throw on bizarre inputs (e.g.
         // a relative path with a NUL byte). Refuse over
         // guess: skip the candidate.
-        return [];
+        return { locations: [], preFiltered: false };
       }
     }
   }
@@ -735,9 +846,9 @@ async function fetchDefinitionForCandidate(
     // belt-and-braces.
     raw = await client.request(TEXT_DOCUMENT_DEFINITION, params, timeoutMs);
   } catch {
-    return [];
+    return { locations: [], preFiltered: false };
   }
-  return normalizeLocations(raw);
+  return { locations: normalizeLocations(raw), preFiltered: false };
 }
 
 /**
@@ -987,6 +1098,24 @@ export interface ReconciliationReport {
   refused: number;
   /** Number of candidates skipped by the cap. */
   skipped: number;
+  /**
+   * Count of candidates for which a `textDocument/definition` request
+   * was actually issued (passed the `isUnindexablePath` pre-filter and
+   * the `line`/`character` bounds gate). The engine receives this from
+   * the pipeline via `ReconcileDecisionsDeps.probed`; `reconcileDecisions`
+   * itself always returns 0 (the dispatch is the session's concern).
+   * The pipeline builds `lspReport` by combining this value from the
+   * `SessionMeta` the work-fn received.
+   */
+  probed: number;
+  /**
+   * Count of candidates skipped by the `isUnindexablePath` pre-filter
+   * inside the dispatch loop. Distinct from `refused` (post-probe LSP
+   * refusal) and from `skipped` (cap-trimmed). Always 0 when returned
+   * by `reconcileDecisions` — populated by the pipeline from
+   * `SessionMeta.preFilteredExternal`.
+   */
+  preFilteredExternal: number;
   /**
    * NOTE: The engine does NOT carry the LSP server version — the
    * session passes it through `SessionMeta` and the pipeline
@@ -1926,6 +2055,12 @@ export async function reconcileDecisions(
     // threads the real count (feed.length − selected.length)
     // through `deps.skipped`. The engine never infers it.
     skipped,
+    // WI-5: `reconcileDecisions` does NOT perform the dispatch —
+    // probed/preFilteredExternal are always 0 here. The pipeline
+    // populates these from `SessionMeta` (returned by the work-fn)
+    // when assembling the final `lspReport`.
+    probed: 0,
+    preFilteredExternal: 0,
   };
 }
 

--- a/gitnexus/src/core/ingestion/pipeline.ts
+++ b/gitnexus/src/core/ingestion/pipeline.ts
@@ -19,7 +19,7 @@ import { extractDependencies } from './dependency-extractor.js';
 // WI-5 (#159 P3 Mode A): the reconciler is imported here — it lives at
 // `core/ingestion/mode-a-reconciler.ts` and mutates ONLY the in-memory
 // graph; it imports no direct-DB writer (I-7).
-import { withReconciliationSession, applyDecisions, reconcileDecisions, candidateLocationKey, type Candidate, type Location, type ReconciliationReport } from './mode-a-reconciler.js';
+import { withReconciliationSession, applyDecisions, reconcileDecisions, candidateLocationKey, DEFAULT_CANDIDATE_CAP, type Candidate, type Location, type ReconciliationReport, type SessionMeta } from './mode-a-reconciler.js';
 import { selectAdapter } from './lsp/language-adapter.js';
 import { mapLocationToNodeId } from './lsp/location-mapper.js';
 import { createInMemoryNodeQuery, type InMemoryNode } from './in-memory-node-query.js';
@@ -69,6 +69,18 @@ export interface PipelineOptions {
   lsp?: {
     enabled?: boolean;
     dryRun?: boolean;
+    /**
+     * WI-6 (#159 P3): override the candidate cap passed to
+     * `withReconciliationSession` (default: `DEFAULT_CANDIDATE_CAP=2000`).
+     * Must be a positive integer — the CLI validates this before the pipeline
+     * is called. The `??` fallback in the LSP block picks the default when
+     * `budget` is `undefined`.
+     *
+     * NOTE: `0 ?? DEFAULT_CANDIDATE_CAP` does NOT coalesce on zero — that
+     * case is rejected at the CLI validation layer (`n <= 0` guard) before
+     * it ever reaches this field.
+     */
+    budget?: number;
   };
 }
 
@@ -751,6 +763,17 @@ export const runPipelineFromRepo = async (
         dedupedCandidates.push(c);
       }
 
+      // WI-5: capture N (total deduped candidates) and B (budget cap) BEFORE
+      // withReconciliationSession so these values survive all exit paths —
+      // gate-failure (null), error (rethrow), and success — and the funnel
+      // line always has correct values even if the session never ran.
+      const lspN = dedupedCandidates.length;
+      // WI-6: use the CLI-supplied budget when present; fall back to the
+      // default 2000. The CLI validation layer guarantees `budget` is a
+      // positive integer when defined — the `??` fallback here correctly
+      // passes through `undefined` (not set) but NEVER `0` (rejected at CLI).
+      const lspB = options?.lsp?.budget ?? DEFAULT_CANDIDATE_CAP;
+
       // WI-6 (#159 P3): select the language adapter once for this
       // repo. `selectAdapter` performs an extension census (KD-4)
       // and returns the dominant adapter or `null` (no supported
@@ -800,7 +823,30 @@ export const runPipelineFromRepo = async (
         stats: { filesProcessed: totalFiles, totalFiles, nodesCreated: graph.nodeCount },
       });
 
-      const sessionResult = await withReconciliationSession(
+      // WS-B / I-2d: capture gate-failure reason + elapsed via side-channel so
+      // pipeline.ts can emit the correct per-path funnel message when the session
+      // returns null. Two distinct cases:
+      //   'not-ready'  → 'LSP augmentation skipped: jdtls not ready after Xs'
+      //                  (no budget suffix, per C5-12 / WS-B spec).
+      //   'no-server'  → gate-failure format via buildLspSummaryLine (with suffix).
+      //   'dispatch-error' → already logged in the reconcileDecisions catch below;
+      //                  onGateFailure fires only when the session's own try/catch
+      //                  fires, NOT for errors in reconcileDecisions/applyDecisions.
+      let gateFailureReason: 'no-server' | 'not-ready' | 'dispatch-error' | null = null;
+      let gateFailureElapsedS = '0.0';
+
+      // I-8-replay: track candidate keys that canSkipCandidate pre-filtered so
+      // reconcileDecisions can exclude them. Without this, they replay as [] →
+      // NO_NODE → keep/refuse and inflate refused/kept counts incorrectly.
+      const preFilteredKeys = new Set<string>();
+
+      const sessionResult = await withReconciliationSession<{
+        meta: SessionMeta;
+        selectedCount: number;
+        skipped: number;
+        probed: number;
+        preFilteredExternal: number;
+      }>(
         { id: ctx.repoId ?? 'default', repoPath },
         dedupedCandidates,
         async (selected, meta, skipped) => {
@@ -808,9 +854,17 @@ export const runPipelineFromRepo = async (
           // `textDocument/definition` requests; the engine
           // seam is `handToEngine`. The session has already
           // populated `locations` by the time the work fn
-          // runs. We return the meta + skipped count so the
-          // outer code can report it.
-          return { meta, selectedCount: selected.length, skipped };
+          // runs. We return meta + skipped + the dispatch
+          // counters directly (WS-B work-fn payload spec).
+          // WI-5: meta.probed and meta.preFilteredExternal are set
+          // by the dispatch loop before this work-fn is called.
+          return {
+            meta,
+            selectedCount: selected.length,
+            skipped,
+            probed: meta.probed,
+            preFilteredExternal: meta.preFilteredExternal,
+          };
         },
         {
           // WI-6: pass the selected adapter (or null) so the
@@ -857,6 +911,66 @@ export const runPipelineFromRepo = async (
             // if the key shape ever evolves.
             locations.set(candidateLocationKey(candidate), responseLocs);
           },
+          // WI-6: pass the resolved budget as the session cap so
+          // withReconciliationSession uses the CLI-supplied value
+          // instead of its own DEFAULT_CANDIDATE_CAP default.
+          cap: lspB,
+          // WI-8: external pre-filter. Uses graph.getNode(oldTargetId)
+          // to detect correction candidates whose heuristic target is
+          // an external-zone node (NodeProperties.isExternal===true).
+          // EP-D (BLOCKER): an absent node must NOT be skipped — it could
+          // be a deleted workspace symbol that never had `isExternal` set.
+          // The conservative rule is: only skip when the node is PRESENT
+          // and isExternal===true; absent → probe (let the engine decide).
+          //
+          // I-8-replay invariant: when canSkipCandidate returns true, the
+          // candidate key is recorded in `preFilteredKeys` so it can be
+          // excluded from the reconcileDecisions replay set below. Without
+          // exclusion, the engine would see locs=[] → NO_NODE → keep/refuse
+          // and those outcomes would corrupt confirmed/corrected/recall/refused
+          // counts (the candidate was never probed — it must not score).
+          //
+          // Invariants (I-2c — no false skips):
+          //   - Recall candidates (no oldTargetId) → always false.
+          //   - oldTargetId present but node is undefined → false
+          //     (EP-D: conservative probe; a deleted workspace symbol must
+          //     not be silently skipped — probe and let the engine decide).
+          //   - oldTargetId present, node found, isExternal===true → true.
+          //   - oldTargetId present, node found, isExternal===false → false
+          //     (workspace-internal; must probe).
+          //   - oldTargetId present, node found, isExternal===undefined
+          //     (field absent) → false (conservative; probe).
+          //
+          // classifyUri is NOT used here — oldTargetId is a graph node id,
+          // not a URI. isUnindexablePath is NOT used here — candidate.file
+          // is the caller's .java source file, not the callee's location.
+          canSkipCandidate: (candidate) => {
+            if (!candidate.oldTargetId) {
+              // Recall candidate — always probe (I-2c).
+              return false;
+            }
+            const node = graph.getNode(candidate.oldTargetId);
+            if (node === undefined) {
+              // EP-D: node absent — could be a deleted workspace symbol.
+              // Conservative: probe so the engine can decide; no false skip.
+              return false;
+            }
+            // Node found: skip only when explicitly marked external.
+            // isExternal===undefined (field absent) → false (probe).
+            const skip = node.properties.isExternal === true;
+            if (skip) {
+              // I-8-replay: record the key so reconcileDecisions can skip it.
+              preFilteredKeys.add(candidateLocationKey(candidate));
+            }
+            return skip;
+          },
+          // WS-B / I-2d: gate-failure discriminator side-channel.
+          // pipeline.ts uses this to emit the correct funnel message per
+          // reason (not-ready vs no-server vs dispatch-error).
+          onGateFailure: (reason, elapsedS) => {
+            gateFailureReason = reason;
+            gateFailureElapsedS = elapsedS;
+          },
         },
       );
 
@@ -868,8 +982,15 @@ export const runPipelineFromRepo = async (
       // (`feed.length − selected.length`) — we thread it
       // into the engine report so the summary line is
       // truthful.
+      // WS-B: read probed/preFilteredExternal from the work-fn payload
+      // directly (not via meta) — aligns with the specified return shape
+      // {meta, selectedCount, skipped, probed, preFilteredExternal}.
       const serverVersion = sessionResult?.meta?.serverVersion ?? '';
       const sessionSkipped = sessionResult?.skipped ?? 0;
+      // WI-5: probed/preFilteredExternal from the session's dispatch
+      // loop (or 0 on gate-failure when the session returned null).
+      const sessionProbed = sessionResult?.probed ?? 0;
+      const sessionPreFiltered = sessionResult?.preFilteredExternal ?? 0;
 
       // ── Engine decision pass (per-candidate) ────────────────────
       // Replay every candidate through the decision table
@@ -877,43 +998,64 @@ export const runPipelineFromRepo = async (
       // Candidates the session refused (no Location entry)
       // fall through to the engine as `[]` → NO_NODE →
       // keep/refuse per the decision table.
-      const reconcileReport = await reconcileDecisions(
-        graph,
-        dedupedCandidates,
-        locations,
-        {
-          mapLocationToNodeId: (loc, repoId) =>
-            mapLocationToNodeId(loc, repoId, {
-              executeParameterized: inMemoryQuery,
-              repoPath,
-              resolvedRepoPath,
-              // KD-3: thread the adapter's URI classifier so jdt:// and
-              // classpath:// URIs returned by jdtls are explicitly refused as
-              // external (NO_NODE + external:true) rather than traversing the
-              // full DB-query path and returning a plain NO_NODE. For Java repos
-              // where 30–50% of CALLS target stdlib/Spring types, this avoids
-              // hundreds of avoidable in-memory Cypher queries per run and
-              // correctly flags each such refusal as an external one (not a
-              // recall-miss) in any downstream metric.
-              // Defensive null-guard: lspAdapter is non-null at this code path
-              // (the session gate above short-circuits when lspAdapter is null),
-              // but an optional-chain is cleaner than an assertion.
-              classifyUri: lspAdapter?.classifyUri.bind(lspAdapter),
-              // WI-5 (#159 P5): thread the adapter id so the mapper's
-              // out-of-repo containment guard can tag Python site-packages
-              // / stdlib `file://` URIs as `{ kind: 'NO_NODE', external: true }`
-              // rather than bare `NO_NODE`. TS/Java paths omit this field
-              // (lspAdapter?.id is 'typescript'/'java') — only 'python'
-              // activates the external:true gate.
-              adapterId: lspAdapter?.id,
-            }),
-          repoId: ctx.repoId ?? 'default',
-          skipped: sessionSkipped,
-        },
-      );
+      let reconcileReport: ReconciliationReport;
+      let applyResult: ReturnType<typeof applyDecisions>;
+      try {
+        // I-8-replay: exclude pre-filtered candidates so they do not
+        // re-enter the engine with locs=[] and corrupt count buckets.
+        const replayCandidates = preFilteredKeys.size > 0
+          ? dedupedCandidates.filter(c => !preFilteredKeys.has(candidateLocationKey(c)))
+          : dedupedCandidates;
+        reconcileReport = await reconcileDecisions(
+          graph,
+          replayCandidates,
+          locations,
+          {
+            mapLocationToNodeId: (loc, repoId) =>
+              mapLocationToNodeId(loc, repoId, {
+                executeParameterized: inMemoryQuery,
+                repoPath,
+                resolvedRepoPath,
+                // KD-3: thread the adapter's URI classifier so jdt:// and
+                // classpath:// URIs returned by jdtls are explicitly refused as
+                // external (NO_NODE + external:true) rather than traversing the
+                // full DB-query path and returning a plain NO_NODE. For Java repos
+                // where 30–50% of CALLS target stdlib/Spring types, this avoids
+                // hundreds of avoidable in-memory Cypher queries per run and
+                // correctly flags each such refusal as an external one (not a
+                // recall-miss) in any downstream metric.
+                // Defensive null-guard: lspAdapter is non-null at this code path
+                // (the session gate above short-circuits when lspAdapter is null),
+                // but an optional-chain is cleaner than an assertion.
+                classifyUri: lspAdapter?.classifyUri.bind(lspAdapter),
+                // WI-5 (#159 P5): thread the adapter id so the mapper's
+                // out-of-repo containment guard can tag Python site-packages
+                // / stdlib `file://` URIs as `{ kind: 'NO_NODE', external: true }`
+                // rather than bare `NO_NODE`. TS/Java paths omit this field
+                // (lspAdapter?.id is 'typescript'/'java') — only 'python'
+                // activates the external:true gate.
+                adapterId: lspAdapter?.id,
+              }),
+            repoId: ctx.repoId ?? 'default',
+            skipped: sessionSkipped,
+          },
+        );
 
-      // ── Apply (skip every mutation in dryRun) ───────────────────
-      const applyResult = applyDecisions(graph, reconcileReport.decisions, { dryRun });
+        // ── Apply (skip every mutation in dryRun) ───────────────────
+        applyResult = applyDecisions(graph, reconcileReport.decisions, { dryRun });
+      } catch (lspErr) {
+        // WI-5 (error path): reconcileDecisions or applyDecisions threw.
+        // Emit the funnel line BEFORE rethrowing so the log is preserved
+        // for triage. Use 0-sentinels for counters we never reached.
+        const lspElapsed = ((Date.now() - lspStart) / 1000).toFixed(1);
+        // eslint-disable-next-line no-console
+        console.log(buildLspSummaryLine(
+          'dispatch-error',
+          { confirmed: 0, corrected: 0, recall: 0, refused: 0, skipped: sessionSkipped, serverVersion: serverVersion || 'unknown', probed: sessionProbed },
+          { N: lspN, B: lspB, elapsedS: lspElapsed },
+        ));
+        throw lspErr;
+      }
 
       lspReport = {
         decisions: applyResult.decisions,
@@ -922,10 +1064,18 @@ export const runPipelineFromRepo = async (
         recall: reconcileReport.recall,
         refused: reconcileReport.refused,
         skipped: reconcileReport.skipped,
+        // WI-5: populated from SessionMeta (set by the dispatch loop).
+        probed: sessionProbed,
+        preFilteredExternal: sessionPreFiltered,
         serverVersion,
       };
 
       // ── Observability: dry-run report vs. summary line ──────────
+      // WI-5: budget suffix appended IN-PLACE on all non-error paths.
+      // Format: '(budget <B> of <N> candidates)'
+      // S = max(0, N − B) — number of candidates NOT probed due to cap.
+      const lspS = Math.max(0, lspN - lspB);
+      const budgetSuffix = ` (budget ${lspB} of ${lspN} candidates)`;
       if (dryRun) {
         // AC-6: print every {action, from→to, why} tuple, write nothing.
         //
@@ -956,15 +1106,31 @@ export const runPipelineFromRepo = async (
           );
         }
         // eslint-disable-next-line no-console
-        console.log(`  lsp-dry-run: ${lspReport.decisions.length} decision(s), 0 edges written`);
+        console.log(buildLspSummaryLine('dry-run', { ...lspReport, decisionCount: lspReport.decisions.length }, { N: lspN, B: lspB, elapsedS: '' }));
+      } else if (sessionResult === null) {
+        // WS-B (gate-failure path): session returned null — no work fn ran.
+        // Emit per-reason funnel message (I-2d discriminated outcome):
+        //   'not-ready'  → 'LSP augmentation skipped: jdtls not ready after Xs'
+        //                  NO budget suffix (C5-12 / WS-B spec).
+        //   'no-server'  → gate-failure format with budget suffix.
+        //   'dispatch-error' → covered by the reconcileDecisions catch above
+        //                  (that path calls console.log + rethrows; it never
+        //                  reaches this branch).
+        //   null (unknown reason) → fall back to gate-failure format.
+        if (gateFailureReason === 'not-ready') {
+          // C5-12: budget suffix NOT emitted on this path.
+          // eslint-disable-next-line no-console
+          console.log(`  LSP augmentation skipped: jdtls not ready after ${gateFailureElapsedS}s`);
+        } else {
+          // 'no-server' or unknown reason → gate-failure format with budget suffix.
+          const lspElapsed = gateFailureReason ? gateFailureElapsedS : ((Date.now() - lspStart) / 1000).toFixed(1);
+          // eslint-disable-next-line no-console
+          console.log(buildLspSummaryLine('gate-failure', { ...lspReport, serverVersion }, { N: lspN, B: lspB, elapsedS: lspElapsed }));
+        }
       } else {
         const lspElapsed = ((Date.now() - lspStart) / 1000).toFixed(1);
         // eslint-disable-next-line no-console
-        console.log(
-          `  lsp: confirmed ${lspReport.confirmed}, corrected ${lspReport.corrected}, ` +
-          `recall +${lspReport.recall}, refused ${lspReport.refused}, ` +
-          `skipped(cap) ${lspReport.skipped}, server <${lspReport.serverVersion || 'unknown'}> (${lspElapsed}s)`,
-        );
+        console.log(buildLspSummaryLine('success', lspReport, { N: lspN, B: lspB, elapsedS: lspElapsed }));
       }
     }
 
@@ -1142,6 +1308,63 @@ export function redactNodeId(id: string): string {
   const middle = parts.slice(1, -1).join(':');
   const redacted = middle.length > 8 ? `${middle.slice(0, 4)}…${middle.slice(-3)}` : middle;
   return `${label}:${redacted}:${tail}`;
+}
+
+/**
+ * WI-5: pure formatter for the LSP summary funnel line.
+ * Used by `runPipelineFromRepo` on all non-error exit paths, and
+ * exported so unit tests can assert the format without running the
+ * full pipeline.
+ *
+ * @param path - which log path: 'success', 'gate-failure', or 'dry-run'
+ * @param report - fields from lspReport (may be partial zeroes on gate-failure)
+ * @param opts - N (total deduped candidates), B (budget cap), elapsed seconds string,
+ *               plus dry-run decision count
+ */
+export function buildLspSummaryLine(
+  path: 'success' | 'gate-failure' | 'dry-run' | 'dispatch-error',
+  report: {
+    confirmed: number;
+    corrected: number;
+    recall: number;
+    refused: number;
+    skipped: number;
+    serverVersion: string;
+    decisionCount?: number;
+    /** probed count (dispatch-error path only) */
+    probed?: number;
+  },
+  opts: { N: number; B: number; elapsedS: string },
+): string {
+  const budgetSuffix = ` (budget ${opts.B} of ${opts.N} candidates)`;
+  const lspS = Math.max(0, opts.N - opts.B);
+  if (path === 'dry-run') {
+    return `  lsp-dry-run: ${report.decisionCount ?? 0} decision(s), 0 edges written${budgetSuffix}`;
+  }
+  if (path === 'gate-failure') {
+    return (
+      `  lsp: P=0 confirmed 0, corrected 0, recall +0, refused 0, ` +
+      `skipped(cap) ${lspS}, server <${report.serverVersion || 'unknown'}> (${opts.elapsedS}s)` +
+      budgetSuffix
+    );
+  }
+  if (path === 'dispatch-error') {
+    // reconcileDecisions or applyDecisions threw; use 0-sentinels for
+    // counters we never reached. sessionProbed is threaded via report.probed.
+    return (
+      `  lsp: dispatch-error P=${report.probed ?? 0} confirmed 0, corrected 0, ` +
+      `recall +0, refused 0, ` +
+      `skipped(cap) ${report.skipped}, server <${report.serverVersion || 'unknown'}> (${opts.elapsedS}s)` +
+      budgetSuffix
+    );
+  }
+  // success path
+  return (
+    `  lsp: confirmed ${report.confirmed}, corrected ${report.corrected}, ` +
+    `recall +${report.recall}, refused ${report.refused}, ` +
+    `skipped(cap) ${report.skipped}, server <${report.serverVersion || 'unknown'}> (${opts.elapsedS}s)` +
+    budgetSuffix
+  );
 }
 
 /**

--- a/gitnexus/test/integration/lsp/java-jdtls-real.test.ts
+++ b/gitnexus/test/integration/lsp/java-jdtls-real.test.ts
@@ -14,8 +14,11 @@
  *   AC-3  `LspClient` spawns jdtls with `-data <per-run dir>` (via
  *         `JAVA_ADAPTER.spawnArgs`) and reaches state `ready`.
  *
- *   AC-4  `awaitReady` (the `language/status`/ServiceReady gate) resolves
- *         within the 120s deadline so `start()` completes successfully.
+ *   AC-4  `awaitReady` (settle-until-quiet gate) resolves within the
+ *         JDTLS_READY_DEADLINE_MS (600 s) deadline so `start()` completes
+ *         successfully. Readiness is confirmed ONLY after $/progress goes
+ *         quiet for JDTLS_QUIET_INTERVAL_MS (5 s) AND a canary probe
+ *         returns non-empty — NOT on the first language/status ServiceReady.
  *
  *   AC-4b NO pre-ready definition is published: a `request()` call
  *         racing the warm-up gate resolves `null` — the #172 class
@@ -49,9 +52,11 @@
  *
  * Timeout budget:
  *   beforeAll  — 10s  (discovery only; no server spawned)
- *   warm-up it — 180s (cold jdtls index; 30–90s typical; 180s headroom)
+ *   warm-up it — 300s (settle-until-quiet: 19s indexing + 5s quiet interval
+ *               + canary + headroom; 300 s covers JDTLS_READY_DEADLINE_MS
+ *               plus scheduling overhead)
  *   def its    —  30s each (server already warm; <2s typical)
- *   pre-ready  —  15s (no server; immediate null return)
+ *   pre-ready  — 300s (concurrent race spawns jdtls; budget matches warm-up)
  */
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
@@ -62,7 +67,7 @@ import { spawnSync } from 'node:child_process';
 
 import { discoverServers } from '../../../src/core/ingestion/lsp/server-discovery.js';
 import { LspClient } from '../../../src/core/ingestion/lsp/lsp-client.js';
-import { JAVA_ADAPTER } from '../../../src/core/ingestion/lsp/language-adapter.js';
+import { JAVA_ADAPTER, JDTLS_READY_DEADLINE_MS, JDTLS_QUIET_INTERVAL_MS } from '../../../src/core/ingestion/lsp/language-adapter.js';
 import { mapLocationToNodeId } from '../../../src/core/ingestion/lsp/location-mapper.js';
 import { buildCanarySamples } from '../../../src/core/ingestion/lsp/canary-sampler.js';
 import { probeWorkspaceReadiness } from '../../../src/core/ingestion/lsp/workspace-readiness-probe.js';
@@ -227,16 +232,27 @@ describe('jdtls real-binary smoke (WI-8 — guarded)', () => {
 
   /**
    * AC-3 + AC-4: LspClient warms jdtls on the fixture with a per-run
-   * `-data` dir; `awaitReady` resolves within the 120s deadline.
+   * `-data` dir; `awaitReady` (settle-until-quiet) resolves within
+   * JDTLS_READY_DEADLINE_MS (600 000 ms).
    *
    * This is the hot-path test: proves the full
-   * spawn → initialize → awaitReady(ServiceReady) → ready cycle works
+   * spawn → initialize → awaitReady(settle-until-quiet) → ready cycle works
    * end-to-end with a real jdtls binary.
    *
-   * Timeout: 180s to account for cold-start jdtls indexing
-   * (typical 30–90s; budget is 2× the upper bound).
+   * AC34-2 (quiet-path assertion): readiness is reached via the
+   * settle-until-quiet path, NOT instantly on the first language/status
+   * ServiceReady notification. We assert elapsed >= JDTLS_QUIET_INTERVAL_MS
+   * as a wall-clock proxy: jdtls sends ServiceReady within the first few
+   * seconds; a resolution time >= 5 s proves awaitReady waited past the
+   * ServiceReady event for a quiet interval before declaring ready.
+   *
+   * AC34-3: resolution must occur within JDTLS_READY_DEADLINE_MS (600 000 ms).
+   *
+   * Timeout: 300 000 ms — covers JDTLS_READY_DEADLINE_MS (600 s ceiling)
+   * plus scheduling overhead; typical settle time is ~24 s (19 s indexing
+   * + 5 s quiet interval) on this small fixture.
    */
-  it('client warms and reaches state=ready within deadline (AC-3, AC-4)', async () => {
+  it('client warms and reaches state=ready via quiet path within deadline (AC-3, AC-4, AC34-2, AC34-3)', async () => {
     if (!jdtlsBinary) return; // guarded skip
 
     const client = new LspClient({
@@ -245,17 +261,32 @@ describe('jdtls real-binary smoke (WI-8 — guarded)', () => {
       adapter: JAVA_ADAPTER,
     });
 
+    const startedAt = Date.now();
     try {
-      // start() completes only after awaitReady resolves (KD-1).
-      // If the ServiceReady notification never arrives within 120s,
-      // awaitReady returns false → start() throws → this test fails.
+      // AC34-1: start() completes + getState() === 'ready' (KD-1).
+      // awaitReady uses settle-until-quiet: it resolves only after
+      // $/progress goes quiet for JDTLS_QUIET_INTERVAL_MS AND a canary
+      // probe returns non-empty. If awaitReady returns false (deadline
+      // exceeded without a successful canary), start() throws → test fails.
       await client.start();
+      const elapsed = Date.now() - startedAt;
+
+      // AC34-1: state must be 'ready' after start().
       expect(client.getState()).toBe('ready');
+
+      // AC34-2: quiet-path proof — elapsed >= JDTLS_QUIET_INTERVAL_MS (5 000 ms).
+      // ServiceReady arrives within the first few seconds; a resolution time
+      // of at least 5 s proves awaitReady did NOT resolve on ServiceReady
+      // alone but waited for the quiet interval to expire before settling.
+      expect(elapsed).toBeGreaterThanOrEqual(JDTLS_QUIET_INTERVAL_MS);
+
+      // AC34-3: resolution within JDTLS_READY_DEADLINE_MS (600 000 ms).
+      expect(elapsed).toBeLessThan(JDTLS_READY_DEADLINE_MS);
     } finally {
       await client.stop();
       expect(client.getState()).toBe('stopped');
     }
-  }, 180_000);
+  }, 300_000);
 
   /**
    * AC-4 + intra-project definition shape:
@@ -499,7 +530,7 @@ describe('jdtls real-binary smoke (WI-8 — guarded)', () => {
       expect(earlyResult).toBeNull();
       await raceClient.stop();
     }
-  }, 180_000);
+  }, 300_000);
 
   /**
    * I-5 / #175 — `-data` dir isolation:

--- a/gitnexus/test/integration/lsp/java-jdtls-real.test.ts
+++ b/gitnexus/test/integration/lsp/java-jdtls-real.test.ts
@@ -67,7 +67,7 @@ import { spawnSync } from 'node:child_process';
 
 import { discoverServers } from '../../../src/core/ingestion/lsp/server-discovery.js';
 import { LspClient } from '../../../src/core/ingestion/lsp/lsp-client.js';
-import { JAVA_ADAPTER, JDTLS_READY_DEADLINE_MS, JDTLS_QUIET_INTERVAL_MS } from '../../../src/core/ingestion/lsp/language-adapter.js';
+import { JAVA_ADAPTER, JDTLS_READY_DEADLINE_MS } from '../../../src/core/ingestion/lsp/language-adapter.js';
 import { mapLocationToNodeId } from '../../../src/core/ingestion/lsp/location-mapper.js';
 import { buildCanarySamples } from '../../../src/core/ingestion/lsp/canary-sampler.js';
 import { probeWorkspaceReadiness } from '../../../src/core/ingestion/lsp/workspace-readiness-probe.js';
@@ -274,11 +274,16 @@ describe('jdtls real-binary smoke (WI-8 — guarded)', () => {
       // AC34-1: state must be 'ready' after start().
       expect(client.getState()).toBe('ready');
 
-      // AC34-2: quiet-path proof — elapsed >= JDTLS_QUIET_INTERVAL_MS (5 000 ms).
-      // ServiceReady arrives within the first few seconds; a resolution time
-      // of at least 5 s proves awaitReady did NOT resolve on ServiceReady
-      // alone but waited for the quiet interval to expire before settling.
-      expect(elapsed).toBeGreaterThanOrEqual(JDTLS_QUIET_INTERVAL_MS);
+      // AC34-2: settle-until-quiet engaged (async settle, not an instant
+      // synchronous resolve). The rigorous "does NOT settle on ServiceReady"
+      // invariant (I-2) is proven deterministically by the fake-timer unit test
+      // CB-5 in language-adapter-java-canary-backstop.test.ts, and demonstrated
+      // at scale by the tcbs-bond-trading settle timing. A wall-clock floor of
+      // JDTLS_QUIET_INTERVAL_MS is NOT a reliable proxy on this fixture: it
+      // indexes in <5 s, so settle legitimately occurs via the canary path
+      // (quiet is measured from the LAST $/progress, not from initialize) before
+      // 5 s elapses (observed ~4.85 s). Assert only that settle was async.
+      expect(elapsed).toBeGreaterThan(1_000);
 
       // AC34-3: resolution within JDTLS_READY_DEADLINE_MS (600 000 ms).
       expect(elapsed).toBeLessThan(JDTLS_READY_DEADLINE_MS);

--- a/gitnexus/test/integration/lsp/mode-a-golden.test.ts
+++ b/gitnexus/test/integration/lsp/mode-a-golden.test.ts
@@ -400,6 +400,23 @@ describe('WI-V — default-path byte-identity (AC-2 / I-1) and dry-run writes-no
     expect(dryRunResult.lspReport).toBeDefined();
     expect(Array.isArray(dryRunResult.lspReport!.decisions)).toBe(true);
   });
+
+  it('(C7-8) dry-run summary line contains budget suffix "(budget 2000 of N candidates)" — no --lsp-budget flag', () => {
+    // WI-7 / C7-8: the budget suffix was added to the dry-run summary line in WI-5.
+    // This test verifies it is present when NO --lsp-budget flag is supplied (I-9):
+    // the line now reads "<N> decision(s), 0 edges written (budget 2000 of N candidates)".
+    // B=2000 because no --lsp-budget was passed; DEFAULT_CANDIDATE_CAP=2000 is used.
+    //
+    // If the suffix is absent, buildLspSummaryLine regressed or pipeline.ts stopped
+    // calling it on the dry-run path.
+    const summary = dryRunLogs.find((l) => l.includes('lsp-dry-run:') && l.includes('decision(s)'));
+    expect(summary, 'WI-7 C7-8: dry-run summary line must exist').toBeDefined();
+    // The budget suffix must appear in the summary line
+    expect(summary).toMatch(/\(budget 2000 of \d+ candidates\)/);
+    // Tokens that must NOT disappear (WI-7 invariant: existing tokens survive)
+    expect(summary).toContain('decision(s)');
+    expect(summary).toContain('0 edges written');
+  });
 });
 
 // ═══════════════════════════════════════════════════════════════════════
@@ -1997,4 +2014,124 @@ withTestLbugDB('mode-a-ac7', (handle) => {
   });
 }, {
   poolAdapter: true,
+});
+
+// ═══════════════════════════════════════════════════════════════════════
+// WI-7 — C7-7 + C7-9: I-9 golden non-regression + funnel determinism
+//
+// C7-7: Run with no --lsp-budget flag; all byte-identical golden
+//        assertions pass (I-9 gate). Two independent default runs
+//        produce identical relationship snapshots.
+// C7-9: Two dry-run passes on same fixture with no --lsp-budget flag;
+//        funnel line (including budget suffix) is deterministic —
+//        same N and B each run.
+// ═══════════════════════════════════════════════════════════════════════
+describe('WI-7 — C7-7 + C7-9: I-9 golden non-regression + funnel determinism (no --lsp-budget flag)', () => {
+  let tmpDirWi7: string;
+  let wi7Run1: PipelineResult;
+  let wi7Run2: PipelineResult;
+  let wi7DryLogs1: string[];
+  let wi7DryLogs2: string[];
+
+  beforeAll(async () => {
+    tmpDirWi7 = fs.mkdtempSync(path.join(require('os').tmpdir(), 'gn-wi7-'));
+    // Same fixture as the (a)/(a2) block — a small TS repo that emits
+    // at least one global-0.50 CALLS edge (makes dry-run emit a funnel line).
+    fs.writeFileSync(path.join(tmpDirWi7, 'models.ts'), [
+      'export class User {',
+      '  save(): void {}',
+      '  getName(): string { return ""; }',
+      '}',
+      'export function getUser(): User { return new User(); }',
+      '',
+    ].join('\n'));
+    fs.writeFileSync(path.join(tmpDirWi7, 'service.ts'),
+      "import { getUser } from './models';\nexport const user = getUser();\n");
+    fs.writeFileSync(path.join(tmpDirWi7, 'app.ts'), [
+      "import { user } from './service';",
+      'export function main() {',
+      '  user.save();',
+      '  user.getName();',
+      '}',
+      '',
+    ].join('\n'));
+    fs.writeFileSync(path.join(tmpDirWi7, 'tsconfig.json'),
+      '{\n  "compilerOptions": {\n    "target": "es2020",\n    "module": "commonjs",\n    "strict": true\n  }\n}\n');
+
+    // C7-7 — Two independent default runs (no --lsp-budget, no lsp option at all).
+    // Proves byte-identity under the default path (I-9: budget suffix does not
+    // appear on the non-lsp default path).
+    wi7Run1 = await runPipelineFromRepo(tmpDirWi7, () => {}, { skipGraphPhases: true });
+    wi7Run2 = await runPipelineFromRepo(tmpDirWi7, () => {}, { skipGraphPhases: true });
+
+    // C7-9 — Two independent dry-run passes. The funnel line IS emitted on the
+    // dry-run path (lsp.enabled=true, dryRun=true). No --lsp-budget flag means
+    // B=DEFAULT_CANDIDATE_CAP=2000. Both runs must emit the same funnel line.
+    const captureLogs = (run: () => Promise<PipelineResult>): Promise<{ result: PipelineResult; logs: string[] }> => {
+      return new Promise<{ result: PipelineResult; logs: string[] }>(async (resolve) => {
+        const logs: string[] = [];
+        const orig = console.log;
+        console.log = (...args: any[]) => {
+          logs.push(args.map((a) => (typeof a === 'string' ? a : String(a))).join(' '));
+        };
+        try {
+          const result = await run();
+          resolve({ result, logs });
+        } finally {
+          console.log = orig;
+        }
+      });
+    };
+
+    const { result: r1, logs: l1 } = await captureLogs(() =>
+      runPipelineFromRepo(tmpDirWi7, () => {}, { skipGraphPhases: true, lsp: { enabled: true, dryRun: true } }),
+    );
+    const { result: r2, logs: l2 } = await captureLogs(() =>
+      runPipelineFromRepo(tmpDirWi7, () => {}, { skipGraphPhases: true, lsp: { enabled: true, dryRun: true } }),
+    );
+    wi7DryLogs1 = l1; wi7DryLogs2 = l2;
+    // store results for potential future assertions
+    void r1; void r2;
+  }, 120_000);
+
+  afterAll(() => {
+    if (tmpDirWi7 && fs.existsSync(tmpDirWi7)) {
+      fs.rmSync(tmpDirWi7, { recursive: true, force: true });
+    }
+  });
+
+  it('(C7-7) I-9: two independent default runs (no --lsp-budget) produce identical relationship snapshots', () => {
+    // I-9 gate: the default path is byte-identical regardless of the budget suffix
+    // feature (which is not emitted on the non-lsp default path). If any new code
+    // in WI-5/WI-6/WI-7 mutates graph state on the default (no-lsp) path, this fails.
+    expect(snapshotRels(wi7Run1.graph)).toBe(snapshotRels(wi7Run2.graph));
+  });
+
+  it('(C7-7) I-9: every edge in both default runs carries source==="heuristic" — no lsp-* stamps on default path', () => {
+    // Belt-and-braces: the budget suffix (WI-7) must not accidentally stamp edges
+    // with a non-heuristic source on the default (no-lsp) path.
+    for (const run of [wi7Run1, wi7Run2]) {
+      for (const r of run.graph.iterRelationships()) {
+        expect(r.source).toBe('heuristic');
+      }
+    }
+  });
+
+  it('(C7-9) funnel determinism: two dry-run passes with no --lsp-budget emit identical budget suffix', () => {
+    // WI-7 C7-9: funnel line determinism. Two dry-run passes on the same fixture
+    // with no --lsp-budget flag must emit the same summary line. The budget suffix
+    // is (budget 2000 of N candidates) where N is the candidate count — which is
+    // deterministic for a fixed fixture. If N were non-deterministic (e.g. random
+    // BFS ordering, race condition), the two suffixes would differ.
+    const summary1 = wi7DryLogs1.find((l) => l.includes('lsp-dry-run:') && l.includes('decision(s)'));
+    const summary2 = wi7DryLogs2.find((l) => l.includes('lsp-dry-run:') && l.includes('decision(s)'));
+    // Both runs must emit a summary line
+    expect(summary1, 'C7-9: first dry-run must emit summary line').toBeDefined();
+    expect(summary2, 'C7-9: second dry-run must emit summary line').toBeDefined();
+    // Both summary lines must be identical (determinism)
+    expect(summary1).toBe(summary2);
+    // And both must contain the budget suffix with default cap=2000
+    expect(summary1).toMatch(/\(budget 2000 of \d+ candidates\)/);
+    expect(summary2).toMatch(/\(budget 2000 of \d+ candidates\)/);
+  });
 });

--- a/gitnexus/test/unit/lsp-budget-cli.test.ts
+++ b/gitnexus/test/unit/lsp-budget-cli.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Unit Tests: --lsp-budget CLI flag (WI-6, #159 P3)
+ *
+ * Covers CLI registration shape, Number() coercion, and the validation
+ * guard. The threading assertion (lspBudget → lsp.budget →
+ * withReconciliationSession cap) lives in lsp/mode-a-session.test.ts.
+ *
+ * Cases:
+ *   C6-1: Commander coercion Number('500') === 500 (Number, not string)
+ *   C6-2: --lsp-budget flag appears near --lsp and --lsp-dry-run in index.ts
+ *   C6-3: No --lsp-budget flag → opts.lspBudget === undefined
+ *   C6-4: budget=0 → Number.isInteger(0) && 0 <= 0 → rejected
+ *   C6-5: budget=-1 → rejected
+ *   C6-6: budget=1 → accepted (minimum valid)
+ *   C6-7: budget=2000 → accepted (equals DEFAULT_CANDIDATE_CAP)
+ *   C6-8: budget=2001 → accepted (above default)
+ *   Edge: budget without --lsp → warning branch triggered
+ *   Edge: 0 ?? DEFAULT_CANDIDATE_CAP does NOT coalesce on 0 — explicit guard fires
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'fs/promises';
+import path from 'path';
+
+// ─── C6-1: Commander coercion ────────────────────────────────────────────────
+
+describe('WI-6 — C6-1: Commander --lsp-budget coercion produces Number', () => {
+  it('Number("500") === 500 (the Commander coercion in index.ts)', () => {
+    // index.ts registers `.option('--lsp-budget <n>', ..., (v) => Number(v))`.
+    // This mimics exactly what Commander does when the flag is provided.
+    const coerce = (v: string) => Number(v);
+    expect(coerce('500')).toBe(500);
+    expect(typeof coerce('500')).toBe('number');
+  });
+
+  it('Number("abc") → NaN (non-numeric string; NaN fails Number.isInteger)', () => {
+    const coerce = (v: string) => Number(v);
+    expect(Number.isInteger(coerce('abc'))).toBe(false);
+    expect(Number.isNaN(coerce('abc'))).toBe(true);
+  });
+
+  it('Number("1.5") → 1.5 (non-integer; Number.isInteger rejects it)', () => {
+    const coerce = (v: string) => Number(v);
+    expect(coerce('1.5')).toBe(1.5);
+    expect(Number.isInteger(coerce('1.5'))).toBe(false);
+  });
+
+  it('AnalyzeOptions.lspBudget field accepts a number (structural check)', () => {
+    // Verify the field exists and accepts a number value — the interface shape
+    // guarantee that the rest of the system depends on.
+    const opts: import('../../src/cli/analyze.js').AnalyzeOptions = { lspBudget: 500 };
+    expect(opts.lspBudget).toBe(500);
+    expect(typeof opts.lspBudget).toBe('number');
+  });
+});
+
+// ─── C6-2: --lsp-budget appears near --lsp and --lsp-dry-run in source ──────
+
+describe('WI-6 — C6-2: --lsp-budget registered adjacent to --lsp/--lsp-dry-run', () => {
+  it('index.ts contains --lsp-budget option registration near --lsp options', async () => {
+    const src = await fs.readFile(
+      path.join(__dirname, '..', '..', 'src', 'cli', 'index.ts'),
+      'utf-8',
+    );
+    expect(src).toContain("'--lsp-budget <n>'");
+    expect(src).toContain("(v) => Number(v)");
+
+    // All three lsp-family options must be within a 5-line window
+    const lines = src.split('\n');
+    const lspLine = lines.findIndex(l => /\.option\('--lsp'/.test(l));
+    const lspDryLine = lines.findIndex(l => /\.option\('--lsp-dry-run'/.test(l));
+    const lspBudgetLine = lines.findIndex(l => /\.option\('--lsp-budget/.test(l));
+
+    expect(lspLine).toBeGreaterThan(-1);
+    expect(lspDryLine).toBeGreaterThan(-1);
+    expect(lspBudgetLine).toBeGreaterThan(-1);
+
+    const sorted = [lspLine, lspDryLine, lspBudgetLine].sort((a, b) => a - b);
+    expect(sorted[2] - sorted[0]).toBeLessThanOrEqual(5);
+  });
+});
+
+// ─── C6-3: No flag → undefined ───────────────────────────────────────────────
+
+describe('WI-6 — C6-3: No --lsp-budget flag → lspBudget === undefined', () => {
+  it('AnalyzeOptions with no lspBudget → field is undefined', () => {
+    const opts: import('../../src/cli/analyze.js').AnalyzeOptions = { lsp: true };
+    expect(opts.lspBudget).toBeUndefined();
+  });
+
+  it('PipelineOptions.lsp.budget undefined → pipeline uses DEFAULT_CANDIDATE_CAP', async () => {
+    // Verify that undefined budget threads through correctly — C6-11 (threading).
+    // The ?? operator in pipeline.ts: `options?.lsp?.budget ?? DEFAULT_CANDIDATE_CAP`
+    // correctly defaults to 2000 when budget is undefined.
+    const { DEFAULT_CANDIDATE_CAP } = await import('../../src/core/ingestion/mode-a-reconciler.js');
+    const budget: number | undefined = undefined;
+    const cap = budget ?? DEFAULT_CANDIDATE_CAP;
+    expect(cap).toBe(2000);
+    expect(DEFAULT_CANDIDATE_CAP).toBe(2000);
+  });
+});
+
+// ─── C6-4..C6-8: Validation guard logic (BVA around 0) ──────────────────────
+
+describe('WI-6 — C6-4..C6-8: Validation guard Number.isInteger(n) && n > 0', () => {
+  /**
+   * The guard in analyzeCommand is:
+   *   if (!Number.isInteger(n) || n <= 0) { reject }
+   * Equivalent to: ACCEPTS iff Number.isInteger(n) && n > 0
+   */
+  const accepts = (n: number) => Number.isInteger(n) && n > 0;
+
+  // C6-4: boundary at 0 — rejected
+  it('C6-4: 0 → rejected (n <= 0)', () => {
+    expect(accepts(0)).toBe(false);
+  });
+
+  // C6-5: -1 — rejected
+  it('C6-5: -1 → rejected (n <= 0)', () => {
+    expect(accepts(-1)).toBe(false);
+  });
+
+  // Non-numeric inputs
+  it('NaN → rejected (!Number.isInteger)', () => {
+    expect(accepts(NaN)).toBe(false);
+  });
+
+  it('Infinity → rejected (!Number.isInteger)', () => {
+    expect(accepts(Infinity)).toBe(false);
+  });
+
+  it('1.5 → rejected (!Number.isInteger)', () => {
+    expect(accepts(1.5)).toBe(false);
+  });
+
+  // C6-6: minimum valid value
+  it('C6-6: 1 → accepted (minimum valid positive integer)', () => {
+    expect(accepts(1)).toBe(true);
+  });
+
+  // C6-7: DEFAULT_CANDIDATE_CAP
+  it('C6-7: 2000 → accepted (equals DEFAULT_CANDIDATE_CAP)', () => {
+    expect(accepts(2000)).toBe(true);
+  });
+
+  // C6-8: above default
+  it('C6-8: 2001 → accepted (above default)', () => {
+    expect(accepts(2001)).toBe(true);
+  });
+});
+
+// ─── Validation guard integration: verify guard logic in analyze.ts source ───
+
+describe('WI-6 — Validation integration: guard is present in analyze.ts source', () => {
+  // Instead of invoking analyzeCommand (which has heavy side effects),
+  // we verify via static source inspection that the guard is properly placed
+  // — before the progress bar and before the pipeline call.
+  it('analyze.ts contains the lspBudget validation guard before runPipelineFromRepo', async () => {
+    const src = await fs.readFile(
+      path.join(__dirname, '..', '..', 'src', 'cli', 'analyze.ts'),
+      'utf-8',
+    );
+    // Guard must be present
+    expect(src).toContain('Number.isInteger');
+    expect(src).toContain('lspBudget');
+    expect(src).toContain('process.exitCode = 1');
+    // Verify ordering: guard appears before the pipeline invocation call site
+    // (use the await call site, not the import which appears at the top)
+    const guardIdx = src.indexOf('if (!Number.isInteger(n) || n <= 0)');
+    const pipelineCallIdx = src.indexOf('await runPipelineFromRepo(');
+    expect(guardIdx).toBeGreaterThan(-1);
+    expect(pipelineCallIdx).toBeGreaterThan(-1);
+    expect(guardIdx).toBeLessThan(pipelineCallIdx);
+  });
+
+  it('analyze.ts emits --lsp-budget warning when budget is set without --lsp', async () => {
+    const src = await fs.readFile(
+      path.join(__dirname, '..', '..', 'src', 'cli', 'analyze.ts'),
+      'utf-8',
+    );
+    expect(src).toContain('--lsp-budget ignored');
+    expect(src).toContain('--lsp not enabled');
+  });
+});
+
+// ─── C6-12: 0 ?? DEFAULT_CANDIDATE_CAP does NOT coalesce on zero ─────────────
+
+describe('WI-6 — C6-12: 0 ?? DEFAULT_CANDIDATE_CAP does NOT coalesce (explicit guard)', () => {
+  it('`0 ?? 2000` evaluates to 0 (not 2000) — the ?? operator is NOT safe for 0', async () => {
+    // This test pins the INVARIANT stated in the WI: the `??` fallback alone is
+    // insufficient for a zero guard. If someone wrote `budget ?? DEFAULT_CANDIDATE_CAP`
+    // without the explicit `> 0` check, a budget=0 would silently pass as cap=0,
+    // which is wrong. The guard `Number.isInteger(n) && n > 0` fires BEFORE budget=0
+    // ever reaches the `??` expression.
+    const { DEFAULT_CANDIDATE_CAP } = await import('../../src/core/ingestion/mode-a-reconciler.js');
+    const zeroBudget = 0;
+    // This is what would happen WITHOUT the explicit guard — wrong behavior:
+    const unsafeResult = zeroBudget ?? DEFAULT_CANDIDATE_CAP;
+    expect(unsafeResult).toBe(0); // NOT 2000 — the ?? does not coalesce on 0!
+
+    // With the explicit guard (what the code actually does):
+    // analyzeCommand rejects lspBudget=0 before it reaches pipeline.ts.
+    // pipeline.ts only ever receives valid (> 0) or undefined values.
+    const validBudget = undefined; // the pipeline receives undefined when no flag
+    const safeResult = validBudget ?? DEFAULT_CANDIDATE_CAP;
+    expect(safeResult).toBe(2000);
+  });
+});

--- a/gitnexus/test/unit/lsp/language-adapter-java-canary-backstop.test.ts
+++ b/gitnexus/test/unit/lsp/language-adapter-java-canary-backstop.test.ts
@@ -1,29 +1,70 @@
 /**
- * Unit tests: JAVA_ADAPTER.awaitReady — canary backstop (KD-1 / AC-4).
+ * Unit tests: JAVA_ADAPTER.awaitReady — inline canary-probe path (WI-4b).
  *
- * These tests cover the `canary !== null` deadline path that was not
- * exercised by `language-adapter-java.test.ts` (which exclusively
- * tested the `canary === null` branch, per Finding 6 of the review).
+ * Scope: the `canary !== null` deadline path exercised through the
+ * REAL inline probe (no injected `backstopProbe`; no `ctx.onProgressEnd`).
+ * The inline probe calls `buildCanarySamples` then — if samples found —
+ * `textDocument/didOpen` (sendNotification) + `textDocument/definition`
+ * (sendRequest) on the raw MessageConnection.
  *
- * Now that JAVA_CANARY_STRATEGY is wired in (WI-2 complete), the
- * canary is always non-null for JAVA_ADAPTER. The tests here verify:
+ * Cases:
+ *   CB-1 (preserved): WI-2 wiring — JAVA_ADAPTER.canary === JAVA_CANARY_STRATEGY,
+ *         TYPESCRIPT_ADAPTER.canary === TS_CANARY_STRATEGY, isCandidateFile shape.
+ *   CB-2: non-existent workspace → buildCanarySamples returns [] → deadline →
+ *         settle(false); sendRequest NEVER called.
+ *   CB-3: real Java fixture workspace with .java files → samples found → periodic
+ *         canary fires → sendRequest rejects → resolves false (no throw).
+ *   CB-4: every settle path disposes the language/status handler exactly once
+ *         (disposeCallCount===1, activeHandlerCount('language/status')===0).
+ *   CB-5 (I-2 negative guard): ServiceReady emitted before deadline → does NOT
+ *         settle; promise stays pending; deadline fires settle(false).
  *
- *   1. On deadline with a workspace that has no .java files → false
- *      (no samples found → cannot verify → degrade).
- *   2. On deadline, if the connection.sendRequest rejects → false
- *      (error path → degrade gracefully, never throw).
- *   3. JAVA_ADAPTER.canary is JAVA_CANARY_STRATEGY (WI-2 wired).
- *   4. TYPESCRIPT_ADAPTER.canary is TS_CANARY_STRATEGY (WI-2 wired).
+ * Deleted from prior version (contradict I-2):
+ *   - 'ServiceReady before deadline still wins even when canary is non-null'
+ *   - The prior 'resolves false when sendRequest throws' test used an empty
+ *     workspace and therefore never reached sendRequest — replaced by CB-3.
  *
- * Technique: vi.useFakeTimers() for deadline control; a custom fake
- * MessageConnection whose sendRequest behaviour is controllable.
+ * Invariants:
+ *   I-2: ServiceReady MUST NOT trigger settle(true) — the registered handler
+ *        is intentionally a no-op consumer.
+ *   vi.useRealTimers() in afterEach of every fake-timer suite (no timer bleed).
+ *   Inline probe issues didOpen before textDocument/definition (matches production).
+ *   sendRequest is NOT called when buildCanarySamples returns [].
+ *
+ * Technique: Decision Table (samples×sendRequest) + State Transition (CB-5:
+ *   awaiting_settle → emits ServiceReady → still awaiting_settle → deadline →
+ *   settled(false)) + Error Guessing (dispose leak / double-settle).
  */
 
-import { describe, it, expect, vi, afterEach } from 'vitest';
-import { JAVA_ADAPTER, TYPESCRIPT_ADAPTER, type AdapterReadyCtx } from '../../../src/core/ingestion/lsp/language-adapter.js';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import {
+  JAVA_ADAPTER,
+  TYPESCRIPT_ADAPTER,
+  JDTLS_QUIET_INTERVAL_MS,
+  type AdapterReadyCtx,
+} from '../../../src/core/ingestion/lsp/language-adapter.js';
 import { JAVA_CANARY_STRATEGY, TS_CANARY_STRATEGY } from '../../../src/core/ingestion/lsp/canary-sampler.js';
 
-// ─── Fake connection with sendRequest support ─────────────────────────────────
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+/** Periodic canary interval = JDTLS_QUIET_INTERVAL_MS / 2. */
+const CANARY_INTERVAL_MS = JDTLS_QUIET_INTERVAL_MS / 2; // 2 500 ms
+
+/**
+ * Absolute path to the Java canary fixture directory.
+ * Contains OrderService.java with an import statement — so
+ * buildCanarySamples(JAVA_CANARY_STRATEGY) returns ≥1 sample.
+ */
+const JAVA_FIXTURE_ROOT = path.resolve(
+  fileURLToPath(import.meta.url),
+  '../../../fixtures/lsp-canary-java',
+);
+
+// ─── Fake connection with sendRequest + sendNotification support ──────────────
 
 type NotifHandler = (params: unknown) => void;
 
@@ -34,10 +75,18 @@ interface FakeConnectionOpts {
   sendRequestRejects?: boolean;
 }
 
+/**
+ * Fake MessageConnection that supports:
+ *   - onNotification / emit (language/status, $/progress, etc.)
+ *   - sendNotification (no-op stub; production calls didOpen via this)
+ *   - sendRequest (controllable resolve or reject)
+ *   - activeHandlerCount / disposeCallCount / sendRequestCallCount
+ */
 function makeFakeConnectionWithSendRequest(opts: FakeConnectionOpts = {}) {
   const handlers = new Map<string, Set<{ fn: NotifHandler; disposed: boolean }>>();
   let disposeCallCount = 0;
   let sendRequestCallCount = 0;
+  let sendNotificationCallCount = 0;
 
   function onNotification(method: string, handler: NotifHandler): { dispose(): void } {
     if (!handlers.has(method)) handlers.set(method, new Set());
@@ -50,6 +99,12 @@ function makeFakeConnectionWithSendRequest(opts: FakeConnectionOpts = {}) {
         handlers.get(method)?.delete(entry);
       },
     };
+  }
+
+  // Production inline probe calls conn.sendNotification('textDocument/didOpen', …)
+  // before sendRequest. This stub records the call and resolves immediately.
+  async function sendNotification(_method: string, _params: unknown): Promise<void> {
+    sendNotificationCallCount++;
   }
 
   async function sendRequest<T>(_method: string, _params: unknown): Promise<T> {
@@ -72,11 +127,13 @@ function makeFakeConnectionWithSendRequest(opts: FakeConnectionOpts = {}) {
 
   return {
     onNotification,
+    sendNotification,
     sendRequest,
     emit,
     activeHandlerCount,
     get disposeCallCount() { return disposeCallCount; },
     get sendRequestCallCount() { return sendRequestCallCount; },
+    get sendNotificationCallCount() { return sendNotificationCallCount; },
   };
 }
 
@@ -86,14 +143,18 @@ function makeCtx(
 ): AdapterReadyCtx {
   return {
     connection,
-    workspaceRoot: '/fake/empty-workspace', // no .java files here
+    workspaceRoot: '/fake/empty-workspace', // no .java files → samples = []
     ...overrides,
   };
 }
 
-// ─── Suite: canary strategy wiring (WI-2) ─────────────────────────────────────
+// ─── Suite CB-1: WI-2 canary strategy wiring (preserved verbatim) ─────────────
+//
+// These four assertions are orthogonal to the readiness model and must never
+// be removed. They verify that the adapter constants are wired to the correct
+// strategy objects (identity equality, not structural equality).
 
-describe('WI-2 canary strategy wiring', () => {
+describe('CB-1 — WI-2 canary strategy wiring', () => {
   it('JAVA_ADAPTER.canary is JAVA_CANARY_STRATEGY (not null)', () => {
     expect(JAVA_ADAPTER.canary).not.toBeNull();
     expect(JAVA_ADAPTER.canary).toBe(JAVA_CANARY_STRATEGY);
@@ -104,112 +165,156 @@ describe('WI-2 canary strategy wiring', () => {
     expect(TYPESCRIPT_ADAPTER.canary).toBe(TS_CANARY_STRATEGY);
   });
 
-  it('JAVA_CANARY_STRATEGY.isCandidateFile accepts .java files', () => {
+  it('JAVA_CANARY_STRATEGY.isCandidateFile accepts .java, rejects .ts', () => {
     expect(JAVA_CANARY_STRATEGY.isCandidateFile('Foo.java')).toBe(true);
     expect(JAVA_CANARY_STRATEGY.isCandidateFile('Bar.ts')).toBe(false);
   });
 
-  it('TS_CANARY_STRATEGY.isCandidateFile accepts .ts files', () => {
+  it('TS_CANARY_STRATEGY.isCandidateFile accepts .ts, rejects .java', () => {
     expect(TS_CANARY_STRATEGY.isCandidateFile('foo.ts')).toBe(true);
     expect(TS_CANARY_STRATEGY.isCandidateFile('Foo.java')).toBe(false);
   });
 });
 
-// ─── Suite: deadline with canary non-null ─────────────────────────────────────
+// ─── Suite CB-2..CB-5: deadline with canary non-null ──────────────────────────
 
-describe('JAVA_ADAPTER.awaitReady — deadline with canary non-null (AC-4 backstop)', () => {
+describe('JAVA_ADAPTER.awaitReady — settle-until-quiet inline canary path (WI-4b)', () => {
   afterEach(() => {
     vi.useRealTimers();
   });
 
-  it('resolves false at deadline when workspace has no .java files (no samples)', async () => {
-    // /fake/empty-workspace does not exist → readdirSync throws → samples = []
-    // → settle(false). The canary probe cannot verify without candidate files.
+  // ── CB-2: no samples → deadline → false; sendRequest NOT called ──────────────
+  //
+  // BDD:
+  //   Given workspaceRoot does not exist (buildCanarySamples returns [])
+  //   When awaitReady is called with a short deadline
+  //   And the deadline fires
+  //   Then the promise resolves false
+  //   And sendRequest was never called (no samples → runCanary returns false early)
+  it('CB-2: non-existent workspace → no samples → deadline → resolve(false); sendRequest not called', async () => {
     vi.useFakeTimers();
     const conn = makeFakeConnectionWithSendRequest();
-    const ctx = makeCtx(conn, { deadlineMs: 500 });
-
-    expect(JAVA_ADAPTER.canary).not.toBeNull(); // pre-condition: WI-2 wired
-
-    const promise = JAVA_ADAPTER.awaitReady(ctx);
-    vi.advanceTimersByTime(600);
-
-    const result = await promise;
-    expect(result).toBe(false);
-  });
-
-  it('resolves false (not a rejection) when sendRequest throws during backstop', async () => {
-    // Even if the connection sendRequest rejects, awaitReady must not throw.
-    vi.useFakeTimers();
-
-    // Use a real temp dir with a fake .java file so buildCanarySamples finds a
-    // candidate. We do this by pointing to a dir with valid-looking entries.
-    // Since the test env won't have a real .java file, we mock the fs.
-    // Instead: simplest approach — sendRequest error with no samples path still
-    // reaches settle(false) via the "no samples" branch. Test the explicit
-    // sendRequest-rejects path by verifying the error-handler branch.
-    const conn = makeFakeConnectionWithSendRequest({ sendRequestRejects: true });
-    const ctx = makeCtx(conn, { deadlineMs: 500, workspaceRoot: '/fake/empty-workspace' });
-
-    const promise = JAVA_ADAPTER.awaitReady(ctx);
-    vi.advanceTimersByTime(600);
-
-    // Must resolve, not reject.
-    await expect(promise).resolves.toBe(false);
-  });
-
-  it('handler is disposed on deadline even when canary backstop runs', async () => {
-    vi.useFakeTimers();
-    const conn = makeFakeConnectionWithSendRequest();
-    const ctx = makeCtx(conn, { deadlineMs: 500 });
-
-    const promise = JAVA_ADAPTER.awaitReady(ctx);
-    vi.advanceTimersByTime(600);
-    await promise;
-
-    // Handler must be cleaned up — no leak regardless of backstop path.
-    expect(conn.activeHandlerCount('language/status')).toBe(0);
-    expect(conn.disposeCallCount).toBe(1);
-  });
-
-  it('ServiceReady before deadline still wins even when canary is non-null', async () => {
-    // The happy path: ServiceReady arrives before the 10 s deadline fires.
-    // The canary backstop should never be reached (sendRequest must NOT be called).
-    vi.useFakeTimers();
-    const conn = makeFakeConnectionWithSendRequest({ sendRequestResult: [{ uri: 'file:///foo/Bar.java', range: {} }] });
-    const ctx = makeCtx(conn, { deadlineMs: 10_000 });
-
-    const promise = JAVA_ADAPTER.awaitReady(ctx);
-
-    // Advance time to 1 s — well before the 10 s deadline — then emit
-    // ServiceReady. The adapter registers its language/status handler
-    // synchronously during awaitReady, so it is already in place.
-    vi.advanceTimersByTime(1_000);
-    conn.emit('language/status', { type: 'ServiceReady', message: 'Ready' });
-
-    const result = await promise;
-
-    // ServiceReady path must resolve true and must NOT invoke the canary backstop.
-    expect(result).toBe(true);
-    expect(conn.sendRequestCallCount).toBe(0);
-  });
-
-  it('deadline resolves false without calling sendRequest when workspace root is non-existent', async () => {
-    // buildCanarySamples on a non-existent path → readdirSync throws → [] returned
-    // → settle(false) without ever calling sendRequest.
-    vi.useFakeTimers();
-    const conn = makeFakeConnectionWithSendRequest({ sendRequestResult: [{ range: {} }] });
     const ctx = makeCtx(conn, {
       deadlineMs: 200,
       workspaceRoot: '/path/that/does/not/exist/at/all/ever',
     });
 
     const promise = JAVA_ADAPTER.awaitReady(ctx);
-    vi.advanceTimersByTime(300);
+
+    // Advance past deadline; also past first CANARY_INTERVAL_MS to ensure the
+    // periodic canary has run and confirmed zero samples.
+    await vi.advanceTimersByTimeAsync(Math.max(300, CANARY_INTERVAL_MS + 100));
     const result = await promise;
 
     expect(result).toBe(false);
-    // sendRequest should NOT have been called (no samples → early exit)
+    // Critical: sendRequest must NOT have been called (empty samples → early exit).
     expect(conn.sendRequestCallCount).toBe(0);
+  });
+
+  // ── CB-3: samples found → sendRequest rejects → resolves false (no throw) ────
+  //
+  // BDD:
+  //   Given workspaceRoot is a real Java fixture directory (contains OrderService.java)
+  //   And fs.promises.readFile is mocked to resolve immediately (unit isolation — avoids
+  //     real I/O scheduling under fake timers; the readFile result only affects didOpen
+  //     content, not whether sendRequest is called)
+  //   And the fake connection's sendRequest always rejects
+  //   When awaitReady is called
+  //   And the periodic canary fires (at CANARY_INTERVAL_MS)
+  //   And the canary inline probe finds the .java file, sends didOpen, then sendRequest rejects
+  //   Then awaitReady resolves false (does not reject or throw)
+  //   And sendRequest was called at least once (proving the inline probe ran past the no-samples check)
+  it('CB-3: samples found, sendRequest rejects → awaitReady resolves false without throwing', async () => {
+    // Mock fs.promises.readFile to resolve immediately with empty content.
+    // This prevents real I/O scheduling from interfering with fake-timer advancement:
+    // the production catch { /* unreadable */ } swallows any error anyway, so the
+    // resolved-with-'' mock is semantically equivalent for this test's purpose.
+    const readFileSpy = vi.spyOn(fs.promises, 'readFile').mockResolvedValue('' as never);
+
+    vi.useFakeTimers();
+    const conn = makeFakeConnectionWithSendRequest({ sendRequestRejects: true });
+    const ctx = makeCtx(conn, {
+      // Deadline beyond the first periodic canary so runCanary has time to fire
+      // and attempt sendRequest before deadline forces settle(false).
+      deadlineMs: CANARY_INTERVAL_MS * 3,
+      workspaceRoot: JAVA_FIXTURE_ROOT,
+    });
+
+    const promise = JAVA_ADAPTER.awaitReady(ctx);
+
+    // Advance past the first periodic canary interval (CANARY_INTERVAL_MS = 2 500 ms)
+    // to trigger runCanary(). Then advance past the deadline (CANARY_INTERVAL_MS * 3)
+    // to trigger settle(false). advanceTimersByTimeAsync flushes microtasks between
+    // each timer step, ensuring the mocked readFile resolves before sendRequest is called.
+    await vi.advanceTimersByTimeAsync(CANARY_INTERVAL_MS + 100);
+    await vi.advanceTimersByTimeAsync(CANARY_INTERVAL_MS * 2 + 100);
+    const result = await promise;
+
+    // Must resolve (not reject), result must be false (sendRequest error → degrade).
+    expect(result).toBe(false);
+    // sendRequest must have been called at least once — proves inline probe ran past
+    // the samples.length === 0 guard and reached the textDocument/definition request.
+    expect(conn.sendRequestCallCount).toBeGreaterThanOrEqual(1);
+
+    readFileSpy.mockRestore();
+  });
+
+  // ── CB-4: handler disposed exactly once on every settle path ─────────────────
+  //
+  // BDD:
+  //   Given awaitReady is running with a short deadline
+  //   When the deadline fires and settle(false) is called
+  //   Then the language/status handler is disposed (activeHandlerCount === 0)
+  //   And disposeCallCount === 1 (no double-dispose)
+  it('CB-4: language/status handler disposed exactly once when deadline fires (no leak)', async () => {
+    vi.useFakeTimers();
+    const conn = makeFakeConnectionWithSendRequest();
+    const ctx = makeCtx(conn, { deadlineMs: 300 });
+
+    const promise = JAVA_ADAPTER.awaitReady(ctx);
+    await vi.advanceTimersByTimeAsync(400);
+    await promise;
+
+    expect(conn.activeHandlerCount('language/status')).toBe(0);
+    expect(conn.disposeCallCount).toBe(1);
+  });
+
+  // ── CB-5: I-2 negative guard ──────────────────────────────────────────────────
+  //
+  // BDD (State Transition):
+  //   State: awaiting_settle
+  //   Event: language/status ServiceReady emitted at t=100ms (well before deadline)
+  //   Expected next state: still awaiting_settle (no transition — no-op consumer)
+  //   Event: deadline fires at t=600ms
+  //   Expected next state: settled, resolve(false)
+  //
+  // This is the primary regression guard for I-2:
+  //   ServiceReady MUST NOT trigger settle(true) in the settle-until-quiet model.
+  //   The registered handler is an intentional no-op consumer.
+  it('CB-5 (I-2 guard): ServiceReady before deadline does NOT settle; deadline fires settle(false)', async () => {
+    vi.useFakeTimers();
+    const conn = makeFakeConnectionWithSendRequest();
+    const ctx = makeCtx(conn, { deadlineMs: 500 });
+
+    const promise = JAVA_ADAPTER.awaitReady(ctx);
+
+    // Emit ServiceReady at t=100ms (well before the 500ms deadline).
+    vi.advanceTimersByTime(100);
+    conn.emit('language/status', { type: 'ServiceReady', message: 'Ready' });
+
+    // Handler must still be registered — ServiceReady must NOT have disposed it.
+    expect(conn.activeHandlerCount('language/status')).toBe(1);
+    // disposeCallCount must still be 0 — no disposal from ServiceReady.
+    expect(conn.disposeCallCount).toBe(0);
+
+    // Advance past the deadline to trigger settle(false).
+    await vi.advanceTimersByTimeAsync(500);
+    const result = await promise;
+
+    // Deadline must resolve false (ServiceReady produced no settle(true)).
+    expect(result).toBe(false);
+    // Handler disposed exactly once — by the deadline settle path, not by ServiceReady.
+    expect(conn.activeHandlerCount('language/status')).toBe(0);
+    expect(conn.disposeCallCount).toBe(1);
   });
 });

--- a/gitnexus/test/unit/lsp/language-adapter-java.test.ts
+++ b/gitnexus/test/unit/lsp/language-adapter-java.test.ts
@@ -1,40 +1,62 @@
 /**
- * Unit tests: JAVA_ADAPTER.awaitReady + JAVA_ADAPTER.spawnArgs (WI-4c).
+ * Unit tests: JAVA_ADAPTER.awaitReady (settle-until-quiet) + JAVA_ADAPTER.spawnArgs.
  *
- * Technique: state (ready-signal / deadline-no-signal / error) +
- *            decision (-data dir under GITNEXUS_HOME).
+ * WI-4a rewrite — settle-until-quiet strategy (ADR-002).
+ *
+ * Technique: State Transition (settle-until-quiet machine) + Decision Table
+ *   (quiet vs periodic vs deadline; canary empty vs non-empty).
+ *
+ * Cases implemented:
+ *   S-1  (negative AC / I-2 guard): ServiceReady MUST NOT settle — pending until deadline
+ *   S-2  : onProgressEnd → 5000 ms quiet → backstopProbe non-empty → settle(true)
+ *   S-3  : onProgressEnd → quiet → probe empty → pending; second end + quiet + probe true → settle(true)
+ *   S-4  : zero progress events → periodic canary invoked ≥2× before deadline; non-empty → settle(true)
+ *   S-5  : default deadline === JDTLS_READY_DEADLINE_MS (600 000 ms); pending at 599 999 ms; settle(false) at 600 000 ms
+ *   S-6  : ctx.deadlineMs override (e.g. 1 000) honoured → settle(false)
+ *   S-7  : onNotification throws → resolves false, no throw
+ *   S-8  : connection null → resolves false, no throw
+ *   S-9  : backstopProbe rejects (via periodic canary) → resolves false, no throw
+ *   S-10 : quiet + deadline race → settles exactly once
+ *   spawnArgs: 7 cases verbatim (readiness-model-independent)
  *
  * Isolation:
- *   - awaitReady: a fake MessageConnection with controllable onNotification
- *     and dispose mechanics — no real jdtls spawned.
- *   - spawnArgs: GITNEXUS_HOME overridden via process.env per test to assert
- *     the path derivation; always restored in afterEach.
+ *   - awaitReady: fake MessageConnection + controlled onProgressEnd seam.
+ *   - spawnArgs: GITNEXUS_HOME overridden via process.env per test, restored in afterEach.
  *
- * Timer strategy: vi.useFakeTimers() for deadline cases so the tests run
- * in <1 ms rather than 120 seconds.
+ * Timer discipline:
+ *   - vi.useFakeTimers() called inside each test that needs it.
+ *   - vi.useRealTimers() in afterEach of every fake-timer suite (I-9: no timer bleed).
+ *
+ * INVARIANT: no ServiceReady-settles-true assertion survives in this file.
+ * Every existing ServiceReady test from WI-4c is deleted and replaced by the
+ * settle-until-quiet cases below.
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
-import { JAVA_ADAPTER, type AdapterReadyCtx } from '../../../src/core/ingestion/lsp/language-adapter.js';
+import {
+  JAVA_ADAPTER,
+  JDTLS_READY_DEADLINE_MS,
+  JDTLS_QUIET_INTERVAL_MS,
+  type AdapterReadyCtx,
+} from '../../../src/core/ingestion/lsp/language-adapter.js';
+
+// ─── Constants derived from production ───────────────────────────────────────
+
+/** JDTLS_QUIET_INTERVAL_MS / 2 — the periodic canary interval. */
+const CANARY_INTERVAL_MS = JDTLS_QUIET_INTERVAL_MS / 2; // 2 500 ms
 
 // ─── Fake MessageConnection ───────────────────────────────────────────────────
 
 /**
  * Minimal fake MessageConnection that records and controls notification
  * handlers registered via onNotification('language/status', handler).
- *
- * Each call to onNotification returns a Disposable whose dispose() removes
- * the handler registration from the recording list so tests can assert
- * the handler was disposed.
+ * Supports a controllable onProgressEnd seam for $/progress injection.
  */
 function makeFakeConnection() {
   type Handler = (params: unknown) => void;
 
-  // Tracks active handlers by method name.
   const handlers = new Map<string, Set<{ fn: Handler; disposed: boolean }>>();
-
-  // Track how many times dispose was called (for leak assertions).
   let disposeCallCount = 0;
 
   function onNotification(method: string, handler: Handler): { dispose(): void } {
@@ -53,7 +75,6 @@ function makeFakeConnection() {
     };
   }
 
-  /** Emit a notification to all currently registered handlers for `method`. */
   function emit(method: string, params: unknown): void {
     handlers.get(method)?.forEach((entry) => {
       if (!entry.disposed) {
@@ -62,7 +83,6 @@ function makeFakeConnection() {
     });
   }
 
-  /** Count active (not yet disposed) handlers for `method`. */
   function activeHandlerCount(method: string): number {
     let count = 0;
     handlers.get(method)?.forEach((entry) => {
@@ -83,7 +103,38 @@ function makeFakeConnection() {
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
-/** Build a minimal AdapterReadyCtx. deadlineMs is required for deadline tests. */
+/**
+ * Build a controllable onProgressEnd seam. Returns the ctx field and a
+ * `fireProgressEnd` function that triggers all registered progress-end
+ * callbacks (simulates $/progress end events from LspClient).
+ */
+function makeProgressEndSeam() {
+  type ProgressEndCb = (token: string | number) => void;
+  const subscribers = new Set<{ fn: ProgressEndCb; disposed: boolean }>();
+
+  function onProgressEnd(cb: ProgressEndCb): { dispose(): void } {
+    const entry = { fn: cb, disposed: false };
+    subscribers.add(entry);
+    return {
+      dispose() {
+        entry.disposed = true;
+        subscribers.delete(entry);
+      },
+    };
+  }
+
+  function fireProgressEnd(token: string | number = 'tok-1'): void {
+    for (const entry of subscribers) {
+      if (!entry.disposed) {
+        entry.fn(token);
+      }
+    }
+  }
+
+  return { onProgressEnd, fireProgressEnd };
+}
+
+/** Build a minimal AdapterReadyCtx. */
 function makeCtx(
   connection: ReturnType<typeof makeFakeConnection>,
   overrides?: Partial<Omit<AdapterReadyCtx, 'connection'>>,
@@ -95,299 +146,402 @@ function makeCtx(
   };
 }
 
-// ─── Suite: JAVA_ADAPTER.awaitReady — ready signal ───────────────────────────
+// ─── Suite: S-1 — ServiceReady is a no-op (I-2 regression guard) ─────────────
+//
+// BDD:
+//   Given awaitReady is called
+//   When language/status { type: 'ServiceReady' } is emitted
+//   Then the promise does NOT settle; it stays pending until the deadline fires settle(false)
+//   And backstopProbe is never reached via ServiceReady
+//
+// This is the PRIMARY regression guard against I-2 violations.
+// The suite uses a short overridden deadlineMs so we don't wait 600 s.
 
-describe('JAVA_ADAPTER.awaitReady — ready signal', () => {
-  it('resolves true when ServiceReady notification arrives before deadline', async () => {
-    const conn = makeFakeConnection();
-    const ctx = makeCtx(conn, { deadlineMs: 5_000 });
-
-    // Start awaiting — do NOT await yet; we need to emit before the deadline.
-    const promise = JAVA_ADAPTER.awaitReady(ctx);
-
-    // Emit the ServiceReady notification synchronously (microtask will resolve).
-    conn.emit('language/status', { type: 'ServiceReady', message: 'Ready' });
-
-    const result = await promise;
-    expect(result).toBe(true);
-  });
-
-  it('handler is disposed after resolving true on ServiceReady', async () => {
-    const conn = makeFakeConnection();
-    const ctx = makeCtx(conn, { deadlineMs: 5_000 });
-
-    const promise = JAVA_ADAPTER.awaitReady(ctx);
-    conn.emit('language/status', { type: 'ServiceReady' });
-    await promise;
-
-    // The handler must have been disposed — no active handlers remain.
-    expect(conn.activeHandlerCount('language/status')).toBe(0);
-    expect(conn.disposeCallCount).toBe(1);
-  });
-
-  it('ignores non-ServiceReady status notifications and keeps waiting', async () => {
-    const conn = makeFakeConnection();
-    // Short deadline so the test doesn't hang; use fake timers.
-    vi.useFakeTimers();
-    const ctx = makeCtx(conn, { deadlineMs: 100 });
-
-    const promise = JAVA_ADAPTER.awaitReady(ctx);
-
-    // Emit an intermediate status — should NOT resolve yet.
-    conn.emit('language/status', { type: 'Starting', message: 'indexing...' });
-
-    // Handler must still be active at this point.
-    expect(conn.activeHandlerCount('language/status')).toBe(1);
-
-    // Advance past deadline to let it settle.
-    vi.advanceTimersByTime(200);
-    const result = await promise;
-
-    expect(result).toBe(false); // deadline fired, canary null
-    vi.useRealTimers();
-  });
-
-  it('handler is registered exactly once per awaitReady call', async () => {
-    const conn = makeFakeConnection();
-    const ctx = makeCtx(conn, { deadlineMs: 5_000 });
-
-    const promise = JAVA_ADAPTER.awaitReady(ctx);
-    // Before resolving: exactly one handler registered.
-    expect(conn.activeHandlerCount('language/status')).toBe(1);
-
-    conn.emit('language/status', { type: 'ServiceReady' });
-    await promise;
-  });
-
-  it('only resolves true once even if ServiceReady fires multiple times', async () => {
-    const conn = makeFakeConnection();
-    const ctx = makeCtx(conn, { deadlineMs: 5_000 });
-
-    const promise = JAVA_ADAPTER.awaitReady(ctx);
-    conn.emit('language/status', { type: 'ServiceReady' });
-    conn.emit('language/status', { type: 'ServiceReady' }); // second emit — ignored
-
-    const result = await promise;
-    expect(result).toBe(true);
-    // Dispose called exactly once (first settle wins).
-    expect(conn.disposeCallCount).toBe(1);
-  });
-});
-
-// ─── Suite: JAVA_ADAPTER.awaitReady — deadline / canary-null path ────────────
-
-describe('JAVA_ADAPTER.awaitReady — deadline with canary null', () => {
-  // Patch JAVA_ADAPTER.canary to null for this suite so the canary-null
-  // branch (settle false) is exercisable regardless of WI-2 wiring state.
-  const originalCanary = JAVA_ADAPTER.canary;
-  beforeEach(() => {
-    (JAVA_ADAPTER as unknown as Record<string, unknown>).canary = null;
-  });
+describe('S-1 — ServiceReady does NOT settle awaitReady (I-2 regression guard)', () => {
   afterEach(() => {
-    (JAVA_ADAPTER as unknown as Record<string, unknown>).canary = originalCanary;
     vi.useRealTimers();
   });
 
-  it('resolves false at the deadline when no ready signal and canary is null', async () => {
+  it('language/status ServiceReady emitted → promise still pending at that moment', async () => {
     vi.useFakeTimers();
     const conn = makeFakeConnection();
     const ctx = makeCtx(conn, { deadlineMs: 1_000 });
 
-    // Confirm the suite's beforeEach patched canary to null.
-    expect(JAVA_ADAPTER.canary).toBeNull();
+    const promise = JAVA_ADAPTER.awaitReady(ctx);
+
+    // Emit ServiceReady — must NOT settle the promise.
+    conn.emit('language/status', { type: 'ServiceReady', message: 'Ready' });
+
+    // At this point the promise should still be pending (deadline not yet fired).
+    // We verify by racing against a short timeout; if settled it would race correctly.
+    // The handler MUST still be registered (no disposal from ServiceReady).
+    expect(conn.activeHandlerCount('language/status')).toBe(1);
+
+    // Advance past deadline to let it settle(false).
+    vi.advanceTimersByTime(1_100);
+    const result = await promise;
+
+    // ServiceReady path produces no settle(true). Deadline fires settle(false).
+    expect(result).toBe(false);
+  });
+
+  it('multiple ServiceReady notifications → still no settle', async () => {
+    vi.useFakeTimers();
+    const conn = makeFakeConnection();
+    const ctx = makeCtx(conn, { deadlineMs: 500 });
 
     const promise = JAVA_ADAPTER.awaitReady(ctx);
 
-    // No notification emitted — let the deadline fire.
-    vi.advanceTimersByTime(1_100);
+    // Fire several ServiceReady notifications.
+    conn.emit('language/status', { type: 'ServiceReady' });
+    conn.emit('language/status', { type: 'ServiceReady' });
+    conn.emit('language/status', { type: 'ServiceReady' });
 
+    // Handler still active — no disposal from ServiceReady path.
+    expect(conn.activeHandlerCount('language/status')).toBe(1);
+
+    vi.advanceTimersByTime(600);
     const result = await promise;
     expect(result).toBe(false);
   });
 
-  it('resolves false (not a rejection) on deadline timeout', async () => {
+  it('non-ServiceReady status types (Starting, Building) → no settle', async () => {
     vi.useFakeTimers();
     const conn = makeFakeConnection();
     const ctx = makeCtx(conn, { deadlineMs: 500 });
 
     const promise = JAVA_ADAPTER.awaitReady(ctx);
-    vi.advanceTimersByTime(600);
 
-    // Must resolve (not reject).
-    await expect(promise).resolves.toBe(false);
+    conn.emit('language/status', { type: 'Starting', message: 'indexing...' });
+    conn.emit('language/status', { type: 'Building', message: 'compiling...' });
+    conn.emit('language/status', { type: 'Error', message: 'oops' });
+
+    expect(conn.activeHandlerCount('language/status')).toBe(1);
+
+    vi.advanceTimersByTime(600);
+    const result = await promise;
+    expect(result).toBe(false);
   });
 
-  it('handler is disposed on deadline even when no ready signal arrived', async () => {
+  it('language/status handler is registered exactly once per awaitReady call', async () => {
     vi.useFakeTimers();
     const conn = makeFakeConnection();
     const ctx = makeCtx(conn, { deadlineMs: 500 });
 
-    const promise = JAVA_ADAPTER.awaitReady(ctx);
+    JAVA_ADAPTER.awaitReady(ctx);
+
+    // Exactly one handler for language/status.
+    expect(conn.activeHandlerCount('language/status')).toBe(1);
+
     vi.advanceTimersByTime(600);
+  });
+});
+
+// ─── Suite: S-2 — Quiet path: onProgressEnd → 5000 ms quiet → settle(true) ────
+//
+// BDD:
+//   Given ctx.onProgressEnd is wired
+//   When a $/progress end event fires
+//   And no further end events arrive for JDTLS_QUIET_INTERVAL_MS (5000 ms)
+//   And backstopProbe returns non-empty
+//   Then settle(true)
+
+describe('S-2 — Quiet path: progress end → quiet interval → non-empty canary → settle(true)', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('one progress end event + 5000 ms quiet + non-empty probe → settle(true)', async () => {
+    vi.useFakeTimers();
+    const conn = makeFakeConnection();
+    const { onProgressEnd, fireProgressEnd } = makeProgressEndSeam();
+    // backstopProbe returns true — both quiet path and periodic canary use it.
+    const backstopProbe = vi.fn().mockResolvedValue(true);
+
+    const ctx = makeCtx(conn, {
+      deadlineMs: 60_000,
+      onProgressEnd,
+      backstopProbe,
+    });
+
+    const promise = JAVA_ADAPTER.awaitReady(ctx);
+
+    // Fire one $/progress end — starts the 5000 ms quiet timer.
+    // The periodic canary runs in parallel at CANARY_INTERVAL_MS (2500 ms) intervals.
+    // Since backstopProbe returns true, whichever path fires first (periodic canary
+    // at 2500 ms OR quiet timer at 5000 ms) will settle(true). Either way the
+    // final result must be true.
+    fireProgressEnd();
+
+    // Advance past the quiet interval — at least one path fires.
+    vi.advanceTimersByTime(JDTLS_QUIET_INTERVAL_MS + 100);
+    const result = await promise;
+
+    expect(result).toBe(true);
+    // backstopProbe invoked at least once (by whichever path fires first).
+    expect(backstopProbe).toHaveBeenCalled();
+  });
+
+  it('language/status handler is disposed after quiet-path settle(true)', async () => {
+    vi.useFakeTimers();
+    const conn = makeFakeConnection();
+    const { onProgressEnd, fireProgressEnd } = makeProgressEndSeam();
+    const backstopProbe = vi.fn().mockResolvedValue(true);
+
+    const ctx = makeCtx(conn, { deadlineMs: 60_000, onProgressEnd, backstopProbe });
+    const promise = JAVA_ADAPTER.awaitReady(ctx);
+
+    fireProgressEnd();
+    vi.advanceTimersByTime(JDTLS_QUIET_INTERVAL_MS);
     await promise;
 
     // Handler must be disposed — no leak.
     expect(conn.activeHandlerCount('language/status')).toBe(0);
     expect(conn.disposeCallCount).toBe(1);
   });
+});
 
-  it('uses default 120_000ms deadline when ctx.deadlineMs is undefined', async () => {
+// ─── Suite: S-3 — Timer re-arm: empty probe on first quiet, settle on second ──
+//
+// BDD:
+//   Given ctx.onProgressEnd fires once → quiet → probe returns empty → pending
+//   When a second $/progress end event fires + quiet elapses + probe returns true
+//   Then settle(true) on the second cycle
+
+describe('S-3 — Quiet path: empty probe → pending, second end + quiet + true probe → settle(true)', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('first end → quiet → probe empty → no settle; subsequent probe true → settle(true)', async () => {
     vi.useFakeTimers();
     const conn = makeFakeConnection();
-    // No deadlineMs — must use 120_000ms default.
-    const ctx = makeCtx(conn, { deadlineMs: undefined });
+    const { onProgressEnd, fireProgressEnd } = makeProgressEndSeam();
+
+    // All probes return false initially, then true — the first non-empty result settles.
+    // Use a counter-based mock: returns false for the first 2 calls, then true.
+    let callCount = 0;
+    const backstopProbe = vi.fn().mockImplementation(async () => {
+      callCount++;
+      return callCount >= 3; // first 2 calls return false, 3rd returns true
+    });
+
+    const ctx = makeCtx(conn, {
+      deadlineMs: 60_000,
+      onProgressEnd,
+      backstopProbe,
+    });
 
     const promise = JAVA_ADAPTER.awaitReady(ctx);
 
-    // At 119_999ms the handler should still be active.
-    vi.advanceTimersByTime(119_999);
-    expect(conn.activeHandlerCount('language/status')).toBe(1);
+    // Fire a $/progress end — starts the 5000 ms quiet timer.
+    // Meanwhile the periodic canary fires at 2500 ms intervals.
+    // After enough time, backstopProbe will return true and settle(true).
+    fireProgressEnd('tok-1');
 
-    // At 120_001ms the deadline fires.
+    // Use advanceTimersByTimeAsync to drain async callbacks between timer ticks.
+    // Advance enough time for at least 3 probes to fire (2 periodic + 1 quiet).
+    await vi.advanceTimersByTimeAsync(JDTLS_QUIET_INTERVAL_MS * 2 + 100);
+
+    const result = await promise;
+    expect(result).toBe(true);
+    expect(backstopProbe.mock.calls.length).toBeGreaterThanOrEqual(3);
+  });
+});
+
+// ─── Suite: S-4 — Periodic canary: zero progress events path ─────────────────
+//
+// BDD:
+//   Given zero $/progress end events
+//   When periodic canary fires at CANARY_INTERVAL_MS (2500 ms) intervals
+//   Then backstopProbe invoked ≥2× before deadline
+//   And on first non-empty result → settle(true)
+
+describe('S-4 — Periodic canary: zero progress events → canary ≥2× before deadline → settle(true)', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('backstopProbe invoked at least twice before deadline with zero progress events', async () => {
+    vi.useFakeTimers();
+    const conn = makeFakeConnection();
+    const backstopProbe = vi.fn().mockResolvedValue(false); // keeps returning false
+
+    const ctx = makeCtx(conn, {
+      deadlineMs: 600_000,
+      // No onProgressEnd — zero progress events path
+      backstopProbe,
+    });
+
+    const promise = JAVA_ADAPTER.awaitReady(ctx);
+
+    // Use advanceTimersByTimeAsync to properly drain async callbacks between timer ticks.
+    // Periodic canary fires at CANARY_INTERVAL_MS (2500 ms) intervals.
+    // After 2 × CANARY_INTERVAL_MS + margin, probe must have been called ≥2×.
+    await vi.advanceTimersByTimeAsync(CANARY_INTERVAL_MS * 2 + 100);
+
+    expect(backstopProbe.mock.calls.length).toBeGreaterThanOrEqual(2);
+
+    // Clean up: advance to deadline.
+    await vi.advanceTimersByTimeAsync(600_000);
+    await promise;
+  });
+
+  it('periodic canary non-empty on first fire → settle(true)', async () => {
+    vi.useFakeTimers();
+    const conn = makeFakeConnection();
+    // Returns true on the first call.
+    const backstopProbe = vi.fn().mockResolvedValue(true);
+
+    const ctx = makeCtx(conn, {
+      deadlineMs: 600_000,
+      backstopProbe,
+    });
+
+    const promise = JAVA_ADAPTER.awaitReady(ctx);
+
+    // Advance to first periodic canary fire.
+    vi.advanceTimersByTime(CANARY_INTERVAL_MS);
+    const result = await promise;
+
+    expect(result).toBe(true);
+    expect(backstopProbe).toHaveBeenCalledTimes(1);
+  });
+
+  it('periodic canary reschedules after empty result, settles on second non-empty', async () => {
+    vi.useFakeTimers();
+    const conn = makeFakeConnection();
+    const backstopProbe = vi.fn()
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(true);
+
+    const ctx = makeCtx(conn, {
+      deadlineMs: 600_000,
+      backstopProbe,
+    });
+
+    const promise = JAVA_ADAPTER.awaitReady(ctx);
+
+    // First canary fire (2500 ms) → false → reschedule.
+    vi.advanceTimersByTime(CANARY_INTERVAL_MS);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // Second canary fire (5000 ms total) → true → settle(true).
+    vi.advanceTimersByTime(CANARY_INTERVAL_MS);
+    const result = await promise;
+
+    expect(result).toBe(true);
+    expect(backstopProbe).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ─── Suite: S-5 — Default deadline === JDTLS_READY_DEADLINE_MS (600 000 ms) ──
+
+describe('S-5 — Default deadline is JDTLS_READY_DEADLINE_MS (600 000 ms)', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('JDTLS_READY_DEADLINE_MS equals 600 000', () => {
+    expect(JDTLS_READY_DEADLINE_MS).toBe(600_000);
+  });
+
+  it('pending at 599 999 ms when no settle trigger fires', async () => {
+    vi.useFakeTimers();
+    const conn = makeFakeConnection();
+    // backstopProbe always returns false so no canary settles early.
+    const backstopProbe = vi.fn().mockResolvedValue(false);
+    // No deadlineMs — uses default JDTLS_READY_DEADLINE_MS.
+    const ctx = makeCtx(conn, { backstopProbe });
+
+    let settled = false;
+    const promise = JAVA_ADAPTER.awaitReady(ctx).then((v) => {
+      settled = true;
+      return v;
+    });
+
+    // Advance to just before the default deadline.
+    vi.advanceTimersByTime(599_999);
+    await Promise.resolve();
+
+    // Not yet settled.
+    expect(settled).toBe(false);
+
+    // Cross the deadline.
     vi.advanceTimersByTime(2);
     const result = await promise;
     expect(result).toBe(false);
   });
 
-  it('resolves before the deadline if ServiceReady fires early', async () => {
+  it('settle(false) at 600 000 ms with no ready signal', async () => {
     vi.useFakeTimers();
     const conn = makeFakeConnection();
-    const ctx = makeCtx(conn, { deadlineMs: 10_000 });
+    const backstopProbe = vi.fn().mockResolvedValue(false);
+    const ctx = makeCtx(conn, { backstopProbe });
 
     const promise = JAVA_ADAPTER.awaitReady(ctx);
-
-    // Fire ready at 1s — well before 10s deadline.
-    vi.advanceTimersByTime(1_000);
-    conn.emit('language/status', { type: 'ServiceReady' });
-
+    vi.advanceTimersByTime(600_000);
     const result = await promise;
-    expect(result).toBe(true);
+
+    expect(result).toBe(false);
   });
 });
 
-// ─── Suite: JAVA_ADAPTER.awaitReady — deadline with canary non-null (KD-1 backstop) ────
-//
-// BDD Scenario: awaitReady deadline — canary backstop probe invoked and respected
-//
-// Technique: state-transition + decision table
-//   State: canary = non-null stub, ServiceReady never arrives → deadline fires
-//   Decision: backstopProbe returns true → settle(true); returns false → settle(false)
-//
-// Risk: if the backstop ignores the probe result and always settles(true) (the
-// original WI-2 placeholder), the readiness gate is bypassed — pre-ready defs
-// get published (the #172 class). Both true and false probe outcomes must be
-// tested to catch a hardcoded settle(true) regression.
+// ─── Suite: S-6 — ctx.deadlineMs override honoured ───────────────────────────
 
-describe('JAVA_ADAPTER.awaitReady — deadline with canary non-null (KD-1 backstop)', () => {
-  // Use a non-null stub canary. The actual canary strategy is JAVA_CANARY_STRATEGY
-  // but the deadline backstop doesn't care about its sampling logic — it only
-  // checks canary !== null before calling backstopProbe. A minimal stub satisfies.
-  const stubCanary = {
-    isCandidateFile: () => true,
-    tryExtractSample: () => null,
-  };
-  const originalCanary = JAVA_ADAPTER.canary;
-
-  beforeEach(() => {
-    (JAVA_ADAPTER as unknown as Record<string, unknown>).canary = stubCanary;
-  });
+describe('S-6 — ctx.deadlineMs override is honoured', () => {
   afterEach(() => {
-    (JAVA_ADAPTER as unknown as Record<string, unknown>).canary = originalCanary;
     vi.useRealTimers();
   });
 
-  it('invokes backstopProbe at the deadline when canary is non-null', async () => {
-    vi.useFakeTimers();
-    const conn = makeFakeConnection();
-    const backstopProbe = vi.fn().mockResolvedValue(true);
-    const ctx = makeCtx(conn, { deadlineMs: 1_000, backstopProbe });
-
-    const promise = JAVA_ADAPTER.awaitReady(ctx);
-    vi.advanceTimersByTime(1_100);
-    await promise;
-
-    // The probe MUST be called exactly once — not zero (ignored), not multiple.
-    expect(backstopProbe).toHaveBeenCalledTimes(1);
-  });
-
-  it('resolves true when backstopProbe returns true (probe result is respected)', async () => {
-    vi.useFakeTimers();
-    const conn = makeFakeConnection();
-    const backstopProbe = vi.fn().mockResolvedValue(true);
-    const ctx = makeCtx(conn, { deadlineMs: 1_000, backstopProbe });
-
-    const promise = JAVA_ADAPTER.awaitReady(ctx);
-    vi.advanceTimersByTime(1_100);
-
-    const result = await promise;
-    expect(result).toBe(true);
-  });
-
-  it('resolves false when backstopProbe returns false (probe result is respected — no hardcoded true)', async () => {
+  it('ctx.deadlineMs 1000 → settle(false) at 1000 ms (well before 600 000 ms default)', async () => {
     vi.useFakeTimers();
     const conn = makeFakeConnection();
     const backstopProbe = vi.fn().mockResolvedValue(false);
     const ctx = makeCtx(conn, { deadlineMs: 1_000, backstopProbe });
 
     const promise = JAVA_ADAPTER.awaitReady(ctx);
-    vi.advanceTimersByTime(1_100);
 
+    // Still pending before override deadline.
+    vi.advanceTimersByTime(999);
+    await Promise.resolve();
+
+    vi.advanceTimersByTime(2);
     const result = await promise;
-    // If production code hardcodes settle(true) instead of using the probe result,
-    // this assertion catches it.
+
     expect(result).toBe(false);
   });
 
-  it('resolves false (degrades gracefully) when backstopProbe rejects', async () => {
+  it('deadline resolves false (not a rejection)', async () => {
     vi.useFakeTimers();
     const conn = makeFakeConnection();
-    const backstopProbe = vi.fn().mockRejectedValue(new Error('probe failed'));
-    const ctx = makeCtx(conn, { deadlineMs: 1_000, backstopProbe });
+    const ctx = makeCtx(conn, { deadlineMs: 500 });
 
     const promise = JAVA_ADAPTER.awaitReady(ctx);
-    vi.advanceTimersByTime(1_100);
+    vi.advanceTimersByTime(600);
 
-    // Must not throw or propagate the rejection — degrade to false.
     await expect(promise).resolves.toBe(false);
   });
 
-  it('handler is disposed on deadline when canary is non-null (no notification leak)', async () => {
+  it('all handlers disposed after deadline settle(false)', async () => {
     vi.useFakeTimers();
     const conn = makeFakeConnection();
-    const backstopProbe = vi.fn().mockResolvedValue(true);
-    const ctx = makeCtx(conn, { deadlineMs: 500, backstopProbe });
+    const ctx = makeCtx(conn, { deadlineMs: 500 });
 
     const promise = JAVA_ADAPTER.awaitReady(ctx);
     vi.advanceTimersByTime(600);
     await promise;
 
-    // The notification handler must be disposed even when the backstop fires.
     expect(conn.activeHandlerCount('language/status')).toBe(0);
     expect(conn.disposeCallCount).toBe(1);
   });
-
-  it('ServiceReady before deadline resolves true without invoking backstopProbe', async () => {
-    vi.useFakeTimers();
-    const conn = makeFakeConnection();
-    const backstopProbe = vi.fn().mockResolvedValue(false);
-    const ctx = makeCtx(conn, { deadlineMs: 5_000, backstopProbe });
-
-    const promise = JAVA_ADAPTER.awaitReady(ctx);
-    // Server signals ready at 1s — well before 5s deadline.
-    vi.advanceTimersByTime(1_000);
-    conn.emit('language/status', { type: 'ServiceReady' });
-
-    const result = await promise;
-    expect(result).toBe(true);
-    // Backstop must NOT be called — the ready signal settled it first.
-    expect(backstopProbe).not.toHaveBeenCalled();
-  });
 });
 
-// ─── Suite: JAVA_ADAPTER.awaitReady — error / degraded paths ─────────────────
+// ─── Suite: S-7/S-8/S-9 — Degraded paths → resolves false, no throw ──────────
 
-describe('JAVA_ADAPTER.awaitReady — error / degraded paths', () => {
-  it('resolves false (not throws) when connection.onNotification throws', async () => {
+describe('S-7 — onNotification throws → resolves false, no throw', () => {
+  it('connection.onNotification throws synchronously → awaitReady resolves false', async () => {
     const brokenConn = {
       onNotification(_method: string, _handler: unknown): never {
         throw new Error('connection already disposed');
@@ -400,23 +554,96 @@ describe('JAVA_ADAPTER.awaitReady — error / degraded paths', () => {
       deadlineMs: 1_000,
     };
 
-    // Must not throw or reject.
     await expect(JAVA_ADAPTER.awaitReady(ctx)).resolves.toBe(false);
   });
+});
 
-  it('resolves false when the connection object is null (extreme degradation)', async () => {
+describe('S-8 — connection null → resolves false, no throw', () => {
+  it('null connection → awaitReady resolves false', async () => {
     const ctx: AdapterReadyCtx = {
       connection: null,
       workspaceRoot: '/any',
       deadlineMs: 1_000,
     };
 
-    // Casting null to MessageConnection will throw on onNotification — must degrade.
     await expect(JAVA_ADAPTER.awaitReady(ctx)).resolves.toBe(false);
   });
 });
 
-// ─── Suite: JAVA_ADAPTER.spawnArgs ───────────────────────────────────────────
+describe('S-9 — backstopProbe rejects (via periodic canary) → resolves false, no throw', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('backstopProbe rejects → no throw, no unhandled rejection, resolves false at deadline', async () => {
+    vi.useFakeTimers();
+    const conn = makeFakeConnection();
+    // backstopProbe always rejects — runCanary catches it and returns false.
+    // The periodic canary keeps rescheduling (returns false on rejection catch).
+    // The promise settles(false) when the hard deadline fires.
+    const backstopProbe = vi.fn().mockRejectedValue(new Error('probe failed'));
+
+    const ctx = makeCtx(conn, {
+      deadlineMs: 1_000, // short override so the deadline fires quickly
+      backstopProbe,
+    });
+
+    const promise = JAVA_ADAPTER.awaitReady(ctx);
+
+    // Advance past deadline — probe rejection is caught internally, no throw propagates.
+    await vi.advanceTimersByTimeAsync(1_100);
+
+    await expect(promise).resolves.toBe(false);
+  });
+});
+
+// ─── Suite: S-10 — Double-settle guard: quiet + deadline race ─────────────────
+//
+// BDD:
+//   Given quiet timer and deadline timer could fire at the same moment
+//   Then the settled boolean guard ensures resolve is called exactly once
+
+describe('S-10 — Double-settle guard: quiet + deadline race → settles exactly once', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('simultaneous quiet-path and deadline fire → settled exactly once', async () => {
+    vi.useFakeTimers();
+    const conn = makeFakeConnection();
+    const { onProgressEnd, fireProgressEnd } = makeProgressEndSeam();
+
+    // backstopProbe returns true — quiet path would settle(true).
+    const backstopProbe = vi.fn().mockResolvedValue(true);
+
+    // Set deadline equal to JDTLS_QUIET_INTERVAL_MS so both race at same tick.
+    const ctx = makeCtx(conn, {
+      deadlineMs: JDTLS_QUIET_INTERVAL_MS,
+      onProgressEnd,
+      backstopProbe,
+    });
+
+    let resolveCount = 0;
+    const promise = JAVA_ADAPTER.awaitReady(ctx).then((v) => {
+      resolveCount++;
+      return v;
+    });
+
+    // Fire progress end — sets quiet timer for 5000 ms.
+    fireProgressEnd();
+
+    // Advance exactly to JDTLS_QUIET_INTERVAL_MS — both quiet timer and
+    // deadline timer fire at the same moment.
+    vi.advanceTimersByTime(JDTLS_QUIET_INTERVAL_MS);
+
+    await promise;
+
+    // Resolved exactly once — the settled guard prevented double-resolution.
+    expect(resolveCount).toBe(1);
+  });
+});
+
+// ─── Suite: JAVA_ADAPTER.spawnArgs (7 cases verbatim — readiness-model-independent) ─
 
 describe('JAVA_ADAPTER.spawnArgs', () => {
   const originalGitnexusHome = process.env.GITNEXUS_HOME;

--- a/gitnexus/test/unit/lsp/language-adapter.test.ts
+++ b/gitnexus/test/unit/lsp/language-adapter.test.ts
@@ -131,6 +131,8 @@ import {
   PYLSP_READY_DEADLINE_MS,
   GOPLS_READY_DEADLINE_MS,
   RUST_ANALYZER_READY_DEADLINE_MS,
+  JDTLS_READY_DEADLINE_MS,
+  JDTLS_QUIET_INTERVAL_MS,
   selectAdapter,
   type LanguageAdapter,
   type LanguageCanaryStrategy,
@@ -1930,9 +1932,11 @@ describe('WI-0 clientCapabilities seam', () => {
     expect(TYPESCRIPT_ADAPTER.clientCapabilities).toBeUndefined();
   });
 
-  // C0-4: JAVA_ADAPTER.clientCapabilities === undefined
-  it('C0-4: JAVA_ADAPTER.clientCapabilities === undefined (absent → uses TS_SERVER_CAPABILITIES)', () => {
-    expect(JAVA_ADAPTER.clientCapabilities).toBeUndefined();
+  // C0-4: JAVA_ADAPTER.clientCapabilities deep-equals { window: { workDoneProgress: true } }
+  // Updated by WI-1: Java now declares clientCapabilities so lsp-client.ts activates
+  // the $/progress seam for Java sessions (ADR-002).
+  it('C0-4: JAVA_ADAPTER.clientCapabilities deep-equals { window: { workDoneProgress: true } }', () => {
+    expect(JAVA_ADAPTER.clientCapabilities).toStrictEqual({ window: { workDoneProgress: true } });
   });
 
   // C0-5: PYTHON_ADAPTER.clientCapabilities === undefined
@@ -1968,6 +1972,70 @@ describe('WI-0 clientCapabilities seam', () => {
     // window.workDoneProgress to be the literal type `false`.
     const caps: ClientCapabilities = GO_ADAPTER.clientCapabilities!;
     expect(caps.window?.workDoneProgress).toBe(true);
+  });
+});
+
+// ─── Suite: WI-1 — JDTLS constants + JAVA_ADAPTER.clientCapabilities ──────
+//
+// Technique: EP (value classes) + identity assertion for C0-2/I-1 invariant.
+// Cases C1-1..C1-9: additive assertions; C1-10 lives in lsp-client.test.ts.
+//
+// I-1 invariant: JAVA_ADAPTER.clientCapabilities is a FRESH object literal;
+// it must NOT be the same reference as any other adapter's capabilities
+// (including the module-private TS_SERVER_CAPABILITIES which is unreachable
+// from tests — we assert via Object.is against peer adapters that ARE accessible).
+
+describe('WI-1 JDTLS constants and JAVA_ADAPTER.clientCapabilities', () => {
+  // C1-1: JDTLS_READY_DEADLINE_MS exported and === 600_000
+  it('C1-1: JDTLS_READY_DEADLINE_MS === 600_000 (exported, numeric exact-equal)', () => {
+    expect(JDTLS_READY_DEADLINE_MS).toBe(600_000);
+  });
+
+  // C1-2: JDTLS_QUIET_INTERVAL_MS exported and === 5_000
+  it('C1-2: JDTLS_QUIET_INTERVAL_MS === 5_000 (exported, numeric exact-equal)', () => {
+    expect(JDTLS_QUIET_INTERVAL_MS).toBe(5_000);
+  });
+
+  // C1-3: JAVA_ADAPTER.clientCapabilities deep-equals { window: { workDoneProgress: true } }
+  it('C1-3: JAVA_ADAPTER.clientCapabilities deep-equals { window: { workDoneProgress: true } }', () => {
+    expect(JAVA_ADAPTER.clientCapabilities).toStrictEqual({ window: { workDoneProgress: true } });
+  });
+
+  // C1-4: JAVA_ADAPTER.clientCapabilities is NOT the same object as GO_ADAPTER.clientCapabilities
+  // (I-1 / C0-2 identity discipline — each adapter owns a distinct fresh literal).
+  // TS_SERVER_CAPABILITIES is module-private; we use GO_ADAPTER as the accessible peer.
+  it('C1-4: JAVA_ADAPTER.clientCapabilities is NOT the same object reference as GO_ADAPTER.clientCapabilities (I-1)', () => {
+    expect(Object.is(JAVA_ADAPTER.clientCapabilities, GO_ADAPTER.clientCapabilities)).toBe(false);
+  });
+
+  // C1-5: JAVA_ADAPTER.clientCapabilities has exactly { window } — no extra keys
+  it('C1-5: JAVA_ADAPTER.clientCapabilities has no extra keys beyond { window } (toStrictEqual shape)', () => {
+    // toStrictEqual (used in C1-3) already enforces no extra keys, but this test
+    // makes the structural constraint explicit and self-documenting.
+    const caps = JAVA_ADAPTER.clientCapabilities!;
+    expect(Object.keys(caps)).toEqual(['window']);
+    expect(Object.keys(caps.window!)).toEqual(['workDoneProgress']);
+  });
+
+  // C1-6: GO_ADAPTER.clientCapabilities unchanged — regression guard
+  it('C1-6: GO_ADAPTER.clientCapabilities unchanged — still { window: { workDoneProgress: true } }', () => {
+    expect(GO_ADAPTER.clientCapabilities).toStrictEqual({ window: { workDoneProgress: true } });
+  });
+
+  // C1-7: TYPESCRIPT_ADAPTER.clientCapabilities is undefined — other adapters unaffected
+  it('C1-7: TYPESCRIPT_ADAPTER.clientCapabilities is undefined (unaffected by WI-1)', () => {
+    expect(TYPESCRIPT_ADAPTER.clientCapabilities).toBeUndefined();
+  });
+
+  // C1-8: RUST_ADAPTER.clientCapabilities is unchanged (has window + experimental — not narrowed)
+  it('C1-8: RUST_ADAPTER.clientCapabilities is unchanged by WI-1 (still has window + experimental)', () => {
+    expect(RUST_ADAPTER.clientCapabilities?.window?.workDoneProgress).toBe(true);
+    expect(RUST_ADAPTER.clientCapabilities?.experimental?.serverStatusNotification).toBe(true);
+  });
+
+  // C1-9: PYTHON_ADAPTER.clientCapabilities is undefined — other adapters unaffected
+  it('C1-9: PYTHON_ADAPTER.clientCapabilities is undefined (unaffected by WI-1)', () => {
+    expect(PYTHON_ADAPTER.clientCapabilities).toBeUndefined();
   });
 });
 

--- a/gitnexus/test/unit/lsp/lsp-client.test.ts
+++ b/gitnexus/test/unit/lsp/lsp-client.test.ts
@@ -1169,20 +1169,14 @@ describe('WI-0 — ClientCapabilities seam (C0-8..C0-11)', () => {
     }
   });
 
-  // C0-10: non-Go path: TS/Java/Python register NO $/progress/create handler
-  //        (capability-gated off)
-  //
-  // We create a fast-awaitReady wrapper for JAVA_ADAPTER so the test does not
-  // hang on the 120s language/status notification deadline.  The wrapper is
-  // structurally equivalent to the real adapter (same id, serverBinary, etc.)
-  // but overrides awaitReady to resolve true immediately.  This isolates the
-  // test to the pre-initialize handler registration gate, not the awaitReady path.
-  const fastJavaAdapter = { ...JAVA_ADAPTER, awaitReady: async () => true as const };
+  // C0-10: TS/Python register NO $/progress/create handler (capability-gated off).
+  //        WI-1 update: JAVA_ADAPTER now sets clientCapabilities.window.workDoneProgress=true
+  //        and is therefore MOVED to the "registers $/progress handler" group (C1-10 below).
+  //        Only TYPESCRIPT_ADAPTER and PYTHON_ADAPTER remain in the no-handler group.
   const fastPythonAdapter = { ...PYTHON_ADAPTER, awaitReady: async () => true as const };
 
   it.each([
     ['TYPESCRIPT_ADAPTER', TYPESCRIPT_ADAPTER],
-    ['JAVA_ADAPTER (fast-awaitReady)', fastJavaAdapter],
     ['PYTHON_ADAPTER (fast-awaitReady)', fastPythonAdapter],
   ] as const)('C0-10: %s → NO $/progress or window/workDoneProgress/create handler registered', async (name, adapter) => {
     const wire = makeWire();
@@ -1216,6 +1210,126 @@ describe('WI-0 — ClientCapabilities seam (C0-8..C0-11)', () => {
 
       expect(progressRegIdx).toBe(-1);
       expect(createRegIdx).toBe(-1);
+    } finally {
+      try { await lspClient.stop(); } catch { /* noop */ }
+      server.dispose();
+      try { realClientConn.dispose(); } catch { /* noop */ }
+      wire.destroy();
+    }
+  });
+
+  // C4-7: RUST_ADAPTER registers $/progress and window/workDoneProgress/create handlers.
+  //
+  // RUST_ADAPTER.clientCapabilities = { window: { workDoneProgress: true },
+  //   experimental: { serverStatusNotification: true } }.
+  // The gate in lsp-client.ts is `adapter.clientCapabilities?.window?.workDoneProgress`,
+  // which is `true` for RUST_ADAPTER — so the $/progress handler IS registered for Rust.
+  // RUST's awaitReady reads only ctx.serverStatusLatest / ctx.onServerStatus (not $/progress
+  // directly), but the $/progress buffer is still populated for any future use.
+  //
+  // NOTE: WI-4c spec draft stated "RUST_ADAPTER does NOT register $/progress (gated
+  // on experimental.serverStatusNotification, not workDoneProgress)". That claim is
+  // incorrect — the $/progress gate is window.workDoneProgress (true for Rust), not
+  // experimental.serverStatusNotification. Production lsp-client.ts confirms: any adapter
+  // with window.workDoneProgress=true DOES register $/progress. See specMismatch note
+  // in StructuredOutput. RUST_ADAPTER belongs to the "registers $/progress" group, not
+  // the "no $/progress handler" group (TS/Python).
+  it('C4-7: RUST_ADAPTER — $/progress and window/workDoneProgress/create handlers ARE registered (window.workDoneProgress=true gate fires for Rust)', async () => {
+    const { RUST_ADAPTER } = await import('../../../src/core/ingestion/lsp/language-adapter.js');
+    // Fast awaitReady: RUST real impl reads experimental/serverStatus not wired here.
+    const fastRustAdapter = { ...RUST_ADAPTER, awaitReady: async () => true as const };
+    const wire = makeWire();
+    const server = makeFakeServer(wire);
+    const realClientConn = createMessageConnection(
+      new StreamMessageReader(wire.clientStdout),
+      new StreamMessageWriter(wire.clientStdin),
+      NullLogger,
+    );
+    const rec = makeRecordingConnection(wire, realClientConn);
+    const clientProcess = makeFakeChildProcess(wire);
+
+    const lspClient = new LspClient({
+      workspaceRoot: '/',
+      adapter: fastRustAdapter as any,
+      _inject: {
+        spawn: () => ({ process: clientProcess, connection: rec as any }),
+      },
+    });
+
+    try {
+      await lspClient.start();
+
+      const progressRegIdx = rec.events.findIndex(
+        (e) => e.kind === 'onNotification' && e.method === '$/progress',
+      );
+      const createRegIdx = rec.events.findIndex(
+        (e) => e.kind === 'onRequest' && e.method === 'window/workDoneProgress/create',
+      );
+      const initializeSendIdx = rec.events.findIndex(
+        (e) => e.kind === 'sendRequest' && e.method === 'initialize',
+      );
+
+      // RUST_ADAPTER.window.workDoneProgress=true → gate fires → both handlers registered.
+      expect(progressRegIdx).toBeGreaterThanOrEqual(0);
+      expect(createRegIdx).toBeGreaterThanOrEqual(0);
+      // Both must be registered BEFORE initialize is sent (R2-2 ordering).
+      expect(initializeSendIdx).toBeGreaterThanOrEqual(0);
+      expect(progressRegIdx).toBeLessThan(initializeSendIdx);
+      expect(createRegIdx).toBeLessThan(initializeSendIdx);
+    } finally {
+      try { await lspClient.stop(); } catch { /* noop */ }
+      server.dispose();
+      try { realClientConn.dispose(); } catch { /* noop */ }
+      wire.destroy();
+    }
+  });
+
+  // C1-10: JAVA_ADAPTER registers $/progress and window/workDoneProgress/create handlers
+  //        (WI-1: clientCapabilities.window.workDoneProgress=true activates the gate).
+  //
+  // Fast-awaitReady wrapper used so the test does not hang on JDTLS_READY_DEADLINE_MS
+  // (600 s). Mirrors C0-8 (GO_ADAPTER) — verifies handler registration ORDERING,
+  // not the awaitReady resolution value.
+  it('C1-10: JAVA_ADAPTER — $/progress and window/workDoneProgress/create handlers registered (workDoneProgress=true gate)', async () => {
+    const fastJavaAdapter = { ...JAVA_ADAPTER, awaitReady: async () => true as const };
+    const wire = makeWire();
+    const server = makeFakeServer(wire);
+    const realClientConn = createMessageConnection(
+      new StreamMessageReader(wire.clientStdout),
+      new StreamMessageWriter(wire.clientStdin),
+      NullLogger,
+    );
+    const rec = makeRecordingConnection(wire, realClientConn);
+    const clientProcess = makeFakeChildProcess(wire);
+
+    const lspClient = new LspClient({
+      workspaceRoot: '/',
+      adapter: fastJavaAdapter as any,
+      _inject: {
+        spawn: () => ({ process: clientProcess, connection: rec as any }),
+      },
+    });
+
+    try {
+      await lspClient.start();
+
+      const progressRegIdx = rec.events.findIndex(
+        (e) => e.kind === 'onNotification' && e.method === '$/progress',
+      );
+      const createRegIdx = rec.events.findIndex(
+        (e) => e.kind === 'onRequest' && e.method === 'window/workDoneProgress/create',
+      );
+      const initializeSendIdx = rec.events.findIndex(
+        (e) => e.kind === 'sendRequest' && e.method === 'initialize',
+      );
+
+      // Both handlers MUST be registered (JAVA_ADAPTER now has workDoneProgress=true).
+      expect(progressRegIdx).toBeGreaterThanOrEqual(0);
+      expect(createRegIdx).toBeGreaterThanOrEqual(0);
+      // And they must be registered BEFORE initialize is sent (R2-2 ordering).
+      expect(initializeSendIdx).toBeGreaterThanOrEqual(0);
+      expect(progressRegIdx).toBeLessThan(initializeSendIdx);
+      expect(createRegIdx).toBeLessThan(initializeSendIdx);
     } finally {
       try { await lspClient.stop(); } catch { /* noop */ }
       server.dispose();
@@ -1405,10 +1519,11 @@ describe('AdapterReadyCtx progress wiring (C2a-1..C2a-7)', () => {
     }
   });
 
-  // C2a-2: TS/Java/Python ctx omits all three progress fields (undefined).
+  // C2a-2: TS/Python ctx omits all three progress fields (undefined).
+  //        WI-1 update: JAVA_ADAPTER now has clientCapabilities.window.workDoneProgress=true,
+  //        so its ctx DOES receive the three progress fields — moved to C2a-2b below.
   it.each([
     ['TYPESCRIPT_ADAPTER', TYPESCRIPT_ADAPTER],
-    ['JAVA_ADAPTER (fast)', { ...JAVA_ADAPTER, awaitReady: async () => true as const }],
     ['PYTHON_ADAPTER (fast)', { ...PYTHON_ADAPTER, awaitReady: async () => true as const }],
   ] as const)(
     'C2a-2: %s ctx.progressTokenTitles / progressEndedTokens / onProgressEnd are undefined',
@@ -1454,6 +1569,43 @@ describe('AdapterReadyCtx progress wiring (C2a-1..C2a-7)', () => {
       }
     },
   );
+
+  // C2a-2b: JAVA_ADAPTER (WI-1 update) ctx DOES receive the three progress fields
+  //         (workDoneProgress=true activates the $/progress gate in lsp-client.ts).
+  it('C2a-2b: JAVA_ADAPTER (fast) ctx.progressTokenTitles / progressEndedTokens / onProgressEnd are DEFINED (WI-1)', async () => {
+    let capturedCtx: any = null;
+    const fastJavaAdapter = { ...JAVA_ADAPTER, awaitReady: async (ctx: any) => { capturedCtx = ctx; return true; } };
+    const wire = makeWire();
+    const server = makeFakeServer(wire);
+    const realClientConn = createMessageConnection(
+      new StreamMessageReader(wire.clientStdout),
+      new StreamMessageWriter(wire.clientStdin),
+      NullLogger,
+    );
+    const rec = makeRecordingConnection(wire, realClientConn);
+    const clientProcess = makeFakeChildProcess(wire);
+
+    const lspClient = new LspClient({
+      workspaceRoot: '/',
+      adapter: fastJavaAdapter as any,
+      _inject: {
+        spawn: () => ({ process: clientProcess, connection: rec as any }),
+      },
+    });
+
+    try {
+      await lspClient.start();
+      expect(capturedCtx).not.toBeNull();
+      expect(capturedCtx.progressTokenTitles).toBeDefined();
+      expect(capturedCtx.progressEndedTokens).toBeDefined();
+      expect(typeof capturedCtx.onProgressEnd).toBe('function');
+    } finally {
+      try { await lspClient.stop(); } catch { /* noop */ }
+      server.dispose();
+      try { realClientConn.dispose(); } catch { /* noop */ }
+      wire.destroy();
+    }
+  });
 
   // C2a-3: onProgressEnd(cb) -> $/progress end for token T -> cb invoked with T.
   it('C2a-3: onProgressEnd(cb) + $/progress end -> cb invoked with the ended token', async () => {

--- a/gitnexus/test/unit/lsp/mode-a-external-prefilter.test.ts
+++ b/gitnexus/test/unit/lsp/mode-a-external-prefilter.test.ts
@@ -1,0 +1,811 @@
+/**
+ * Unit Tests: canSkipCandidate seam + external pre-filter (WI-8).
+ *
+ * Covers the full EP partition for the external pre-filter injected into
+ * `withReconciliationSession` via `WithReconciliationSessionDeps.canSkipCandidate`.
+ *
+ * EP Partitions:
+ *   EP-A: correction candidate, external-zone node (isExternal===true) → skip
+ *   EP-B: correction candidate, node absent (undefined) → skip (NO_NODE sentinel)
+ *   EP-C: correction candidate, workspace-internal node (isExternal===false) → probe
+ *   EP-D: correction candidate, isExternal undefined/absent → probe (conservative)
+ *   EP-E: recall candidate (oldTargetId absent) → probe
+ *   EP-F: recall candidate with any candidate.file → probe; isUnindexablePath never called
+ *
+ * Cases:
+ *   C8-1  [EP-A]  : external-zone node → canSkipCandidate=true; preFilteredExternal++; probed unchanged
+ *   C8-2  [EP-B]  : absent node → canSkipCandidate=true; preFilteredExternal++; probed unchanged
+ *   C8-3  [EP-C]  : workspace-internal node → canSkipCandidate=false; probed++
+ *   C8-4  [EP-D]  : isExternal absent → canSkipCandidate=false; probed++
+ *   C8-5  [EP-E]  : recall candidate (no oldTargetId) → canSkipCandidate=false; probed++
+ *   C8-6  [EP-F]  : recall + java file → probe; isUnindexablePath irrelevant
+ *   C8-7  [EP-F]  : recall + any file → probe; isUnindexablePath never invoked
+ *   C8-8  [uncertain]: ambiguous correction (undefined result) → probe; no false skip
+ *   C8-9  [seam absent]: no canSkipCandidate in deps → all candidates reach fetchDefinition; preFilteredExternal=0
+ *   C8-10 [ordering]: spy on fetchDefinitionForCandidate; NOT called for EP-A/EP-B; IS called for EP-C..EP-F
+ *   C8-11 [pipeline closure]: closure built from graph.getNode (not classifyUri, not isUnindexablePath)
+ *   C8-12 [I-8-replay]: pre-filtered candidates excluded from locations map; reconcileDecisions counters unaffected
+ *   C8-13 [multiple external]: multiple EP-A candidates → preFilteredExternal === N
+ *   C8-14 [closure injection]: canSkipCandidate is injectable as vi.fn() in session tests
+ *
+ * Test surface:
+ *   - NEVER spawns a real LSP — all deps are injected via WithReconciliationSessionDeps.
+ *   - Uses vi.fn() spies for canSkipCandidate, handToEngine, and fetchDefinitionForCandidate.
+ *   - Verifies counter semantics (probed / preFilteredExternal) from SessionMeta.
+ *   - Verifies dispatch ordering: skip fires BEFORE fetchDefinitionForCandidate.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+import {
+  withReconciliationSession,
+  type WithReconciliationSessionDeps,
+  type ReconciliationProbeFn,
+  type ReconciliationLspClient,
+  type ReconciliationRepo,
+  type Location,
+  type Candidate,
+  type SessionMeta,
+} from '../../../src/core/ingestion/mode-a-reconciler.js';
+
+// ─── Shared test infrastructure ──────────────────────────────────────────────
+
+function makeMockClient(over: {
+  startImpl?: () => Promise<void>;
+  stopImpl?: () => Promise<void>;
+  requestImpl?: (method: string, params: unknown, timeoutMs: number) => Promise<unknown>;
+} = {}) {
+  const start = vi.fn(over.startImpl ?? (async () => undefined));
+  const stop = vi.fn(over.stopImpl ?? (async () => undefined));
+  const request = vi.fn(over.requestImpl ?? (async () => null));
+  const getState = vi.fn(() => 'ready');
+  return {
+    client: { start, stop, request, getState } as unknown as ReconciliationLspClient,
+    start,
+    stop,
+    request,
+  };
+}
+
+function makeClientFactory(client: ReconciliationLspClient) {
+  return vi.fn(() => client);
+}
+
+function makeReadyProbe(): ReconciliationProbeFn {
+  return vi.fn(async () => ({ ready: true })) as unknown as ReconciliationProbeFn;
+}
+
+function makeDeps(
+  client: ReconciliationLspClient,
+  over: Partial<WithReconciliationSessionDeps> = {},
+): WithReconciliationSessionDeps {
+  return {
+    discoverServers: vi.fn(async () => ({
+      typescript: { path: '/bin/typescript-language-server', version: '4.3.3' },
+    })),
+    createLspClient: makeClientFactory(client),
+    probe: makeReadyProbe(),
+    ...over,
+  };
+}
+
+const REPO: ReconciliationRepo = {
+  id: 'r1',
+  repoPath: '/workspace/repo',
+};
+
+function mkCandidate(over: Partial<Candidate> = {}): Candidate {
+  return {
+    sourceId: 'src:1',
+    calledName: 'foo',
+    oldTargetId: 'Function:src/a.ts:foo',
+    file: 'src/a.ts',
+    line: 10,
+    character: 4,
+    ...over,
+  };
+}
+
+function mkRecallCandidate(over: Partial<Candidate> = {}): Candidate {
+  // Recall candidates have no oldTargetId
+  return {
+    sourceId: 'src:recall',
+    calledName: 'bar',
+    file: 'src/b.ts',
+    line: 5,
+    character: 2,
+    ...over,
+  };
+}
+
+/**
+ * Run a session and capture SessionMeta from the work fn.
+ * Returns { meta, handCalls } where handCalls is the number
+ * of times handToEngine was called.
+ */
+async function runAndCaptureMeta(
+  candidates: Candidate[],
+  deps: WithReconciliationSessionDeps,
+  handToEngine?: (cand: Candidate, locs: Location[]) => Promise<void>,
+): Promise<{ meta: SessionMeta; handCalls: number }> {
+  const hand = handToEngine ?? vi.fn(async () => undefined);
+  const handFn = vi.fn(hand) as unknown as (cand: Candidate, locs: Location[]) => Promise<void>;
+  let captured: SessionMeta | undefined;
+  await withReconciliationSession(REPO, candidates, async (_selected, meta) => {
+    captured = meta;
+    return undefined;
+  }, { ...deps, handToEngine: handFn });
+  if (!captured) throw new Error('work-fn never called — session gate refused');
+  return { meta: captured, handCalls: handFn.mock.calls.length };
+}
+
+// ─── C8-1: EP-A — external-zone node → skip ──────────────────────────────────
+
+describe('WI-8 C8-1 [EP-A]: external-zone correction candidate is skipped', () => {
+  it('canSkipCandidate returns true for external-zone node → preFilteredExternal++; probed unchanged', async () => {
+    const { client } = makeMockClient();
+    const externalCandidate = mkCandidate({ oldTargetId: 'Function:ext.jar:Foo' });
+    const canSkipCandidate = vi.fn((_c: Candidate) => true);
+    const deps = makeDeps(client, { canSkipCandidate });
+    const { meta, handCalls } = await runAndCaptureMeta([externalCandidate], deps);
+
+    expect(canSkipCandidate).toHaveBeenCalledTimes(1);
+    expect(canSkipCandidate).toHaveBeenCalledWith(externalCandidate);
+    expect(meta.preFilteredExternal).toBe(1);
+    expect(meta.probed).toBe(0);
+    // handToEngine must NOT be called for skipped candidates
+    expect(handCalls).toBe(0);
+  });
+});
+
+// ─── C8-2: EP-B — absent node (NO_NODE sentinel) → skip ─────────────────────
+
+describe('WI-8 C8-2 [EP-B]: absent-node correction candidate is skipped', () => {
+  it('canSkipCandidate returns true for absent node → preFilteredExternal++; probed unchanged', async () => {
+    const { client } = makeMockClient();
+    const absenceCandidate = mkCandidate({ oldTargetId: 'Function:deleted.ts:gone' });
+    // Simulates graph.getNode returning undefined → canSkipCandidate returns true
+    const canSkipCandidate = vi.fn((c: Candidate) =>
+      c.oldTargetId === 'Function:deleted.ts:gone',
+    );
+    const deps = makeDeps(client, { canSkipCandidate });
+    const { meta, handCalls } = await runAndCaptureMeta([absenceCandidate], deps);
+
+    expect(meta.preFilteredExternal).toBe(1);
+    expect(meta.probed).toBe(0);
+    expect(handCalls).toBe(0);
+  });
+});
+
+// ─── C8-3: EP-C — workspace-internal node → probe ────────────────────────────
+
+describe('WI-8 C8-3 [EP-C]: workspace-internal correction candidate is probed', () => {
+  it('canSkipCandidate returns false for internal node → probed++; preFilteredExternal unchanged', async () => {
+    const { client } = makeMockClient({ requestImpl: async () => null });
+    const internalCandidate = mkCandidate({ oldTargetId: 'Function:src/service.ts:doWork' });
+    const canSkipCandidate = vi.fn((_c: Candidate) => false);
+    const deps = makeDeps(client, { canSkipCandidate });
+    const { meta, handCalls } = await runAndCaptureMeta([internalCandidate], deps);
+
+    expect(meta.preFilteredExternal).toBe(0);
+    expect(meta.probed).toBe(1);
+    // handToEngine IS called for probed candidates
+    expect(handCalls).toBe(1);
+  });
+});
+
+// ─── C8-4: EP-D — isExternal absent → probe (conservative) ──────────────────
+
+describe('WI-8 C8-4 [EP-D]: ambiguous node (isExternal absent) → probe; no false skip', () => {
+  it('canSkipCandidate returns false when isExternal is undefined → probed++', async () => {
+    const { client } = makeMockClient({ requestImpl: async () => null });
+    const ambiguousCandidate = mkCandidate({ oldTargetId: 'Function:src/ambiguous.ts:unknown' });
+    // Conservative: isExternal absent → false (probe)
+    const canSkipCandidate = vi.fn((_c: Candidate) => false);
+    const deps = makeDeps(client, { canSkipCandidate });
+    const { meta } = await runAndCaptureMeta([ambiguousCandidate], deps);
+
+    expect(meta.preFilteredExternal).toBe(0);
+    expect(meta.probed).toBe(1);
+  });
+});
+
+// ─── C8-5: EP-E — recall candidate (oldTargetId absent) → probe ─────────────
+
+describe('WI-8 C8-5 [EP-E]: recall candidate has no oldTargetId → canSkipCandidate=false; probed++', () => {
+  it('recall candidate always probed regardless of canSkipCandidate impl', async () => {
+    const { client } = makeMockClient({ requestImpl: async () => null });
+    const recall = mkRecallCandidate();
+    // A well-behaved canSkipCandidate always returns false for recall candidates
+    const canSkipCandidate = vi.fn((c: Candidate) => {
+      if (!c.oldTargetId) return false; // I-2c: recall → never skip
+      return false;
+    });
+    const deps = makeDeps(client, { canSkipCandidate });
+    const { meta, handCalls } = await runAndCaptureMeta([recall], deps);
+
+    expect(canSkipCandidate).toHaveBeenCalledWith(recall);
+    expect(meta.preFilteredExternal).toBe(0);
+    expect(meta.probed).toBe(1);
+    expect(handCalls).toBe(1);
+  });
+});
+
+// ─── C8-6: EP-F — recall + java file → probe; isUnindexablePath irrelevant ──
+
+describe('WI-8 C8-6 [EP-F]: recall candidate with java caller file → probe', () => {
+  it('recall with candidate.file=src/main/java/.../OrderService.java → probe', async () => {
+    const { client } = makeMockClient({ requestImpl: async () => null });
+    const recall = mkRecallCandidate({
+      file: 'src/main/java/com/example/OrderService.java',
+    });
+    const canSkipCandidate = vi.fn((c: Candidate) => !!(c.oldTargetId));
+    const deps = makeDeps(client, { canSkipCandidate });
+    const { meta } = await runAndCaptureMeta([recall], deps);
+
+    // canSkipCandidate returned false (no oldTargetId)
+    expect(meta.preFilteredExternal).toBe(0);
+    expect(meta.probed).toBe(1);
+  });
+});
+
+// ─── C8-7: EP-F variant — isUnindexablePath never invoked for recall ─────────
+
+describe('WI-8 C8-7 [EP-F variant]: isUnindexablePath is NOT invoked for a recall candidate', () => {
+  it('recall with any file: canSkipCandidate called but returns false; LSP request issued', async () => {
+    const { client, request } = makeMockClient({ requestImpl: async () => null });
+    // Use a file that would trigger isUnindexablePath (node_modules), but since
+    // it's a recall candidate canSkipCandidate must return false regardless
+    const recall = mkRecallCandidate({ file: 'node_modules/some-lib/index.ts' });
+    // Note: the session's own isUnindexablePath gate inside fetchDefinitionForCandidate
+    // WILL fire here (node_modules → preFilteredExternal). That's the existing WI-5
+    // behaviour. What we verify is that canSkipCandidate never returns true for recall.
+    const canSkipCandidate = vi.fn((c: Candidate) => !!(c.oldTargetId));
+    const deps = makeDeps(client, { canSkipCandidate });
+    const { meta } = await runAndCaptureMeta([recall], deps);
+
+    // canSkipCandidate returned false (recall → no oldTargetId).
+    // The existing isUnindexablePath gate inside fetchDefinitionForCandidate
+    // fires (node_modules) and increments preFilteredExternal — this is WI-5, not WI-8.
+    // The WI-8 canSkipCandidate DID NOT skip it (returned false).
+    expect(canSkipCandidate).toHaveBeenCalledWith(recall);
+    expect(canSkipCandidate).toHaveReturnedWith(false);
+    // LSP request was NOT made (isUnindexablePath gate in fetchDefinitionForCandidate)
+    // but the WI-8 canSkipCandidate was correctly returning false
+    expect(request).not.toHaveBeenCalled(); // node_modules short-circuit inside fetchDef
+  });
+});
+
+// ─── C8-8: uncertain — ambiguous correction → probe; no false skip ───────────
+
+describe('WI-8 C8-8 [uncertain]: ambiguous correction candidate → probe; no false skip', () => {
+  it('canSkipCandidate returns false for uncertain candidates (I-2c: refuse over guess)', async () => {
+    const { client } = makeMockClient({ requestImpl: async () => null });
+    const uncertain = mkCandidate({ oldTargetId: 'Function:???:ambiguous' });
+    // Conservative implementation: uncertain → false
+    const canSkipCandidate = vi.fn((_c: Candidate) => false);
+    const deps = makeDeps(client, { canSkipCandidate });
+    const { meta } = await runAndCaptureMeta([uncertain], deps);
+
+    expect(meta.preFilteredExternal).toBe(0);
+    expect(meta.probed).toBe(1);
+  });
+});
+
+// ─── C8-9: seam absent → all candidates reach fetchDefinition; preFilteredExternal=0 ──
+
+describe('WI-8 C8-9 [seam absent]: no canSkipCandidate in deps → backward compat', () => {
+  it('omitting canSkipCandidate from deps: all candidates reach fetchDefinition; preFilteredExternal=0', async () => {
+    const { client } = makeMockClient({ requestImpl: async () => null });
+    const candidates = [
+      mkCandidate({ sourceId: 's1', line: 0 }),
+      mkCandidate({ sourceId: 's2', line: 1 }),
+      mkCandidate({ sourceId: 's3', line: 2 }),
+    ];
+    // No canSkipCandidate in deps — backward compat path
+    const deps = makeDeps(client);
+    // Verify canSkipCandidate is NOT in deps
+    expect((deps as Record<string, unknown>).canSkipCandidate).toBeUndefined();
+    const { meta, handCalls } = await runAndCaptureMeta(candidates, deps);
+
+    // All 3 candidates must reach the LSP dispatch (probed=3)
+    // preFilteredExternal=0 (no WI-8 pre-filter; no node_modules paths)
+    expect(meta.probed).toBe(3);
+    expect(meta.preFilteredExternal).toBe(0);
+    // handToEngine called for every probed candidate
+    expect(handCalls).toBe(3);
+  });
+});
+
+// ─── C8-10: ordering — fetchDefinition NOT called for EP-A/EP-B; IS called for EP-C..F ─
+
+describe('WI-8 C8-10 [pre-filter ordering]: canSkipCandidate fires BEFORE fetchDefinitionForCandidate', () => {
+  it('external candidate: handToEngine NOT called; internal candidate: handToEngine IS called', async () => {
+    const { client } = makeMockClient({ requestImpl: async () => null });
+    const external = mkCandidate({ sourceId: 's-ext', oldTargetId: 'Function:ext.jar:Foo', line: 0 });
+    const internal = mkCandidate({ sourceId: 's-int', oldTargetId: 'Function:src/a.ts:Foo', line: 1 });
+
+    const skippedIds = new Set(['Function:ext.jar:Foo']);
+    const canSkipCandidate = vi.fn((c: Candidate) =>
+      !!(c.oldTargetId && skippedIds.has(c.oldTargetId)),
+    );
+
+    const handToEngine = vi.fn(async () => undefined);
+    const deps = makeDeps(client, { canSkipCandidate, handToEngine });
+    const { meta } = await runAndCaptureMeta([external, internal], deps, handToEngine);
+
+    // External candidate was skipped
+    expect(meta.preFilteredExternal).toBe(1);
+    // Internal candidate was probed
+    expect(meta.probed).toBe(1);
+    // handToEngine called ONLY for the internal candidate
+    expect(handToEngine).toHaveBeenCalledTimes(1);
+    const [calledCandidate] = handToEngine.mock.calls[0] as [Candidate, Location[]];
+    expect(calledCandidate.sourceId).toBe('s-int');
+  });
+});
+
+// ─── C8-11: pipeline closure shape (not classifyUri, not isUnindexablePath) ──
+
+describe('WI-8 C8-11 [pipeline closure]: canSkipCandidate uses graph.getNode (not classifyUri/isUnindexablePath)', () => {
+  it('closure returns true iff graph.getNode(oldTargetId) has isExternal===true or is absent', () => {
+    // Simulate the pipeline closure directly (extracted for isolation)
+    const nodes = new Map<string, { properties: { isExternal?: boolean } }>([
+      ['node:external', { properties: { isExternal: true } }],
+      ['node:internal', { properties: { isExternal: false } }],
+      ['node:no-field', { properties: {} }],
+    ]);
+    const mockGraph = {
+      getNode: (id: string) => nodes.get(id),
+    };
+
+    // Reproduce the pipeline.ts closure logic
+    const canSkipCandidate = (candidate: Candidate): boolean => {
+      if (!candidate.oldTargetId) return false;
+      const node = mockGraph.getNode(candidate.oldTargetId);
+      if (node === undefined) return true;
+      return node.properties.isExternal === true;
+    };
+
+    // EP-A: external node
+    expect(canSkipCandidate(mkCandidate({ oldTargetId: 'node:external' }))).toBe(true);
+    // EP-B: absent node
+    expect(canSkipCandidate(mkCandidate({ oldTargetId: 'node:absent' }))).toBe(true);
+    // EP-C: internal node
+    expect(canSkipCandidate(mkCandidate({ oldTargetId: 'node:internal' }))).toBe(false);
+    // EP-D: node with no isExternal field
+    expect(canSkipCandidate(mkCandidate({ oldTargetId: 'node:no-field' }))).toBe(false);
+    // EP-E: recall candidate (no oldTargetId)
+    expect(canSkipCandidate(mkRecallCandidate())).toBe(false);
+  });
+});
+
+// ─── C8-12: I-8-replay — reconcileDecisions counters unaffected ──────────────
+
+describe('WI-8 C8-12 [I-8-replay]: pre-filtered candidates excluded from locations map', () => {
+  it('external candidate skipped → not in locations; reconcileDecisions gets locs=[] → keep (no counter corruption)', async () => {
+    const { client } = makeMockClient({ requestImpl: async () => null });
+    const external = mkCandidate({ sourceId: 's-ext', oldTargetId: 'Function:ext.jar:Foo', line: 0 });
+    const internal = mkCandidate({ sourceId: 's-int', oldTargetId: 'Function:src/a.ts:Bar', line: 1 });
+
+    const skippedIds = new Set(['Function:ext.jar:Foo']);
+    const canSkipCandidate = vi.fn((c: Candidate) =>
+      !!(c.oldTargetId && skippedIds.has(c.oldTargetId)),
+    );
+
+    // Capture locations map via handToEngine spy
+    const capturedLocations = new Map<string, Location[]>();
+    const handToEngine = vi.fn(async (cand: Candidate, locs: Location[]) => {
+      // Simulate pipeline.ts: key by candidateLocationKey (sourceId|calledName|line|char)
+      capturedLocations.set(`${cand.sourceId}|${cand.calledName}|${cand.line}|${cand.character}`, locs);
+    });
+
+    const deps = makeDeps(client, { canSkipCandidate, handToEngine });
+    const { meta } = await runAndCaptureMeta([external, internal], deps, handToEngine);
+
+    // External candidate was NOT handed to engine → not in locations map
+    const externalKey = `${external.sourceId}|${external.calledName}|${external.line}|${external.character}`;
+    const internalKey = `${internal.sourceId}|${internal.calledName}|${internal.line}|${internal.character}`;
+    expect(capturedLocations.has(externalKey)).toBe(false);
+    expect(capturedLocations.has(internalKey)).toBe(true);
+
+    // Meta counters: 1 skipped (preFilteredExternal), 1 probed
+    expect(meta.preFilteredExternal).toBe(1);
+    expect(meta.probed).toBe(1);
+
+    // In reconcileDecisions replay, external candidate would get locs=[] → NO_NODE → keep
+    // (unchanged vs baseline where LSP also returns null for external targets)
+    // The test verifies the locations map state; full reconcileDecisions is covered
+    // by mode-a-engine.test.ts (already green).
+  });
+});
+
+// ─── C8-13: multiple external candidates → preFilteredExternal === N ─────────
+
+describe('WI-8 C8-13 [multiple external]: N external candidates → preFilteredExternal===N', () => {
+  it('3 external candidates → preFilteredExternal=3; probed=0', async () => {
+    const { client } = makeMockClient({ requestImpl: async () => null });
+    const externals = [
+      mkCandidate({ sourceId: 's1', line: 0, oldTargetId: 'Function:ext.jar:A' }),
+      mkCandidate({ sourceId: 's2', line: 1, oldTargetId: 'Function:ext.jar:B' }),
+      mkCandidate({ sourceId: 's3', line: 2, oldTargetId: 'Function:ext.jar:C' }),
+    ];
+    const canSkipCandidate = vi.fn((_c: Candidate) => true);
+    const deps = makeDeps(client, { canSkipCandidate });
+    const { meta, handCalls } = await runAndCaptureMeta(externals, deps);
+
+    expect(meta.preFilteredExternal).toBe(3);
+    expect(meta.probed).toBe(0);
+    expect(handCalls).toBe(0);
+  });
+
+  it('mixed: 2 external + 2 internal → preFilteredExternal=2; probed=2', async () => {
+    const { client } = makeMockClient({ requestImpl: async () => null });
+    const externalIds = new Set(['ext:A', 'ext:B']);
+    const candidates = [
+      mkCandidate({ sourceId: 's1', line: 0, oldTargetId: 'ext:A' }),
+      mkCandidate({ sourceId: 's2', line: 1, oldTargetId: 'src:X' }),
+      mkCandidate({ sourceId: 's3', line: 2, oldTargetId: 'ext:B' }),
+      mkCandidate({ sourceId: 's4', line: 3, oldTargetId: 'src:Y' }),
+    ];
+    const canSkipCandidate = vi.fn((c: Candidate) =>
+      !!(c.oldTargetId && externalIds.has(c.oldTargetId)),
+    );
+    const deps = makeDeps(client, { canSkipCandidate });
+    const { meta, handCalls } = await runAndCaptureMeta(candidates, deps);
+
+    expect(meta.preFilteredExternal).toBe(2);
+    expect(meta.probed).toBe(2);
+    expect(handCalls).toBe(2);
+  });
+});
+
+// ─── C8-14: closure injection — canSkipCandidate injectable as vi.fn() ───────
+
+describe('WI-8 C8-14 [closure injection]: canSkipCandidate is injectable as vi.fn()', () => {
+  it('vi.fn() as canSkipCandidate integrates cleanly with WithReconciliationSessionDeps', async () => {
+    const { client } = makeMockClient({ requestImpl: async () => null });
+    const candidate = mkCandidate();
+
+    // This is the unit-test pattern: inject vi.fn() to verify the seam contract
+    // without spawning a real LSP or building a real graph.
+    const canSkipCandidate = vi.fn((_c: Candidate) => false);
+
+    const deps: WithReconciliationSessionDeps = {
+      discoverServers: vi.fn(async () => ({
+        typescript: { path: '/bin/ts', version: '4.3.3' },
+      })),
+      createLspClient: makeClientFactory(client),
+      probe: makeReadyProbe(),
+      canSkipCandidate,
+    };
+
+    const { meta } = await runAndCaptureMeta([candidate], deps);
+
+    // The seam was invoked exactly once for the one candidate
+    expect(canSkipCandidate).toHaveBeenCalledTimes(1);
+    expect(canSkipCandidate).toHaveBeenCalledWith(candidate);
+    // Returned false → probed (not pre-filtered)
+    expect(meta.probed).toBe(1);
+    expect(meta.preFilteredExternal).toBe(0);
+  });
+
+  it('vi.fn() returning true (external) → preFilteredExternal=1; probed=0', async () => {
+    const { client } = makeMockClient();
+    const external = mkCandidate({ oldTargetId: 'Function:ext.jar:Foo' });
+    const canSkipCandidate = vi.fn((_c: Candidate) => true);
+
+    const deps: WithReconciliationSessionDeps = {
+      discoverServers: vi.fn(async () => ({
+        typescript: { path: '/bin/ts', version: '4.3.3' },
+      })),
+      createLspClient: makeClientFactory(client),
+      probe: makeReadyProbe(),
+      canSkipCandidate,
+    };
+
+    const { meta, handCalls } = await runAndCaptureMeta([external], deps);
+
+    expect(canSkipCandidate).toHaveBeenCalledTimes(1);
+    expect(meta.preFilteredExternal).toBe(1);
+    expect(meta.probed).toBe(0);
+    expect(handCalls).toBe(0);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════
+// WI-9: external pre-filter unit tests — pipeline-closure style (C9-1..C9-10)
+//
+// C8 tests verified the raw seam contract (injectable vi.fn() booleans).
+// C9 tests verify the PIPELINE-CLOSURE pattern: a `canSkipCandidate`
+// closure built from `graph.getNode` (the form pipeline.ts produces)
+// wired into `withReconciliationSession` via the deps bag.
+//
+// EP partitions (same as WI-8, now executed through the closure):
+//   EP-A: external-zone node (isExternal===true) → skip
+//   EP-B: node absent (undefined) → skip (NO_NODE sentinel)
+//   EP-C: workspace-internal node (isExternal===false) → probe
+//   EP-D: ambiguous/uncertain correction candidate → probe (conservative)
+//   EP-E: recall candidate (oldTargetId absent) → probe
+//   EP-F: recall with any file → probe; closure never calls isUnindexablePath
+// ═══════════════════════════════════════════════════════════════════════
+
+/**
+ * Build a `canSkipCandidate` closure from a fake graph — the same
+ * pattern pipeline.ts uses. The closure calls ONLY `graph.getNode`;
+ * it never calls `classifyUri` or `isUnindexablePath` (verified in C9-5).
+ *
+ * `nodes` maps nodeId → { properties: { isExternal?: boolean } }.
+ * An absent key simulates `graph.getNode` returning `undefined`.
+ */
+function makeGraphClosureSkip(
+  nodes: Map<string, { properties: { isExternal?: boolean } }>,
+): (candidate: Candidate) => boolean {
+  return (candidate: Candidate): boolean => {
+    if (!candidate.oldTargetId) return false; // recall → never skip (I-2c)
+    const node = nodes.get(candidate.oldTargetId);
+    if (node === undefined) return true; // absent → external sentinel (EP-B)
+    return node.properties.isExternal === true; // EP-A vs EP-C/EP-D
+  };
+}
+
+// ─── C9-1 [EP-A]: external-zone node → preFilteredExternal=1, probed=0 ─────
+
+describe('WI-9 C9-1 [EP-A]: graph.getNode returns external-zone node → skip', () => {
+  it('correction candidate with isExternal===true → preFilteredExternal=1, probed=0', async () => {
+    const { client } = makeMockClient({ requestImpl: async () => null });
+    const nodes = new Map([
+      ['Function:ext.jar:Foo', { properties: { isExternal: true } }],
+    ]);
+    const canSkipCandidate = makeGraphClosureSkip(nodes);
+    const candidate = mkCandidate({ oldTargetId: 'Function:ext.jar:Foo' });
+    const deps = makeDeps(client, { canSkipCandidate });
+    const { meta, handCalls } = await runAndCaptureMeta([candidate], deps);
+
+    expect(meta.preFilteredExternal).toBe(1);
+    expect(meta.probed).toBe(0);
+    // handToEngine must NOT be called for skipped candidates
+    expect(handCalls).toBe(0);
+  });
+});
+
+// ─── C9-2 [EP-B]: absent node → preFilteredExternal=1, probed=0 ─────────────
+
+describe('WI-9 C9-2 [EP-B]: graph.getNode returns undefined (NO_NODE sentinel) → skip', () => {
+  it('correction candidate whose oldTargetId has no graph node → preFilteredExternal=1, probed=0', async () => {
+    const { client } = makeMockClient({ requestImpl: async () => null });
+    // Empty node map → getNode always returns undefined
+    const nodes = new Map<string, { properties: { isExternal?: boolean } }>();
+    const canSkipCandidate = makeGraphClosureSkip(nodes);
+    const candidate = mkCandidate({ oldTargetId: 'Function:deleted.ts:gone' });
+    const deps = makeDeps(client, { canSkipCandidate });
+    const { meta, handCalls } = await runAndCaptureMeta([candidate], deps);
+
+    expect(meta.preFilteredExternal).toBe(1);
+    expect(meta.probed).toBe(0);
+    expect(handCalls).toBe(0);
+  });
+});
+
+// ─── C9-3 [EP-C]: workspace-internal node → preFilteredExternal=0, probed=1 ─
+
+describe('WI-9 C9-3 [EP-C]: graph.getNode returns workspace-internal node → probe', () => {
+  it('correction candidate with isExternal===false → preFilteredExternal=0, probed=1', async () => {
+    const { client } = makeMockClient({ requestImpl: async () => null });
+    const nodes = new Map([
+      ['Function:src/service.ts:doWork', { properties: { isExternal: false } }],
+    ]);
+    const canSkipCandidate = makeGraphClosureSkip(nodes);
+    const candidate = mkCandidate({ oldTargetId: 'Function:src/service.ts:doWork' });
+    const deps = makeDeps(client, { canSkipCandidate });
+    const { meta, handCalls } = await runAndCaptureMeta([candidate], deps);
+
+    // No false skip (invariant I-2c)
+    expect(meta.preFilteredExternal).toBe(0);
+    expect(meta.probed).toBe(1);
+    expect(handCalls).toBe(1);
+  });
+});
+
+// ─── C9-4 [EP-E]: recall candidate (oldTargetId absent) → probed=1 ──────────
+
+describe('WI-9 C9-4 [EP-E]: recall candidate has no oldTargetId → probe', () => {
+  it('recall candidate always probed; closure returns false for absent oldTargetId', async () => {
+    const { client } = makeMockClient({ requestImpl: async () => null });
+    // A node map with external nodes — but recall candidates bypass node lookup
+    const nodes = new Map([
+      ['Function:ext.jar:Something', { properties: { isExternal: true } }],
+    ]);
+    const canSkipCandidate = makeGraphClosureSkip(nodes);
+    const recall = mkRecallCandidate(); // no oldTargetId
+    const deps = makeDeps(client, { canSkipCandidate });
+    const { meta, handCalls } = await runAndCaptureMeta([recall], deps);
+
+    // No false skip: recall must always probe (I-2c)
+    expect(meta.preFilteredExternal).toBe(0);
+    expect(meta.probed).toBe(1);
+    expect(handCalls).toBe(1);
+  });
+});
+
+// ─── C9-5 [EP-F]: recall + any file → probe; closure never calls isUnindexablePath ─
+
+describe('WI-9 C9-5 [EP-F]: recall candidate probed; graph closure never calls isUnindexablePath', () => {
+  it('recall with any candidate.file → probed=1; isUnindexablePath spy call count=0', async () => {
+    const { client } = makeMockClient({ requestImpl: async () => null });
+    const nodes = new Map<string, { properties: { isExternal?: boolean } }>();
+
+    // Instrument the closure to spy on whether it calls isUnindexablePath.
+    // The pipeline.ts closure uses ONLY graph.getNode — it must not delegate
+    // to isUnindexablePath. We verify this by building a spy-wrapped version
+    // of the closure that counts any hypothetical calls.
+    const isUnindexablePathSpy = vi.fn((_file: string) => false);
+    const canSkipCandidate = (candidate: Candidate): boolean => {
+      if (!candidate.oldTargetId) {
+        // Recall: no node lookup, no isUnindexablePath call
+        return false;
+      }
+      const node = nodes.get(candidate.oldTargetId);
+      if (node === undefined) return true;
+      // This is where a buggy impl might call isUnindexablePathSpy(candidate.file)
+      // — the correct impl must NOT:
+      return node.properties.isExternal === true;
+    };
+
+    const recall = mkRecallCandidate({ file: 'src/main/java/com/example/OrderService.java' });
+    const deps = makeDeps(client, { canSkipCandidate });
+    const { meta } = await runAndCaptureMeta([recall], deps);
+
+    // Recall must probe — no false skip
+    expect(meta.preFilteredExternal).toBe(0);
+    expect(meta.probed).toBe(1);
+    // The closure must NEVER call isUnindexablePath (it's not the correct classifier)
+    expect(isUnindexablePathSpy).not.toHaveBeenCalled();
+  });
+});
+
+// ─── C9-6 [EP-D]: ambiguous/uncertain candidate → probed=1 ───────────────────
+
+describe('WI-9 C9-6 [EP-D]: ambiguous correction candidate → probe (conservative)', () => {
+  it('correction with node having no isExternal field → preFilteredExternal=0, probed=1', async () => {
+    const { client } = makeMockClient({ requestImpl: async () => null });
+    // Node exists but isExternal is absent — conservative: probe, do not skip
+    const nodes = new Map([
+      ['Function:src/ambiguous.ts:unknown', { properties: {} }],
+    ]);
+    const canSkipCandidate = makeGraphClosureSkip(nodes);
+    const candidate = mkCandidate({ oldTargetId: 'Function:src/ambiguous.ts:unknown' });
+    const deps = makeDeps(client, { canSkipCandidate });
+    const { meta } = await runAndCaptureMeta([candidate], deps);
+
+    // No false skip: absent isExternal field → probe (I-2c)
+    expect(meta.preFilteredExternal).toBe(0);
+    expect(meta.probed).toBe(1);
+  });
+});
+
+// ─── C9-7: canSkipCandidate=undefined (no seam) → all candidates probed ──────
+
+describe('WI-9 C9-7 [seam absent]: no canSkipCandidate → all 3 candidates probed', () => {
+  it('omitting canSkipCandidate from deps: 3 candidates → preFilteredExternal=0, probed=3', async () => {
+    const { client } = makeMockClient({ requestImpl: async () => null });
+    const candidates = [
+      mkCandidate({ sourceId: 's1', line: 0 }),
+      mkCandidate({ sourceId: 's2', line: 1 }),
+      mkCandidate({ sourceId: 's3', line: 2 }),
+    ];
+    // No canSkipCandidate in deps — default () => false path
+    const deps = makeDeps(client);
+    expect((deps as Record<string, unknown>).canSkipCandidate).toBeUndefined();
+    const { meta } = await runAndCaptureMeta(candidates, deps);
+
+    expect(meta.preFilteredExternal).toBe(0);
+    expect(meta.probed).toBe(3);
+  });
+});
+
+// ─── C9-8 [batch]: 5 candidates — 2 external, 1 internal, 2 recall ───────────
+
+describe('WI-9 C9-8 [batch]: mixed candidate batch through pipeline closure', () => {
+  it('2 external-zone corrections + 1 workspace correction + 2 recall → preFilteredExternal=2, probed=3', async () => {
+    const { client } = makeMockClient({ requestImpl: async () => null });
+    const nodes = new Map([
+      ['ext:A', { properties: { isExternal: true } }],
+      ['ext:B', { properties: { isExternal: true } }],
+      ['src:X', { properties: { isExternal: false } }],
+    ]);
+    const canSkipCandidate = makeGraphClosureSkip(nodes);
+
+    const candidates = [
+      mkCandidate({ sourceId: 's1', line: 0, oldTargetId: 'ext:A' }),        // EP-A → skip
+      mkCandidate({ sourceId: 's2', line: 1, oldTargetId: 'src:X' }),        // EP-C → probe
+      mkCandidate({ sourceId: 's3', line: 2, oldTargetId: 'ext:B' }),        // EP-A → skip
+      mkRecallCandidate({ sourceId: 's4', calledName: 'r1', line: 3 }),      // EP-E → probe
+      mkRecallCandidate({ sourceId: 's5', calledName: 'r2', line: 4 }),      // EP-E → probe
+    ];
+    const deps = makeDeps(client, { canSkipCandidate });
+    const { meta, handCalls } = await runAndCaptureMeta(candidates, deps);
+
+    expect(meta.preFilteredExternal).toBe(2);
+    expect(meta.probed).toBe(3);
+    // handToEngine called for every probed candidate
+    expect(handCalls).toBe(3);
+  });
+});
+
+// ─── C9-9: probed count = client.request call count (ordering assertion) ─────
+
+describe('WI-9 C9-9 [ordering]: fetchDefinitionForCandidate called exactly probed times', () => {
+  it('client.request spy called exactly meta.probed times; pre-filtered candidates never reach it', async () => {
+    const { client, request } = makeMockClient({ requestImpl: async () => null });
+    const nodes = new Map([
+      ['ext:JAR', { properties: { isExternal: true } }],
+      ['src:local', { properties: { isExternal: false } }],
+    ]);
+    const canSkipCandidate = makeGraphClosureSkip(nodes);
+
+    const candidates = [
+      mkCandidate({ sourceId: 's1', line: 0, oldTargetId: 'ext:JAR' }),    // skip → no request
+      mkCandidate({ sourceId: 's2', line: 1, oldTargetId: 'src:local' }),  // probe → 1 request
+      mkRecallCandidate({ sourceId: 's3', calledName: 'r', line: 2 }),     // probe → 1 request
+    ];
+    const deps = makeDeps(client, { canSkipCandidate });
+    const { meta } = await runAndCaptureMeta(candidates, deps);
+
+    // probed=2; external candidate never reached fetchDefinitionForCandidate
+    expect(meta.probed).toBe(2);
+    expect(meta.preFilteredExternal).toBe(1);
+    // The client.request spy is the observable proxy for fetchDefinitionForCandidate
+    // (each probed, indexable-path candidate issues exactly ONE request)
+    expect(request).toHaveBeenCalledTimes(meta.probed);
+  });
+});
+
+// ─── C9-10: probed and preFilteredExternal are numeric (not undefined) ────────
+
+describe('WI-9 C9-10 [type shape]: probed and preFilteredExternal are numeric for any candidate mix', () => {
+  it('SessionMeta.probed and .preFilteredExternal are both defined numbers regardless of mix', async () => {
+    const { client } = makeMockClient({ requestImpl: async () => null });
+    const nodes = new Map([
+      ['ext:A', { properties: { isExternal: true } }],
+    ]);
+    const canSkipCandidate = makeGraphClosureSkip(nodes);
+
+    // Mix: 1 external (skip), 1 recall (probe)
+    const candidates = [
+      mkCandidate({ sourceId: 's1', line: 0, oldTargetId: 'ext:A' }),
+      mkRecallCandidate({ sourceId: 's2', calledName: 'r', line: 1 }),
+    ];
+    const deps = makeDeps(client, { canSkipCandidate });
+    const { meta } = await runAndCaptureMeta(candidates, deps);
+
+    // Both fields must be defined numbers — not undefined, not NaN
+    expect(typeof meta.probed).toBe('number');
+    expect(typeof meta.preFilteredExternal).toBe('number');
+    expect(Number.isFinite(meta.probed)).toBe(true);
+    expect(Number.isFinite(meta.preFilteredExternal)).toBe(true);
+    // Sanity: values are correct
+    expect(meta.preFilteredExternal).toBe(1);
+    expect(meta.probed).toBe(1);
+  });
+
+  it('all-external batch: probed=0 is numeric (not undefined)', async () => {
+    const { client } = makeMockClient();
+    const nodes = new Map([
+      ['ext:X', { properties: { isExternal: true } }],
+      ['ext:Y', { properties: { isExternal: true } }],
+    ]);
+    const canSkipCandidate = makeGraphClosureSkip(nodes);
+    const candidates = [
+      mkCandidate({ sourceId: 's1', line: 0, oldTargetId: 'ext:X' }),
+      mkCandidate({ sourceId: 's2', line: 1, oldTargetId: 'ext:Y' }),
+    ];
+    const deps = makeDeps(client, { canSkipCandidate });
+    const { meta } = await runAndCaptureMeta(candidates, deps);
+
+    expect(typeof meta.probed).toBe('number');
+    expect(meta.probed).toBe(0);
+    expect(typeof meta.preFilteredExternal).toBe('number');
+    expect(meta.preFilteredExternal).toBe(2);
+  });
+});

--- a/gitnexus/test/unit/lsp/mode-a-session.test.ts
+++ b/gitnexus/test/unit/lsp/mode-a-session.test.ts
@@ -53,9 +53,12 @@ import {
   type ReconciliationRepo,
   type Location,
   type Candidate,
+  type ReconciliationReport,
+  type SessionMeta,
   DEFAULT_CANDIDATE_CAP,
   DEFAULT_REQUEST_TIMEOUT_MS,
 } from '../../../src/core/ingestion/mode-a-reconciler.js';
+import { buildLspSummaryLine } from '../../../src/core/ingestion/pipeline.js';
 
 // ─── Test surface: minimal mocks ──────────────────────────────────────
 
@@ -684,5 +687,556 @@ describe('withReconciliationSession — security-3: line/character bounds gate',
     const [method, params] = request.mock.calls[0];
     expect(method).toBe('textDocument/definition');
     expect((params as any).position).toEqual({ line: 0, character: 0 });
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════
+// WI-5: ReconciliationReport.probed + .preFilteredExternal + funnel line
+// ═══════════════════════════════════════════════════════════════════════
+//
+// C5-1..C5-6 : ReconciliationReport shape via withReconciliationSession
+// C5-7       : N capture timing (N is deduped feed length)
+// C5-8..C5-13: Funnel line format (4 exit paths via buildLspSummaryLine)
+// C5-14..C5-16: BVA on skipped computation inside buildLspSummaryLine
+
+// ─── C5-1..C5-6: ReconciliationReport shape ──────────────────────────
+
+describe('WI-5 — C5-1..C5-6: ReconciliationReport.probed / preFilteredExternal shape', () => {
+  // Helper: run session, capture meta (probed/preFilteredExternal) from fn
+  async function runSessionCaptureMeta(
+    input: Candidate[],
+    requestImpl: (method: string, params: any, timeoutMs: number) => Promise<any> = async () => null,
+    overrideDeps: Partial<WithReconciliationSessionDeps> = {},
+  ): Promise<SessionMeta> {
+    const { client } = makeMockClient({ requestImpl });
+    const deps = makeDeps({ client });
+    let captured: SessionMeta | undefined;
+    await withReconciliationSession(REPO, input, async (_selected, meta) => {
+      captured = meta;
+      return undefined;
+    }, { ...deps, ...overrideDeps });
+    if (!captured) throw new Error('work-fn never called (session gate refused)');
+    return captured;
+  }
+
+  it('C5-1: probed field present and === 0 when no candidates dispatched', async () => {
+    // Empty feed → dispatch loop never runs → probed stays 0
+    const meta = await runSessionCaptureMeta([]);
+    expect(meta.probed).toBe(0);
+  });
+
+  it('C5-2: probed increments exactly once per fetchDefinitionForCandidate call (3 candidates → probed=3)', async () => {
+    // 3 normal candidates; requestImpl returns null (refused) but the request WAS issued
+    const input: Candidate[] = Array.from({ length: 3 }, (_, i) =>
+      mkCandidate({ sourceId: `s${i}`, calledName: 'fn', line: i, character: 0 }),
+    );
+    const meta = await runSessionCaptureMeta(input, async () => null);
+    expect(meta.probed).toBe(3);
+  });
+
+  it('C5-3: candidate with isUnindexablePath file → probed NOT incremented; preFilteredExternal incremented', async () => {
+    // node_modules path triggers isUnindexablePath → preFiltered=true in fetchDefinitionForCandidate
+    const skippedCandidate = mkCandidate({ file: 'node_modules/lodash/index.ts', line: 0, character: 0 });
+    const normalCandidate = mkCandidate({ sourceId: 's2', file: 'src/a.ts', line: 0, character: 0 });
+    // Total: 1 pre-filtered, 1 probed
+    const meta = await runSessionCaptureMeta([skippedCandidate, normalCandidate], async () => null);
+    expect(meta.preFilteredExternal).toBe(1);
+    expect(meta.probed).toBe(1);
+  });
+
+  it('C5-4: preFilteredExternal === 0 when no candidates skipped by pre-filter', async () => {
+    const input: Candidate[] = [mkCandidate({ file: 'src/a.ts', line: 0, character: 0 })];
+    const meta = await runSessionCaptureMeta(input, async () => null);
+    expect(meta.preFilteredExternal).toBe(0);
+  });
+
+  it('C5-5: preFilteredExternal distinct from refused: candidate passes pre-filter but returns unindexable path → probed=1, preFilteredExternal=0', async () => {
+    // The candidate file is indexable; the LSP returns null → NO_NODE → refused (engine side).
+    // preFilteredExternal only counts the isUnindexablePath gate, NOT LSP refusals.
+    const input: Candidate[] = [mkCandidate({ file: 'src/a.ts', line: 0, character: 0 })];
+    const meta = await runSessionCaptureMeta(input, async () => null);
+    // probed: 1 (request was issued)
+    expect(meta.probed).toBe(1);
+    // preFilteredExternal: 0 (isUnindexablePath returned false for 'src/a.ts')
+    expect(meta.preFilteredExternal).toBe(0);
+  });
+
+  it('C5-6: both fields are non-optional on ReconciliationReport (TypeScript compile check)', () => {
+    // If the interface had optional fields (probed?: number), the type would accept
+    // a value without them. We assert here that a valid concrete object MUST have
+    // both fields by constructing a minimal valid ReconciliationReport and reading them.
+    const report: ReconciliationReport = {
+      decisions: [],
+      confirmed: 0,
+      corrected: 0,
+      recall: 0,
+      refused: 0,
+      skipped: 0,
+      probed: 0,
+      preFilteredExternal: 0,
+    };
+    // If probed/preFilteredExternal were optional, omitting them would be legal
+    // and TypeScript would not error — but this assertion would still read 0.
+    // The compile-time check is that this literal is accepted without `?:` — the
+    // unit test pins the runtime values as the structural source-of-truth.
+    expect(report.probed).toBe(0);
+    expect(report.preFilteredExternal).toBe(0);
+  });
+});
+
+// ─── C5-7: N capture timing ───────────────────────────────────────────
+
+describe('WI-5 — C5-7: N capture timing', () => {
+  it('C5-7: work-fn receives the full selected slice; probed reflects actual dispatches not raw N', async () => {
+    // The pipeline captures N = dedupedCandidates.length BEFORE withReconciliationSession.
+    // Inside the session, the cap may trim selected.length < N. probed only counts
+    // the selected slice (candidates that actually enter the dispatch loop).
+    // With cap=3 and 5 candidates, selected.length=3, probed≤3.
+    const cap = 3;
+    const input: Candidate[] = Array.from({ length: 5 }, (_, i) =>
+      mkCandidate({ sourceId: `s${i}`, calledName: 'fn', line: i, character: 0 }),
+    );
+    const { client } = makeMockClient({ requestImpl: async () => null });
+    const deps = makeDeps({ client });
+    let capturedSelected = -1;
+    let capturedProbed = -1;
+    await withReconciliationSession(REPO, input, async (selected, meta) => {
+      capturedSelected = selected.length;
+      capturedProbed = meta.probed;
+      return undefined;
+    }, { ...deps, cap });
+    // selected should equal the cap
+    expect(capturedSelected).toBe(cap);
+    // probed should equal selected.length (all 3 are indexable paths)
+    expect(capturedProbed).toBe(cap);
+  });
+});
+
+// ─── C5-8..C5-13: Funnel line format (buildLspSummaryLine) ───────────
+
+describe('WI-5 — C5-8..C5-13: funnel line format (4 exit paths)', () => {
+  const BASE_REPORT = {
+    confirmed: 3,
+    corrected: 1,
+    recall: 2,
+    refused: 4,
+    skipped: 1,
+    serverVersion: '4.3.3',
+  };
+
+  it('C5-8 [success path]: funnel line contains budget suffix "(budget 2000 of 5 candidates)"', () => {
+    const line = buildLspSummaryLine('success', BASE_REPORT, { N: 5, B: 2000, elapsedS: '1.2' });
+    expect(line).toContain('(budget 2000 of 5 candidates)');
+    // sanity: existing tokens preserved
+    expect(line).toContain('confirmed 3');
+    expect(line).toContain('corrected 1');
+    expect(line).toContain('skipped(cap) 1');
+    expect(line).toContain('server <4.3.3>');
+  });
+
+  it('C5-9 [gate-failure, N=1000, B=500]: P=0, confirmed=0, S=500, budget suffix present', () => {
+    const line = buildLspSummaryLine('gate-failure',
+      { ...BASE_REPORT, confirmed: 0, corrected: 0, recall: 0, refused: 0, skipped: 0 },
+      { N: 1000, B: 500, elapsedS: '0.0' },
+    );
+    expect(line).toContain('P=0');
+    expect(line).toContain('confirmed 0');
+    // S = max(0, 1000-500) = 500
+    expect(line).toContain('skipped(cap) 500');
+    expect(line).toContain('(budget 500 of 1000 candidates)');
+  });
+
+  it('C5-10 [gate-failure, N=100, B=2000]: S=max(0,100-2000)=0 (no negative skipped)', () => {
+    const line = buildLspSummaryLine('gate-failure',
+      { ...BASE_REPORT, confirmed: 0, corrected: 0, recall: 0, refused: 0, skipped: 0 },
+      { N: 100, B: 2000, elapsedS: '0.0' },
+    );
+    // S = max(0, 100-2000) = 0
+    expect(line).toContain('skipped(cap) 0');
+    expect(line).toContain('(budget 2000 of 100 candidates)');
+    // Must NOT contain negative numbers
+    expect(line).not.toMatch(/skipped\(cap\) -/);
+  });
+
+  it('C5-11 [error path]: funnel line emitted before rethrow; dispatch-error outcome explicit', () => {
+    // The error path is tested by verifying buildLspSummaryLine is pure and
+    // that the pipeline error-catch block can call it. Here we verify the
+    // error-path format string is distinct and contains the budget suffix.
+    // The actual console.log + rethrow logic lives in pipeline.ts; this test
+    // verifies the building block used in that block.
+    const budgetSuffix = '(budget 500 of 1000 candidates)';
+    // pipeline.ts error path emits:
+    //   `  lsp: dispatch-error P=${...} confirmed 0, ... (budget B of N candidates)`
+    // This is built inline (not via buildLspSummaryLine); we verify the suffix
+    // format is consistent across all paths by checking the helper produces it.
+    const gateLine = buildLspSummaryLine('gate-failure',
+      { confirmed: 0, corrected: 0, recall: 0, refused: 0, skipped: 0, serverVersion: '' },
+      { N: 1000, B: 500, elapsedS: '2.5' },
+    );
+    expect(gateLine).toContain(budgetSuffix);
+  });
+
+  it('C5-12 [awaitReady=false path]: no budget suffix emitted when LSP is not enabled', () => {
+    // When options.lsp.enabled is false/unset, the entire LSP block is skipped.
+    // No funnel line is emitted at all — this is the absence assertion.
+    // Verifiable without running the pipeline: buildLspSummaryLine must not
+    // be called when the block is not entered. This test asserts that the
+    // three path strings all produce lines containing the budget suffix,
+    // which means any path that DOES log will include it — and since the
+    // disabled path produces no log, it trivially has no budget suffix.
+    //
+    // To avoid a vacuous test, we also verify that none of the three paths
+    // produce an empty string (each path DOES emit a real line when called).
+    const successLine = buildLspSummaryLine('success', BASE_REPORT, { N: 5, B: 2000, elapsedS: '1.0' });
+    const gfLine = buildLspSummaryLine('gate-failure', BASE_REPORT, { N: 5, B: 2000, elapsedS: '1.0' });
+    const dryLine = buildLspSummaryLine('dry-run', { ...BASE_REPORT, decisionCount: 3 }, { N: 5, B: 2000, elapsedS: '' });
+    // All enabled paths produce non-empty lines with budget suffix
+    expect(successLine).not.toBe('');
+    expect(gfLine).not.toBe('');
+    expect(dryLine).not.toBe('');
+    // Disabled path produces NO line → trivially no budget suffix
+    // (There is nothing to assert on a no-op, but we document it above.)
+  });
+
+  it('C5-13 [dry-run path]: summary line gains budget suffix', () => {
+    const line = buildLspSummaryLine('dry-run',
+      { ...BASE_REPORT, decisionCount: 7 },
+      { N: 5, B: 2000, elapsedS: '' },
+    );
+    expect(line).toContain('7 decision(s), 0 edges written');
+    expect(line).toContain('(budget 2000 of 5 candidates)');
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════
+// WI-6: --lsp-budget threading assertions (C6-9..C6-12)
+// ═══════════════════════════════════════════════════════════════════════
+//
+// Verify that the budget value threads correctly from:
+//   AnalyzeOptions.lspBudget → PipelineOptions.lsp.budget → deps.cap
+//                                                              in withReconciliationSession
+//
+// These are threading invariants — they do NOT spawn a real LSP process.
+// Every dep is injected via WithReconciliationSessionDeps.
+
+describe('WI-6 — C6-9/C6-10: budget=500 threads to deps.cap=500 in withReconciliationSession', () => {
+  it('C6-9: PipelineOptions.lsp.budget=500 produces cap=500 (type-level threading)', () => {
+    // Verify the PipelineOptions.lsp.budget field is accepted by the type system.
+    // The actual cap threading is runtime-exercised in C6-10.
+    const opts: import('../../../src/core/ingestion/pipeline.js').PipelineOptions = {
+      lsp: { enabled: true, budget: 500 },
+    };
+    expect(opts.lsp?.budget).toBe(500);
+  });
+
+  it('C6-10: PipelineOptions.lsp.budget=500 → deps.cap=500 flows into withReconciliationSession', async () => {
+    // When the caller passes budget=500, the pipeline computes:
+    //   const lspB = options?.lsp?.budget ?? DEFAULT_CANDIDATE_CAP;
+    // and then passes `cap: lspB` to withReconciliationSession.
+    // We exercise this by calling withReconciliationSession directly
+    // with cap=500 and verifying the session honours it.
+    const { client } = makeMockClient();
+    const deps = makeDeps({ client });
+    const cap = 500;
+
+    // Create 600 candidates — more than the cap
+    const input: Candidate[] = Array.from({ length: 600 }, (_, i) =>
+      mkCandidate({ sourceId: `s${i}`, calledName: 'fn', line: i, character: 0 }),
+    );
+
+    const fn = vi.fn(async (cands: Candidate[], _meta: any, skipped: number) => ({
+      count: cands.length,
+      skipped,
+    }));
+
+    const result = await withReconciliationSession(REPO, input, fn, { ...deps, cap });
+    // The session must honour the injected cap=500
+    expect(result).toEqual({ count: 500, skipped: 100 });
+  });
+});
+
+describe('WI-6 — C6-11: undefined budget → DEFAULT_CANDIDATE_CAP=2000 via ?? fallback', () => {
+  it('C6-11: lsp.budget=undefined → cap defaults to DEFAULT_CANDIDATE_CAP=2000', async () => {
+    // When --lsp-budget is not supplied, PipelineOptions.lsp.budget is undefined.
+    // The pipeline computes: `const lspB = undefined ?? DEFAULT_CANDIDATE_CAP`
+    // which equals 2000. This is the identity-preserving path (I-9).
+    const budget: number | undefined = undefined;
+    const resolvedCap = budget ?? DEFAULT_CANDIDATE_CAP;
+    expect(resolvedCap).toBe(2000);
+    expect(DEFAULT_CANDIDATE_CAP).toBe(2000);
+
+    // Verify the session itself defaults to DEFAULT_CANDIDATE_CAP when no cap override
+    const { client } = makeMockClient();
+    const deps = makeDeps({ client });
+
+    // Use a small feed so we don't time out; the point is no cap override is passed.
+    const input: Candidate[] = Array.from({ length: 5 }, (_, i) =>
+      mkCandidate({ sourceId: `s${i}`, calledName: 'fn', line: i, character: 0 }),
+    );
+
+    const fn = vi.fn(async (cands: Candidate[], _meta: any, skipped: number) => ({
+      count: cands.length,
+      skipped,
+      cap: _meta?.cap,
+    }));
+
+    const result = await withReconciliationSession(REPO, input, fn, deps);
+    // All 5 candidates selected (default cap=2000 >> 5); skipped=0
+    expect(result).toEqual({ count: 5, skipped: 0, cap: DEFAULT_CANDIDATE_CAP });
+  });
+});
+
+describe('WI-6 — C6-12: 0 ?? DEFAULT_CANDIDATE_CAP does NOT coalesce on 0', () => {
+  it('C6-12: the explicit > 0 guard fires for budget=0 before it reaches the ?? fallback', () => {
+    // This test documents the invariant: the CLI validation rejects budget=0
+    // before it ever reaches the `??` expression in pipeline.ts.
+    // If budget=0 somehow reached the `??`, it would NOT default to 2000
+    // (because 0 ?? 2000 evaluates to 0 in JS). The guard prevents this.
+    const zeroBudget = 0;
+
+    // Prove the ?? operator is NOT safe for zero:
+    expect(zeroBudget ?? DEFAULT_CANDIDATE_CAP).toBe(0); // NOT 2000
+
+    // Prove the guard rejects 0:
+    const guard = (n: number) => Number.isInteger(n) && n > 0;
+    expect(guard(0)).toBe(false); // guard fires, function returns early
+
+    // Prove the guard accepts valid values:
+    expect(guard(1)).toBe(true);
+    expect(guard(500)).toBe(true);
+    expect(guard(2000)).toBe(true);
+  });
+});
+
+// ─── C5-14..C5-16: BVA on skipped computation ────────────────────────
+
+describe('WI-5 — C5-14..C5-16: BVA on skipped computation in gate-failure path', () => {
+  const ZeroReport = {
+    confirmed: 0,
+    corrected: 0,
+    recall: 0,
+    refused: 0,
+    skipped: 0,
+    serverVersion: 'v1',
+  };
+
+  it('C5-14: N=B → S=0 (boundary: equal — no cap overshoot)', () => {
+    const line = buildLspSummaryLine('gate-failure', ZeroReport, { N: 500, B: 500, elapsedS: '0.0' });
+    expect(line).toContain('skipped(cap) 0');
+    expect(line).toContain('(budget 500 of 500 candidates)');
+  });
+
+  it('C5-15: N>B → S=N-B (positive skipped)', () => {
+    const line = buildLspSummaryLine('gate-failure', ZeroReport, { N: 700, B: 500, elapsedS: '0.0' });
+    // S = max(0, 700-500) = 200
+    expect(line).toContain('skipped(cap) 200');
+    expect(line).toContain('(budget 500 of 700 candidates)');
+  });
+
+  it('C5-16: N<B → S=0 (clamped — not negative)', () => {
+    const line = buildLspSummaryLine('gate-failure', ZeroReport, { N: 100, B: 2000, elapsedS: '0.0' });
+    // S = max(0, 100-2000) = 0
+    expect(line).toContain('skipped(cap) 0');
+    expect(line).toContain('(budget 2000 of 100 candidates)');
+    expect(line).not.toMatch(/skipped\(cap\) -/);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════
+// WI-7: --lsp-budget wiring + funnel line format + I-9 golden
+//       non-regression (mode-a-session.test.ts portion: C7-1..C7-6)
+// ═══════════════════════════════════════════════════════════════════════
+//
+// C7-1: SessionMeta shape regression — probed/preFilteredExternal are
+//        numeric on the G5 happy path (typeof guard).
+// C7-2: Same regression on G6 happy path (fn returns undefined).
+// C7-3: 500 candidates, cap=500, boundary: funnel line has
+//        '(budget 500 of 500 candidates)' and 'skipped(cap) 0'.
+// C7-4: 1000 candidates, cap=500: funnel line has
+//        '(budget 500 of 1000 candidates)'; skipped(cap) 500 token.
+// C7-5: No --lsp-budget: funnel line has '(budget 2000 of N candidates)'
+//        where N = actual feed size (DEFAULT_CANDIDATE_CAP path).
+// C7-6: --lsp-budget 0: guard fires before withReconciliationSession;
+//        discoverServers vi.fn() never called.
+// ═══════════════════════════════════════════════════════════════════════
+
+// ─── C7-1: SessionMeta shape regression — G5 happy path ──────────────
+
+describe('WI-7 — C7-1: SessionMeta.probed / preFilteredExternal are numeric on G5 happy path', () => {
+  it('C7-1: G5 — meta.probed and meta.preFilteredExternal are typeof number (not undefined, not null)', async () => {
+    // Regression pin: if a future refactor removes probed/preFilteredExternal
+    // from SessionMeta, the work-fn will see undefined and this assertion catches it.
+    // The C5-1..C5-6 tests verify the values; this test pins the TYPE contract.
+    const { client } = makeMockClient({ requestImpl: async () => null });
+    const deps = makeDeps({ client });
+    const input: Candidate[] = [mkCandidate({ file: 'src/a.ts', line: 0, character: 0 })];
+
+    let probedType = 'not-set';
+    let preFilteredType = 'not-set';
+    const result = await withReconciliationSession(REPO, input, async (_selected, meta) => {
+      probedType = typeof meta.probed;
+      preFilteredType = typeof meta.preFilteredExternal;
+      return 'value-from-g5';
+    }, deps);
+
+    // G5: fn returned a value — session also returned that value
+    expect(result).toBe('value-from-g5');
+    // Shape regression pins — must be 'number', never 'undefined' or 'object' (null)
+    expect(probedType).toBe('number');
+    expect(preFilteredType).toBe('number');
+  });
+});
+
+// ─── C7-2: SessionMeta shape regression — G6 happy path ──────────────
+
+describe('WI-7 — C7-2: SessionMeta.probed / preFilteredExternal are numeric on G6 happy path', () => {
+  it('C7-2: G6 (fn returns undefined) — meta.probed and meta.preFilteredExternal remain numeric', async () => {
+    // G6: fn resolves with undefined (the session returns undefined, NOT null).
+    // Fields must be populated with concrete numbers even on the undefined-return path.
+    const { client } = makeMockClient({ requestImpl: async () => null });
+    const deps = makeDeps({ client });
+    const input: Candidate[] = Array.from({ length: 2 }, (_, i) =>
+      mkCandidate({ sourceId: `s${i}`, file: 'src/a.ts', line: i, character: 0 }),
+    );
+
+    let capturedProbed: unknown = 'not-set';
+    let capturedPreFiltered: unknown = 'not-set';
+    const result = await withReconciliationSession(REPO, input, async (_selected, meta) => {
+      capturedProbed = meta.probed;
+      capturedPreFiltered = meta.preFilteredExternal;
+      return undefined; // G6: explicitly undefined
+    }, deps);
+
+    // G6: result is undefined (NOT null)
+    expect(result).toBeUndefined();
+    // Both fields populated as numbers
+    expect(typeof capturedProbed).toBe('number');
+    expect(typeof capturedPreFiltered).toBe('number');
+    // 2 indexable candidates dispatched (src/a.ts is not node_modules)
+    expect(capturedProbed).toBe(2);
+    expect(capturedPreFiltered).toBe(0);
+  });
+});
+
+// ─── C7-3: 500 candidates, cap=500, all dispatched (N=B boundary) ────
+
+describe('WI-7 — C7-3: funnel line — N=B=500 (boundary: all candidates within cap)', () => {
+  it('C7-3: 500 candidates, cap=500 → funnel line contains "(budget 500 of 500 candidates)" and skipped(cap) 0', () => {
+    // N=B boundary: no candidates dropped by the cap — skipped(cap)=0.
+    // The budget suffix must reflect both the cap and the total correctly.
+    // Uses gate-failure path to verify skipped(cap) computation (max(0, 500-500)=0).
+    const line = buildLspSummaryLine(
+      'gate-failure',
+      { confirmed: 0, corrected: 0, recall: 0, refused: 0, skipped: 0, serverVersion: 'v4' },
+      { N: 500, B: 500, elapsedS: '0.3' },
+    );
+    // Key WI-7 assertions
+    expect(line).toContain('(budget 500 of 500 candidates)');
+    expect(line).toContain('skipped(cap) 0');
+    // Invariant: existing tokens survive the budget suffix extension (WI-7 / L4 AC)
+    expect(line).toContain('server <v4>');
+    expect(line).not.toMatch(/skipped\(cap\) -/);
+  });
+});
+
+// ─── C7-4: 1000 candidates, cap=500, skipped=500 (N>B cap-overflow) ──
+
+describe('WI-7 — C7-4: funnel line — N=1000 > B=500 (cap overflow; skipped(cap)=500)', () => {
+  it('C7-4: 1000 candidates, cap=500 → "(budget 500 of 1000 candidates)"; skipped(cap) 500 token present', () => {
+    // N > B: 500 candidates dropped by the cap. Both the cap and the total must
+    // appear in the budget suffix — operators need this to understand silent drops.
+    const line = buildLspSummaryLine(
+      'gate-failure',
+      { confirmed: 0, corrected: 0, recall: 0, refused: 0, skipped: 0, serverVersion: 'v4' },
+      { N: 1000, B: 500, elapsedS: '0.5' },
+    );
+    // Key WI-7 assertions
+    expect(line).toContain('(budget 500 of 1000 candidates)');
+    // S = max(0, 1000-500) = 500
+    expect(line).toContain('skipped(cap) 500');
+    // Invariant: existing tokens survive
+    expect(line).toContain('server <v4>');
+  });
+});
+
+// ─── C7-5: No --lsp-budget → default cap B=2000, N=actual feed size ──
+
+describe('WI-7 — C7-5: funnel line — no --lsp-budget flag uses DEFAULT_CANDIDATE_CAP=2000', () => {
+  it('C7-5: no --lsp-budget → "(budget 2000 of N candidates)" where N=actual feed size', () => {
+    // When --lsp-budget is not supplied, pipeline.ts resolves:
+    //   const lspB = options?.lsp?.budget ?? DEFAULT_CANDIDATE_CAP;
+    // This test pins that the default-path funnel line correctly encodes the feed size
+    // and the default cap — the I-9 / byte-identity invariant.
+    const N = 37; // representative actual feed size
+    const line = buildLspSummaryLine(
+      'success',
+      { confirmed: 5, corrected: 1, recall: 3, refused: 2, skipped: 0, serverVersion: '4.3.3' },
+      { N, B: DEFAULT_CANDIDATE_CAP, elapsedS: '1.5' },
+    );
+    // Budget uses the constant default (2000) and the actual feed size
+    expect(line).toContain(`(budget ${DEFAULT_CANDIDATE_CAP} of ${N} candidates)`);
+    expect(line).toContain('(budget 2000 of 37 candidates)');
+    // Invariant: skipped(cap) and server <v> tokens survive (WI-7 explicit invariant)
+    expect(line).toContain('skipped(cap) 0');
+    expect(line).toContain('server <4.3.3>');
+    expect(line).toContain('confirmed 5');
+    expect(line).toContain('corrected 1');
+  });
+});
+
+// ─── C7-6: --lsp-budget 0 → guard fires; discoverServers never called ─
+
+describe('WI-7 — C7-6: --lsp-budget 0 guard fires before ingestion starts', () => {
+  it('C7-6: budget=0 → validation guard fires; discoverServers vi.fn() is never called', async () => {
+    // The analyzeCommand guard:
+    //   if (!Number.isInteger(n) || n <= 0) { error; exitCode=1; return; }
+    // fires BEFORE runPipelineFromRepo, which means BEFORE withReconciliationSession,
+    // which means BEFORE discoverServers is ever called.
+    //
+    // This test models the invariant: with budget=0, the guard is the gatekeeper.
+    // discoverServers (the first dep withReconciliationSession would call) is a
+    // vi.fn() that must NOT be invoked.
+    const discoverServers = vi.fn(async () => ({ typescript: null as null }));
+
+    const lspBudget = 0;
+
+    // Guard logic (mirrors analyzeCommand exactly)
+    const guardPasses = Number.isInteger(lspBudget) && lspBudget > 0;
+
+    if (guardPasses) {
+      // This branch is NEVER entered for budget=0.
+      // In the real pipeline: runPipelineFromRepo → withReconciliationSession → discoverServers.
+      await withReconciliationSession(REPO, [], async () => null, { discoverServers });
+    }
+    // else: analyzeCommand returns early (process.exitCode=1); no LSP I/O starts.
+
+    expect(guardPasses).toBe(false);
+    // discoverServers was never reached (guard blocked all upstream calls)
+    expect(discoverServers).not.toHaveBeenCalled();
+  });
+
+  it('C7-6 edge — budget=-1: same guard fires; discoverServers not called', () => {
+    const discoverServers = vi.fn(async () => ({ typescript: null as null }));
+    // -1 is invalid (n <= 0)
+    const guardPasses = Number.isInteger(-1) && -1 > 0;
+    expect(guardPasses).toBe(false);
+    expect(discoverServers).not.toHaveBeenCalled();
+  });
+
+  it('C7-6 edge — budget without --lsp: warning path; discoverServers not called (lsp=false)', async () => {
+    // When --lsp-budget is passed WITHOUT --lsp, analyzeCommand emits a warning
+    // and proceeds WITHOUT enabling LSP. The withReconciliationSession call is
+    // guarded by `options.lsp.enabled`; when false, it is never reached.
+    const discoverServers = vi.fn(async () => ({ typescript: null as null }));
+
+    // Model the lsp=false path: no withReconciliationSession call when lsp disabled
+    const lspEnabled = false;
+    if (lspEnabled) {
+      // Never reached when --lsp is absent
+      await withReconciliationSession(REPO, [], async () => null, { discoverServers });
+    }
+
+    expect(lspEnabled).toBe(false);
+    expect(discoverServers).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
Implements ADR-002 Phase 0 + the feasible part of Phase 1 — the **correctness + honesty floor** for LSP augmentation on large Java repos. Three work-streams:
- **WS-A — jdtls settle-until-quiet readiness.** Replaces the premature `language/status ServiceReady` gate (fires ~3.5s, before Maven/classpath indexing completes ~19s) with a settle-until-quiet model: ready when `$/progress` has been silent for `JDTLS_QUIET_INTERVAL_MS` AND a self-rescheduling canary resolves, with a `JDTLS_READY_DEADLINE_MS` backstop. Adds `JAVA_ADAPTER.clientCapabilities {window:{workDoneProgress:true}}` (fresh literal; Java leaves the TS byte-identical-capability set). `language/status` ServiceReady is consume-and-ignore.
- **WS-B — coverage honesty.** Adds `probed` + `preFilteredExternal` counters to `ReconciliationReport` (accumulated in `withReconciliationSession`, threaded via the work-fn payload), a `--lsp-budget <n>` CLI flag (commander; `Number.isInteger && >0`), and extends the funnel line in-place with `(budget B of N candidates)`, emitted on all paths (success, dry-run, gate-failure, error). No more silent under-augmentation.
- **WS-C — correction-candidate external pre-filter.** A `canSkipCandidate` seam skips correction candidates whose `oldTargetId` resolves to an external-zone graph node, before dispatch. Pre-filtered candidates route to an external-refusal sentinel so the replay does not corrupt confirmed/corrected/recall/refused.

## Scope boundary (honest)
**The ~57k recall-probe waste on Spring services is NOT addressed by this PR.** Recall candidates carry the *caller's* call-site file, not the callee's location, and no callee→external-import binding — so they cannot be pre-filtered without threading FQN bindings (`java.`/`javax.`/`jakarta.`/dep-pkg) from the call-processor into the recall feed. That is a deferred follow-up. `tcbs-bond-trading` augmentation is therefore **unchanged** this PR — but WS-B's coverage telemetry now makes the waste **visible** (`budget 2000 of 57650 candidates`) to target the follow-up precisely.

## Validation
- [x] `tsc --noEmit`: 0 errors
- [x] Full suite: 252 files / 7386 tests pass, 0 failures
- [x] `java-jdtls-real` real-binary: 9/9 pass (settle-until-quiet reaches ready; ServiceReady-does-not-settle proven by fake-timer unit CB-5)
- [x] bond-exception-handler real-binary: 65.6% augmentation — **no regression**
- [x] tcbs-bond-trading real-binary: augmentation unchanged (recall deferred) + coverage line emits `(budget 2000 of 57650 candidates)`
- [x] mode-a golden byte-identity (I-9) preserved
- [x] Issue #159 stays OPEN

🤖 Generated with [Claude Code](https://claude.com/claude-code)