### PR TITLE
perf: deterministic indexing + bounded analyze --lsp

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "gitnexus": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "gitnexus@latest", "mcp"]
+    }
+  }
+}

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,9 +1,0 @@
-{
-  "mcpServers": {
-    "gitnexus": {
-      "type": "stdio",
-      "command": "npx",
-      "args": ["-y", "gitnexus@latest", "mcp"]
-    }
-  }
-}

--- a/gitnexus/src/cli/analyze.ts
+++ b/gitnexus/src/cli/analyze.ts
@@ -105,6 +105,13 @@ export interface AnalyzeOptions {
    * Requires `--lsp`.
    */
   lspNoEarlyBail?: boolean;
+  /**
+   * When false (or when GITNEXUS_PARALLEL_PARSE=0 env is set), disable parallel
+   * parse workers and use sequential parsing. Default: true (parallel ON).
+   * Set via --no-parallel-parse CLI flag; Commander populates this as false when
+   * --no-parallel-parse is passed, true otherwise.
+   */
+  parallelParse?: boolean;
 }
 
 /** Threshold: auto-skip embeddings for repos with more nodes than this */
@@ -404,7 +411,7 @@ export const analyzeCommand = async (
   // cache whenever caching would be unsound (dirty tree / unknown commit), so
   // a stale hit is impossible by construction.
   const lspDefinitionCache =
-    options?.lspCache && (options?.lsp || options?.lspDryRun)
+    options?.lspCache !== false && (options?.lsp || options?.lspDryRun)
       ? buildDefinitionCache({
           enabled: true,
           commit: getCurrentCommit(repoPath) || null,
@@ -413,9 +420,6 @@ export const analyzeCommand = async (
           repoId: repoPath,
         })
       : undefined;
-  if (options?.lspCache && !options?.lsp && !options?.lspDryRun) {
-    console.warn('  Warning: --lsp-cache ignored: --lsp not enabled');
-  }
   // Non-git tree: the commit-namespaced cache and changed-since scoping both
   // need git, so they silently no-op here. Say so once, up front, so the user
   // isn't surprised the speed levers had no effect.
@@ -436,7 +440,9 @@ export const analyzeCommand = async (
   let timedPhase: string | null = null;
   let timedPhaseStart = Date.now();
   const pipelineResult = await runPipelineFromRepo(repoPath, (progress) => {
-    const phaseLabel = PHASE_LABELS[progress.phase] || progress.phase;
+    const phaseLabel = (progress.phase === 'lsp' && progress.message)
+      ? progress.message
+      : (PHASE_LABELS[progress.phase] || progress.phase);
     const scaled = Math.round(progress.percent * 0.6);
     if (phaseTiming && progress.phase !== timedPhase) {
       const now = Date.now();
@@ -448,6 +454,7 @@ export const analyzeCommand = async (
     }
     updateBar(scaled, phaseLabel);
   }, {
+    parallelParse: options?.parallelParse !== false,
     lsp: {
       enabled: options?.lsp === true || options?.lspDryRun === true,
       dryRun: options?.lspDryRun === true,

--- a/gitnexus/src/cli/analyze.ts
+++ b/gitnexus/src/cli/analyze.ts
@@ -98,6 +98,13 @@ export interface AnalyzeOptions {
    * on a clean working tree (results are keyed to the HEAD commit). Requires `--lsp`.
    */
   lspCache?: boolean;
+  /**
+   * Disable adaptive early-bail. By default the LSP dispatch stops after 150
+   * consecutive unresolved probes (the server isn't resolving this repo) and
+   * keeps the heuristic for the rest. This flag forces exhaustive probing.
+   * Requires `--lsp`.
+   */
+  lspNoEarlyBail?: boolean;
 }
 
 /** Threshold: auto-skip embeddings for repos with more nodes than this */
@@ -135,6 +142,19 @@ export function shouldCacheEmbeddings(
   return shouldPreserveExistingEmbeddings(existingMeta, options) || !!options?.embeddings;
 }
 
+/**
+ * Default LSP request-pipelining concurrency when `--lsp` is on and
+ * `--lsp-pipeline` is not given. Activates the already-present 8-way dispatch
+ * pool (`CONCURRENT_DEFINITION_REQUESTS`) that was previously throttled to
+ * serial by the `maxInFlight=1` client default. Byte-identical to serial
+ * (results are content-keyed; `textDocument/definition` is a pure query
+ * post-readiness) — proven by the mode-A golden suite. `--lsp-pipeline 1`
+ * forces the old strictly-serial behaviour. 4 (not 8) keeps single-threaded
+ * servers (pylsp/tsserver) from thrashing while capturing most round-trip
+ * overlap.
+ */
+const DEFAULT_LSP_PIPELINE = 4;
+
 const PHASE_LABELS: Record<string, string> = {
   extracting: 'Scanning files',
   structure: 'Building structure',
@@ -142,6 +162,7 @@ const PHASE_LABELS: Record<string, string> = {
   imports: 'Resolving imports',
   calls: 'Tracing calls',
   heritage: 'Extracting inheritance',
+  lsp: 'LSP augmentation',
   communities: 'Detecting communities',
   processes: 'Detecting processes',
   complete: 'Pipeline complete',
@@ -395,6 +416,12 @@ export const analyzeCommand = async (
   if (options?.lspCache && !options?.lsp && !options?.lspDryRun) {
     console.warn('  Warning: --lsp-cache ignored: --lsp not enabled');
   }
+  // Non-git tree: the commit-namespaced cache and changed-since scoping both
+  // need git, so they silently no-op here. Say so once, up front, so the user
+  // isn't surprised the speed levers had no effect.
+  if ((options?.lsp || options?.lspDryRun) && !repoHasGit) {
+    console.warn('  Note: --lsp-cache and --lsp-changed-since need git and have no effect on a non-git tree.');
+  }
 
   // ── Phase 1: Full Pipeline (0–60%) ─────────────────────────────────
   // WI-5 (#159 P3 Mode A): thread `lsp` + `lspDryRun` through to
@@ -403,9 +430,22 @@ export const analyzeCommand = async (
   // true; the default `analyze` (no flag) takes the byte-identical
   // path. The pipeline prints the dry-run report or the summary
   // line itself (single source of truth).
+  // Opt-in per-phase wall-clock timing (GITNEXUS_PHASE_TIMING=1). Zero impact
+  // on default runs — purely a profiling aid for tuning analyze performance.
+  const phaseTiming = process.env.GITNEXUS_PHASE_TIMING === '1';
+  let timedPhase: string | null = null;
+  let timedPhaseStart = Date.now();
   const pipelineResult = await runPipelineFromRepo(repoPath, (progress) => {
     const phaseLabel = PHASE_LABELS[progress.phase] || progress.phase;
     const scaled = Math.round(progress.percent * 0.6);
+    if (phaseTiming && progress.phase !== timedPhase) {
+      const now = Date.now();
+      if (timedPhase !== null) {
+        console.warn(`  [phase-timing] ${timedPhase}: ${((now - timedPhaseStart) / 1000).toFixed(1)}s`);
+      }
+      timedPhase = progress.phase;
+      timedPhaseStart = now;
+    }
     updateBar(scaled, phaseLabel);
   }, {
     lsp: {
@@ -417,14 +457,33 @@ export const analyzeCommand = async (
       budget: options?.lspBudget,
       // Lever 12: validated spot-check rate (undefined → off in the pipeline).
       highTierSampleRate: options?.lspHighTierSample,
-      // Lever 13: validated request-pipelining concurrency (undefined → serial).
-      pipeline: options?.lspPipeline,
+      // Lever 13: request-pipelining concurrency. Defaults to
+      // DEFAULT_LSP_PIPELINE (activates the existing 8-way dispatch pool;
+      // byte-identical to serial, golden-gated). `--lsp-pipeline 1` forces
+      // the old strictly-serial path; an explicit value overrides the default.
+      pipeline: options?.lspPipeline ?? DEFAULT_LSP_PIPELINE,
       // Lever 15: changed-file scoping set (undefined → full feed).
       changedFiles: lspChangedFiles,
       // Lever 14: definition cache (undefined → no caching).
       definitionCache: lspDefinitionCache,
+      // Adaptive early-bail (default on): stop probing after 150 unresolved
+      // candidates. --lsp-no-early-bail forces exhaustive probing.
+      earlyBail: !options?.lspNoEarlyBail,
     },
   });
+  if (phaseTiming && timedPhase !== null) {
+    console.warn(`  [phase-timing] ${timedPhase}: ${((Date.now() - timedPhaseStart) / 1000).toFixed(1)}s`);
+  }
+  // Edge-ID dump for lossless verification (GITNEXUS_DUMP_EDGES=<path>): writes
+  // sorted `type<TAB>id` lines so two runs can be diffed at the edge-ID level
+  // (counts alone hide overshoot+loss canceling out). Zero default impact.
+  if (process.env.GITNEXUS_DUMP_EDGES) {
+    const _ids: string[] = [];
+    pipelineResult.graph.forEachRelationship((r) => _ids.push(`${r.type}\t${r.id}`));
+    _ids.sort();
+    await fs.writeFile(process.env.GITNEXUS_DUMP_EDGES, _ids.join('\n') + '\n');
+    console.warn(`  [dump-edges] ${_ids.length} relationships → ${process.env.GITNEXUS_DUMP_EDGES}`);
+  }
 
   // ── Phase 2: LadybugDB (60–85%) ──────────────────────────────────────
   updateBar(60, 'Loading into LadybugDB...');

--- a/gitnexus/src/cli/index.ts
+++ b/gitnexus/src/cli/index.ts
@@ -34,11 +34,12 @@ program
    .option('--lsp-dry-run', 'Preview every LSP reconciliation decision and write nothing; implies --lsp')
    .option('--lsp-budget <n>', 'Limit LSP candidate cap to n (positive integer; default 2000); requires --lsp', (v) => Number(v))
    .option('--lsp-high-tier-sample <rate>', 'Spot-check fraction [0,1] of import-scoped (0.90) CALLS edges via LSP to catch confidently-wrong edges (default 0 = off); requires --lsp', (v) => Number(v))
-   .option('--lsp-pipeline <n>', 'Allow n LSP requests in flight concurrently (default 1 = serial); speeds up dispatch on jdtls/tsserver; requires --lsp', (v) => Number(v))
+   .option('--lsp-pipeline <n>', 'Allow n LSP requests in flight concurrently (default 4); speeds up dispatch on jdtls/tsserver; requires --lsp', (v) => Number(v))
    .option('--lsp-changed-since <ref>', 'Scope LSP augmentation to call/heritage sites in files changed since <ref> (git diff); requires --lsp')
-   .option('--lsp-cache', 'Cache textDocument/definition results across runs (clean working tree only); speeds re-indexing; requires --lsp')
+   .option('--no-lsp-cache', 'Disable the definition cache (on by default when --lsp is active on a clean git tree); cache is commit-namespaced so stale hits are impossible')
    .option('--lsp-no-early-bail', 'Disable adaptive early-bail; probe every candidate even when the language server resolves none (default: bail after 150 unresolved probes); requires --lsp')
-   .addHelpText('after', '\nEnvironment variables:\n  GITNEXUS_NO_GITIGNORE=1  Skip .gitignore parsing (still reads .gitnexusignore)')
+   .option('--no-parallel-parse', 'Disable parallel parse workers (only affects repos above the 100-file / 512KB threshold; for debugging or memory-constrained environments)')
+   .addHelpText('after', '\nEnvironment variables:\n  GITNEXUS_NO_GITIGNORE=1  Skip .gitignore parsing (still reads .gitnexusignore)\n  GITNEXUS_PARALLEL_PARSE=0  Disable parallel parse workers (same as --no-parallel-parse)')
    .action(createLazyAction(() => import('./analyze.js'), 'analyzeCommand'));
 
 program

--- a/gitnexus/src/cli/index.ts
+++ b/gitnexus/src/cli/index.ts
@@ -37,6 +37,7 @@ program
    .option('--lsp-pipeline <n>', 'Allow n LSP requests in flight concurrently (default 1 = serial); speeds up dispatch on jdtls/tsserver; requires --lsp', (v) => Number(v))
    .option('--lsp-changed-since <ref>', 'Scope LSP augmentation to call/heritage sites in files changed since <ref> (git diff); requires --lsp')
    .option('--lsp-cache', 'Cache textDocument/definition results across runs (clean working tree only); speeds re-indexing; requires --lsp')
+   .option('--lsp-no-early-bail', 'Disable adaptive early-bail; probe every candidate even when the language server resolves none (default: bail after 150 unresolved probes); requires --lsp')
    .addHelpText('after', '\nEnvironment variables:\n  GITNEXUS_NO_GITIGNORE=1  Skip .gitignore parsing (still reads .gitnexusignore)')
    .action(createLazyAction(() => import('./analyze.js'), 'analyzeCommand'));
 

--- a/gitnexus/src/core/ingestion/call-processor.ts
+++ b/gitnexus/src/core/ingestion/call-processor.ts
@@ -337,6 +337,76 @@ export const processCalls = async (
   const logSkipped = isVerboseIngestionEnabled();
   const skippedByLang = logSkipped ? new Map<string, number>() : null;
 
+  // ── Property pre-pass: register all field/property symbols (ownerId + declaredType)
+  //    into the SymbolTable BEFORE the per-file call-resolution loop below.
+  //
+  //    WHY: properties (Ruby `attr_*`) are emitted via the `properties` call-route and,
+  //    historically, were registered into the SymbolTable inside the same per-file loop
+  //    that resolves calls. That makes field-type disambiguation order-dependent: a
+  //    `user.address.save` chain in service.rb resolves `user.address` by looking up the
+  //    `address` field on class User — but if service.rb is processed before user.rb (e.g.
+  //    under the deterministic lexicographic file sort), the `address` field is not yet in
+  //    `fieldByOwner`, the chain breaks, and `.save` falls back to the receiver type
+  //    (User#save) instead of the field type (Address#save). Registering every property
+  //    up-front makes `fieldByOwner` complete when any chain is walked, so resolution is
+  //    file-order-independent by construction. This mirrors the existing deferral done for
+  //    write-access (`pendingWrites`) for the same mid-loop-registration reason.
+  //
+  //    Only Ruby's callRouter produces `kind: 'properties'`, so this loop is a no-op for
+  //    every other language. Graph node/edge emission for properties is intentionally LEFT
+  //    in the main loop (unchanged emission order → byte-identical edge ids); this pre-pass
+  //    touches the SymbolTable only.
+  for (let i = 0; i < files.length; i++) {
+    const file = files[i];
+    if (i % 20 === 0) await yieldToEventLoop();
+    const language = getLanguageFromFilename(file.path);
+    if (!language) continue;
+    if (!isLanguageAvailable(language)) continue;
+    const provider = getProvider(language);
+    if (!provider.callRouter) continue;
+    const queryStr = provider.treeSitterQueries;
+    if (!queryStr) continue;
+    await loadLanguage(language, file.path);
+
+    let tree = astCache.get(file.path);
+    if (!tree) {
+      try {
+        tree = parser.parse(file.content, undefined, { bufferSize: getTreeSitterBufferSize(file.content.length) });
+      } catch {
+        continue;
+      }
+      astCache.set(file.path, tree);
+    }
+
+    let matches;
+    try {
+      const lang = parser.getLanguage();
+      const query = new Parser.Query(lang, queryStr);
+      matches = query.matches(tree.rootNode);
+    } catch {
+      continue;
+    }
+
+    for (const match of matches) {
+      const captureMap: Record<string, any> = {};
+      match.captures.forEach(c => captureMap[c.name] = c.node);
+      const callNode = captureMap['call'];
+      if (!callNode) continue;
+      const nameNode = captureMap['call.name'];
+      if (!nameNode) continue;
+      const routed = provider.callRouter(nameNode.text, callNode);
+      if (!routed || routed.kind !== 'properties') continue;
+      const propEnclosingClassId = findEnclosingClassId(callNode, file.path);
+      for (const item of routed.items) {
+        const nodeId = generateId('Property', `${file.path}:${item.propName}`);
+        ctx.symbols.add(file.path, item.propName, nodeId, 'Property', {
+          ...(propEnclosingClassId ? { ownerId: propEnclosingClassId } : {}),
+          ...(item.declaredType ? { declaredType: item.declaredType } : {}),
+        });
+      }
+    }
+  }
+
   for (let i = 0; i < files.length; i++) {
     const file = files[i];
     onProgress?.(i + 1, files.length);
@@ -507,10 +577,10 @@ export const processCalls = async (
                   description: item.accessorType,
                 },
               });
-              ctx.symbols.add(file.path, item.propName, nodeId, 'Property', {
-                ...(propEnclosingClassId ? { ownerId: propEnclosingClassId } : {}),
-                ...(item.declaredType ? { declaredType: item.declaredType } : {}),
-              });
+              // Symbol-table registration (ownerId + declaredType) is done in the
+              // property pre-pass above so `fieldByOwner` is complete before any call
+              // is resolved — see the pre-pass comment for the order-dependence rationale.
+              // Only the graph node/edge emission stays here, preserving edge-id order.
               const relId = generateId('DEFINES', `${fileId}->${nodeId}`);
               graph.addRelationship({
                 id: relId, sourceId: fileId, targetId: nodeId,

--- a/gitnexus/src/core/ingestion/call-processor.ts
+++ b/gitnexus/src/core/ingestion/call-processor.ts
@@ -658,9 +658,13 @@ export const processCalls = async (
           // WI-A2 — inject calleeExternalFqn when the receiver type is a provably-external
           // Java class. Slow site uses `file.path` (not `filePath`) and the bare local
           // variable `receiverTypeName` (not effectiveCall — not in scope here).
-          const calleeExternalFqn =
-            file.path.endsWith('.java') && receiverTypeName
-              ? opts.javaExternalFqnIndex?.get(file.path)?.get(receiverTypeName)
+          // ADR-002 Lever 10: for Python, look up the receiver name first (covers
+          // `np.array()` → receiverName='np'), then fall back to calledName (covers
+          // free-function calls like `getcwd()` where receiverName is undefined).
+          const calleeExternalFqn = file.path.endsWith('.java') && receiverTypeName
+            ? opts.javaExternalFqnIndex?.get(file.path)?.get(receiverTypeName)
+            : file.path.endsWith('.py')
+              ? (opts.pythonExternalFqnIndex?.get(file.path)?.get(receiverName ?? calledName))
               : undefined;
           opts.recallFeed.push({
             sourceId,
@@ -1502,6 +1506,13 @@ export interface ProcessCallsOpts {
    * Absent on the default analyze path (I-9: default path stays byte-identical).
    */
   javaExternalFqnIndex?: Map<string, Map<string, string>>;
+  /**
+   * ADR-002 Lever 10 — Index built by import-processor at LSP-analysis time for Python.
+   * Maps filePath → boundName → module for provably-external Python imports.
+   * Examples: 'np' → 'numpy', 'getcwd' → 'os', 'os' → 'os'.
+   * Absent on the default analyze path (I-9: byte-identical).
+   */
+  pythonExternalFqnIndex?: Map<string, Map<string, string>>;
 }
 
 /**
@@ -1674,9 +1685,15 @@ export const processCallsFromExtracted = async (
           // WI-A2 — inject calleeExternalFqn when the receiver type is a provably-external
           // Java class (JDK/Spring/Jackson). Gate: .java file + receiverTypeName present.
           // ?.get(undefined) is safe — Map.get(undefined) returns undefined without error.
-          const calleeExternalFqn =
-            effectiveCall.filePath.endsWith('.java') && effectiveCall.receiverTypeName
-              ? opts.javaExternalFqnIndex?.get(effectiveCall.filePath)?.get(effectiveCall.receiverTypeName)
+          // ADR-002 Lever 10: for Python, look up receiver name first (covers
+          // `np.array()` → effectiveCall.receiverName='np'), then fall back to
+          // calledName (covers free-function calls like `getcwd()`).
+          const calleeExternalFqn = effectiveCall.filePath.endsWith('.java') && effectiveCall.receiverTypeName
+            ? opts.javaExternalFqnIndex?.get(effectiveCall.filePath)?.get(effectiveCall.receiverTypeName)
+            : effectiveCall.filePath.endsWith('.py')
+              ? (opts.pythonExternalFqnIndex?.get(effectiveCall.filePath)?.get(
+                  effectiveCall.receiverName ?? effectiveCall.calledName,
+                ))
               : undefined;
           opts.recallFeed.push({
             sourceId: effectiveCall.sourceId,

--- a/gitnexus/src/core/ingestion/community-processor.ts
+++ b/gitnexus/src/core/ingestion/community-processor.ts
@@ -24,6 +24,32 @@ const leidenPath = resolve(__dirname, '..', '..', '..', 'vendor', 'leiden', 'ind
 const _require = createRequire(import.meta.url);
 const leiden = _require(leidenPath);
 
+/**
+ * Deterministic PRNG (mulberry32) so Leiden's randomized node-move order is
+ * reproducible. Fresh instance per run from a fixed seed → identical partition
+ * + identical comm_N numbering every run. Replaces the default Math.random,
+ * which made symbol→community MEMBER_OF edges nondeterministic.
+ */
+function makeSeededRng(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/** FNV-1a → positive 31-bit int. Used for content-derived community numbering. */
+function fnv1a31(s: string): number {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  return (h >>> 0) & 0x7fffffff;
+}
+
 // ============================================================================
 // TYPES
 // ============================================================================
@@ -124,6 +150,11 @@ export const processCommunities = async (
       Promise.resolve((leiden as any).detailed(graph, {
         resolution: isLarge ? 2.0 : 1.0,
         maxIterations: isLarge ? 3 : 0,
+        // Deterministic RNG (default was Math.random) so the partition AND the
+        // comm_N numbering reproduce run-to-run. Without this the symbol→community
+        // MEMBER_OF edges churned by ~1500/run, producing phantom detect_changes
+        // diffs and making any "lossless" verification impossible.
+        rng: makeSeededRng(0x6e657875),
       })),
       new Promise((_, reject) =>
         setTimeout(() => reject(new Error('Leiden timeout')), LEIDEN_TIMEOUT_MS)
@@ -142,6 +173,27 @@ export const processCommunities = async (
   }
 
   onProgress?.(`Found ${details.count} communities...`, 60);
+
+  // Content-derived community numbering: number each community by a hash of its
+  // lexicographically-smallest member id. Each community's id depends ONLY on its
+  // own members, so a residual partition difference (Leiden is not 100% reproducible
+  // even seeded) churns just the affected communities — it never cascades the way a
+  // sequential renumber does (which reshuffled every later community's id → ~1684
+  // MEMBER_OF + ~1000 STEP_IN_PROCESS churn/run). Distinct communities have distinct
+  // smallest members → distinct ids (hash collisions ~0 for a few hundred communities).
+  {
+    const rawCommunities = details.communities as Record<string, number>;
+    const minMemberByComm = new Map<number, string>();
+    for (const [nodeId, num] of Object.entries(rawCommunities)) {
+      const cur = minMemberByComm.get(num);
+      if (cur === undefined || nodeId < cur) minMemberByComm.set(num, nodeId);
+    }
+    const remap = new Map<number, number>();
+    for (const [num, minMember] of minMemberByComm) remap.set(num, fnv1a31(minMember));
+    const canonical: Record<string, number> = {};
+    for (const [nodeId, num] of Object.entries(rawCommunities)) canonical[nodeId] = remap.get(num)!;
+    details.communities = canonical;
+  }
 
   // Step 3: Create community nodes with heuristic labels
   const communityNodes = createCommunityNodes(
@@ -204,28 +256,36 @@ const buildGraphologyGraph = (knowledgeGraph: KnowledgeGraph, isLarge: boolean):
     nodeDegree.set(rel.targetId, (nodeDegree.get(rel.targetId) || 0) + 1);
   });
 
+  // Insert nodes + edges in a STABLE (id-sorted) order. graphology iterates in
+  // insertion order, and Leiden's result depends on that order — so a
+  // nondeterministic build order (parallel/async ingestion) produced a different
+  // partition each run. Sorting makes the partition reproducible (with the seeded
+  // rng above), killing the ~1500/run symbol→community MEMBER_OF churn.
+  const nodesToAdd: Array<{ id: string; name: unknown; filePath: unknown; type: NodeLabel }> = [];
   knowledgeGraph.forEachNode(node => {
     if (!symbolTypes.has(node.label) || !connectedNodes.has(node.id)) return;
     // For large graphs, skip degree-1 nodes — they just become singletons or
     // get absorbed into their single neighbor's community, but cost iteration time.
     if (isLarge && (nodeDegree.get(node.id) || 0) < 2) return;
-
-    graph.addNode(node.id, {
-      name: node.properties.name,
-      filePath: node.properties.filePath,
-      type: node.label,
-    });
+    nodesToAdd.push({ id: node.id, name: node.properties.name, filePath: node.properties.filePath, type: node.label });
   });
+  nodesToAdd.sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
+  for (const n of nodesToAdd) {
+    graph.addNode(n.id, { name: n.name, filePath: n.filePath, type: n.type });
+  }
 
+  const edgesToAdd: Array<[string, string]> = [];
   knowledgeGraph.forEachRelationship(rel => {
     if (!clusteringRelTypes.has(rel.type)) return;
     if (isLarge && rel.confidence < MIN_CONFIDENCE_LARGE) return;
     if (graph.hasNode(rel.sourceId) && graph.hasNode(rel.targetId) && rel.sourceId !== rel.targetId) {
-      if (!graph.hasEdge(rel.sourceId, rel.targetId)) {
-        graph.addEdge(rel.sourceId, rel.targetId);
-      }
+      edgesToAdd.push([rel.sourceId, rel.targetId]);
     }
   });
+  edgesToAdd.sort((a, b) => (a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : a[1] < b[1] ? -1 : a[1] > b[1] ? 1 : 0));
+  for (const [s, t] of edgesToAdd) {
+    if (!graph.hasEdge(s, t)) graph.addEdge(s, t);
+  }
 
   return graph;
 };

--- a/gitnexus/src/core/ingestion/filesystem-walker.ts
+++ b/gitnexus/src/core/ingestion/filesystem-walker.ts
@@ -73,6 +73,18 @@ export const walkRepositoryPaths = async (
     console.warn(`  Skipped ${skippedLarge} large files (>${MAX_FILE_SIZE / 1024}KB, likely generated/vendored)`);
   }
 
+  // Deterministic file order. `glob` v11 walks directories in parallel
+  // (path-scurry) and does NOT sort its output — two calls return the SAME set
+  // in a DIFFERENT order. That order propagates into symbol-table insertion
+  // order, so for any globally-ambiguous name `lookupFuzzy(name)[0]` (the
+  // first-inserted definition) can flip between runs, changing a CALLS edge's
+  // resolved target → the community-detection graph topology → the Leiden
+  // partition → MEMBER_OF / STEP_IN_PROCESS edge ids. Sorting here makes the
+  // whole downstream chain reproducible. This is the load-bearing determinism
+  // guarantee; the seeded RNG + node/edge sort in community-processor only fix
+  // the ORDER Leiden processes a fixed set, not the SET itself.
+  entries.sort((a, b) => (a.path < b.path ? -1 : a.path > b.path ? 1 : 0));
+
   return entries;
 };
 

--- a/gitnexus/src/core/ingestion/import-processor.ts
+++ b/gitnexus/src/core/ingestion/import-processor.ts
@@ -327,6 +327,7 @@ export const processImports = async (
   allPaths?: string[],
   crossRepoRegistry?: CrossRepoRegistry,
   javaExternalFqnIndex?: Map<string, Map<string, string>>,
+  pythonExternalFqnIndex?: Map<string, Map<string, string>>,
 ) => {
   const importMap = ctx.importMap;
   const packageMap = ctx.packageMap;
@@ -451,6 +452,36 @@ export const processImports = async (
           if (!fileMap) { fileMap = new Map(); javaExternalFqnIndex.set(file.path, fileMap); }
           fileMap.set(simple, rawImportPath);
         }
+        // ADR-002 Lever 10: populate pythonExternalFqnIndex for provably-external Python imports.
+        // "Provably external" = non-relative AND the resolver found no in-repo file.
+        // Relative imports (.helpers, ..utils) always have in-repo intent — never classify them
+        // external regardless of whether the resolver found them.  "Unknown ≠ external" (I-2c).
+        //
+        // Bound-name extraction:
+        //   import numpy as np        → binding { local:'np', exported:'numpy', isModuleAlias:true }
+        //                             → record pythonExternalFqnIndex[file.path]['np'] = 'numpy'
+        //   from os import getcwd     → binding { local:'getcwd', exported:'getcwd' }
+        //                             → record pythonExternalFqnIndex[file.path]['getcwd'] = 'os'
+        //   import os                 → no bindings → record ['os'] = 'os'
+        if (
+          !result &&
+          pythonExternalFqnIndex &&
+          language === SupportedLanguages.Python &&
+          !rawImportPath.startsWith('.')
+        ) {
+          let fileMap = pythonExternalFqnIndex.get(file.path);
+          if (!fileMap) { fileMap = new Map(); pythonExternalFqnIndex.set(file.path, fileMap); }
+          if (bindings && bindings.length > 0) {
+            for (const b of bindings) {
+              fileMap.set(b.local, rawImportPath);
+            }
+          } else {
+            // Bare `import <module>` with no alias — bound name IS the top-level module name.
+            // Use the first dotted segment (import os.path → bound name 'os').
+            const topLevel = rawImportPath.split('.')[0];
+            fileMap.set(topLevel, rawImportPath);
+          }
+        }
       }
 
       // ---- Language-specific call-as-import routing (Ruby require, etc.) ----
@@ -499,6 +530,7 @@ export const processImportsFromExtracted = async (
   prebuiltCtx?: ImportResolutionContext,
   crossRepoRegistry?: CrossRepoRegistry,
   javaExternalFqnIndex?: Map<string, Map<string, string>>,
+  pythonExternalFqnIndex?: Map<string, Map<string, string>>,
 ) => {
   const importMap = ctx.importMap;
   const packageMap = ctx.packageMap;
@@ -558,6 +590,27 @@ export const processImportsFromExtracted = async (
         let fileMap = javaExternalFqnIndex.get(filePath);
         if (!fileMap) { fileMap = new Map(); javaExternalFqnIndex.set(filePath, fileMap); }
         fileMap.set(simple, imp.rawImportPath);
+      }
+      // ADR-002 Lever 10: populate pythonExternalFqnIndex for provably-external Python imports.
+      // Fast path: imp.namedBindings lacks isModuleAlias — treat all bindings uniformly
+      // (module alias and named imports map the same: local → rawImportPath).
+      // No bindings → bare `import <module>` → bound name is the top-level segment.
+      if (
+        !result &&
+        pythonExternalFqnIndex &&
+        imp.language === SupportedLanguages.Python &&
+        !imp.rawImportPath.startsWith('.')
+      ) {
+        let fileMap = pythonExternalFqnIndex.get(filePath);
+        if (!fileMap) { fileMap = new Map(); pythonExternalFqnIndex.set(filePath, fileMap); }
+        if (imp.namedBindings && imp.namedBindings.length > 0) {
+          for (const b of imp.namedBindings) {
+            fileMap.set(b.local, imp.rawImportPath);
+          }
+        } else {
+          const topLevel = imp.rawImportPath.split('.')[0];
+          fileMap.set(topLevel, imp.rawImportPath);
+        }
       }
     }
   }

--- a/gitnexus/src/core/ingestion/import-processor.ts
+++ b/gitnexus/src/core/ingestion/import-processor.ts
@@ -350,7 +350,8 @@ export const processImports = async (
 
   // Load language-specific configs once before the file loop
   const configs = await loadImportConfigs(repoRoot || '');
-  const resolveCtx: ResolveCtx = { allFilePaths, allFileList, normalizedFileList, index, resolveCache, configs };
+  const definesSymbol = (fp: string, name: string) => ctx.symbols.lookupExact(fp, name) !== undefined;
+  const resolveCtx: ResolveCtx = { allFilePaths, allFileList, normalizedFileList, index, resolveCache, configs, definesSymbol };
   const { addImportEdge, addImportGraphEdge, getResolvedCount } = createImportEdgeHelpers(graph, importMap);
 
   for (let i = 0; i < files.length; i++) {
@@ -542,7 +543,8 @@ export const processImportsFromExtracted = async (
   let totalImportsFound = 0;
 
   const configs = await loadImportConfigs(repoRoot || '');
-  const resolveCtx: ResolveCtx = { allFilePaths, allFileList, normalizedFileList, index, resolveCache, configs };
+  const definesSymbol = (fp: string, name: string) => ctx.symbols.lookupExact(fp, name) !== undefined;
+  const resolveCtx: ResolveCtx = { allFilePaths, allFileList, normalizedFileList, index, resolveCache, configs, definesSymbol };
   const { addImportEdge, addImportGraphEdge, getResolvedCount } = createImportEdgeHelpers(graph, importMap);
 
   // Group by file for progress reporting (users see file count, not import count)

--- a/gitnexus/src/core/ingestion/import-resolvers/php.ts
+++ b/gitnexus/src/core/ingestion/import-resolvers/php.ts
@@ -26,11 +26,13 @@ function getSortedPsr4(config: ComposerConfig): readonly [string, string][] {
  * a file. When PSR-4 class-style resolution fails, we fall back to scanning
  * .php files in the namespace directory.
  *
- * NOTE: The function-import fallback returns the first matching .php file in the
- * namespace directory. When multiple files exist in the same namespace directory,
- * resolution is non-deterministic (depends on Set/index iteration order). This is
- * a known limitation — PHP function imports cannot be resolved to a specific file
- * without parsing all candidate files.
+ * Order-independent disambiguation: when multiple .php files live in the same
+ * namespace directory, we pick the file that actually DEFINES the imported
+ * symbol, using `definesSymbol` (backed by the SymbolTable populated by the
+ * parsing phase). This is resolved from symbol definitions, not file-walk
+ * order, so the result no longer depends on which file was indexed first.
+ * Only when no candidate defines the symbol (or no symbol table is available)
+ * do we fall back to the first matching .php file in the directory.
  */
 export function resolvePhpImportInternal(
   importPath: string,
@@ -39,6 +41,7 @@ export function resolvePhpImportInternal(
   normalizedFileList: string[],
   allFileList: string[],
   index?: SuffixIndex,
+  definesSymbol?: (filePath: string, name: string) => boolean,
 ): string | null {
   // Normalize: replace backslashes with forward slashes
   const normalized = importPath.replace(/\\/g, '/');
@@ -62,8 +65,9 @@ export function resolvePhpImportInternal(
         }
 
         // 2. Function/constant fallback: strip last segment (symbol name), scan namespace directory.
-        //    e.g. App\Models\getUser → directory app/Models/, find first .php file in that dir.
+        //    e.g. App\Models\getUser → symbol "getUser" in directory app/Models/.
         const lastSlash = remainder.lastIndexOf('/');
+        const symbolName = lastSlash >= 0 ? remainder.slice(lastSlash + 1) : remainder;
         const nsDir = lastSlash >= 0
           ? dirPrefix + '/' + remainder.slice(0, lastSlash)
           : dirPrefix;
@@ -71,16 +75,27 @@ export function resolvePhpImportInternal(
         // Prefer SuffixIndex directory lookup (O(log n + matches)) over linear scan
         if (index) {
           const candidates = index.getFilesInDir(nsDir, '.php');
-          if (candidates.length > 0) return candidates[0];
+          if (candidates.length > 0) {
+            // Order-independent: pick the candidate that actually defines the symbol.
+            if (definesSymbol && symbolName) {
+              const defining = candidates.find(f => definesSymbol(f, symbolName));
+              if (defining) return defining;
+            }
+            return candidates[0];
+          }
         }
 
         // Fallback: linear scan (only when SuffixIndex unavailable)
         const nsDirPrefix = nsDir.endsWith('/') ? nsDir : nsDir + '/';
+        let firstInDir: string | null = null;
         for (const f of allFiles) {
           if (f.startsWith(nsDirPrefix) && f.endsWith('.php') && !f.slice(nsDirPrefix.length).includes('/')) {
-            return f;
+            // Order-independent: prefer the file that defines the symbol.
+            if (definesSymbol && symbolName && definesSymbol(f, symbolName)) return f;
+            if (firstInDir === null) firstInDir = f;
           }
         }
+        if (firstInDir !== null) return firstInDir;
       }
     }
   }
@@ -96,6 +111,6 @@ export function resolvePhpImport(
   _filePath: string,
   ctx: ResolveCtx,
 ): ImportResult {
-  const resolved = resolvePhpImportInternal(rawImportPath, ctx.configs.composerConfig, ctx.allFilePaths, ctx.normalizedFileList, ctx.allFileList, ctx.index);
+  const resolved = resolvePhpImportInternal(rawImportPath, ctx.configs.composerConfig, ctx.allFilePaths, ctx.normalizedFileList, ctx.allFileList, ctx.index, ctx.definesSymbol);
   return resolved ? { kind: 'files', files: [resolved] } : null;
 }

--- a/gitnexus/src/core/ingestion/import-resolvers/types.ts
+++ b/gitnexus/src/core/ingestion/import-resolvers/types.ts
@@ -40,6 +40,16 @@ export interface ImportResolutionContext {
 /** Full context for import resolution: file lookups + language configs. */
 export interface ResolveCtx extends ImportResolutionContext {
   configs: ImportConfigs;
+  /**
+   * Optional: returns true iff `filePath` defines a symbol named `name`.
+   * Backed by the SymbolTable populated by the parsing phase (which runs
+   * before import resolution). Lets a resolver disambiguate which file in a
+   * namespace directory actually defines an imported function/constant —
+   * making resolution order-INDEPENDENT instead of "first file wins".
+   * Absent on resolution paths that have no symbol table yet; resolvers must
+   * treat `undefined` as "no symbol info" and fall back gracefully.
+   */
+  definesSymbol?: (filePath: string, name: string) => boolean;
 }
 
 /** Per-language import resolver -- function alias matching ExportChecker/CallRouter pattern. */

--- a/gitnexus/src/core/ingestion/lsp/language-adapter.ts
+++ b/gitnexus/src/core/ingestion/lsp/language-adapter.ts
@@ -189,6 +189,14 @@ export interface AdapterReadyCtx {
    *   sub?.dispose();
    */
   onServerStatus?: (cb: (payload: { quiescent: boolean; health: string }) => void) => { dispose(): void };
+
+  /**
+   * WI-1 (heartbeat): optional callback fired every ~2 s while the adapter
+   * is waiting in `awaitReady`. Callers use it to emit live progress messages
+   * so a long warm-up does not look hung. `elapsedMs` is measured from the
+   * start of the `awaitReady` call. Never throws — callers must guard.
+   */
+  onHeartbeat?: (elapsedMs: number) => void;
 }
 
 // ─── ClientCapabilities ───────────────────────────────────────────────
@@ -510,6 +518,18 @@ export const JAVA_ADAPTER: LanguageAdapter = {
       let quietTimer: ReturnType<typeof setTimeout> | null = null;
       let canaryTimer: ReturnType<typeof setTimeout> | null = null;
       let deadlineTimer: ReturnType<typeof setTimeout> | null = null;
+      let _heartbeatTimer: ReturnType<typeof setTimeout> | null = null;
+
+      const _heartbeatStart = Date.now();
+      function _scheduleHeartbeat(): void {
+        if (settled) return;
+        _heartbeatTimer = setTimeout(() => {
+          if (settled) return;
+          try { ctx.onHeartbeat?.(Date.now() - _heartbeatStart); } catch { /* progress callback must never break readiness */ }
+          _scheduleHeartbeat();
+        }, 2000);
+        _heartbeatTimer.unref?.();
+      }
 
       function dispose(): void {
         if (langStatusHandler !== null) {
@@ -523,6 +543,7 @@ export const JAVA_ADAPTER: LanguageAdapter = {
         if (quietTimer !== null) { clearTimeout(quietTimer); quietTimer = null; }
         if (canaryTimer !== null) { clearTimeout(canaryTimer); canaryTimer = null; }
         if (deadlineTimer !== null) { clearTimeout(deadlineTimer); deadlineTimer = null; }
+        if (_heartbeatTimer !== null) { clearTimeout(_heartbeatTimer); _heartbeatTimer = null; }
       }
 
       function settle(value: boolean): void {
@@ -669,6 +690,7 @@ export const JAVA_ADAPTER: LanguageAdapter = {
       schedulePeriodicCanary();
 
       // ── Step 4: hard deadline ──────────────────────────────────────────
+      _scheduleHeartbeat();
       deadlineTimer = setTimeout(() => {
         settle(false);
       }, deadline);
@@ -775,6 +797,18 @@ export const PYTHON_ADAPTER: LanguageAdapter = {
       let settled = false;
       let timer: ReturnType<typeof setTimeout> | null = null;
 
+      const _heartbeatStart = Date.now();
+      let _heartbeatTimer: ReturnType<typeof setTimeout> | null = null;
+      function _scheduleHeartbeat(): void {
+        if (settled) return;
+        _heartbeatTimer = setTimeout(() => {
+          if (settled) return;
+          try { ctx.onHeartbeat?.(Date.now() - _heartbeatStart); } catch { /* progress callback must never break readiness */ }
+          _scheduleHeartbeat();
+        }, 2000);
+        _heartbeatTimer.unref?.();
+      }
+
       function settle(value: boolean): void {
         if (settled) return;
         settled = true;
@@ -782,11 +816,13 @@ export const PYTHON_ADAPTER: LanguageAdapter = {
           clearTimeout(timer);
           timer = null;
         }
+        if (_heartbeatTimer !== null) { clearTimeout(_heartbeatTimer); _heartbeatTimer = null; }
         resolve(value);
       }
 
       // Set the hard deadline — resolves false if the probe loop does not
       // produce a ready signal before it elapses.
+      _scheduleHeartbeat();
       timer = setTimeout(() => {
         settle(false);
       }, deadline);
@@ -1005,10 +1041,23 @@ export const GO_ADAPTER: LanguageAdapter = {
       let progressSub: { dispose(): void } | null = null;
       let timer: ReturnType<typeof setTimeout> | null = null;
 
+      const _heartbeatStart = Date.now();
+      let _heartbeatTimer: ReturnType<typeof setTimeout> | null = null;
+      function _scheduleHeartbeat(): void {
+        if (settled) return;
+        _heartbeatTimer = setTimeout(() => {
+          if (settled) return;
+          try { ctx.onHeartbeat?.(Date.now() - _heartbeatStart); } catch { /* progress callback must never break readiness */ }
+          _scheduleHeartbeat();
+        }, 2000);
+        _heartbeatTimer.unref?.();
+      }
+
       function settle(value: boolean): void {
         if (settled) return;
         settled = true;
         if (timer !== null) { clearTimeout(timer); timer = null; }
+        if (_heartbeatTimer !== null) { clearTimeout(_heartbeatTimer); _heartbeatTimer = null; }
         try { progressSub?.dispose(); } catch { /* ignore */ }
         resolve(value);
       }
@@ -1043,6 +1092,7 @@ export const GO_ADAPTER: LanguageAdapter = {
       }
 
       // Step 3: deadline backstop — canary probe (mirrors JAVA_ADAPTER path B).
+      _scheduleHeartbeat();
       timer = setTimeout(() => {
         if (settled) return;
         void (async () => {
@@ -1216,10 +1266,23 @@ export const RUST_ADAPTER: LanguageAdapter = {
       let statusSub: { dispose(): void } | null = null;
       let timer: ReturnType<typeof setTimeout> | null = null;
 
+      const _heartbeatStart = Date.now();
+      let _heartbeatTimer: ReturnType<typeof setTimeout> | null = null;
+      function _scheduleHeartbeat(): void {
+        if (settled) return;
+        _heartbeatTimer = setTimeout(() => {
+          if (settled) return;
+          try { ctx.onHeartbeat?.(Date.now() - _heartbeatStart); } catch { /* progress callback must never break readiness */ }
+          _scheduleHeartbeat();
+        }, 2000);
+        _heartbeatTimer.unref?.();
+      }
+
       function settle(value: boolean): void {
         if (settled) return;
         settled = true;
         if (timer !== null) { clearTimeout(timer); timer = null; }
+        if (_heartbeatTimer !== null) { clearTimeout(_heartbeatTimer); _heartbeatTimer = null; }
         try { statusSub?.dispose(); } catch { /* ignore */ }
         resolve(value);
       }
@@ -1253,6 +1316,7 @@ export const RUST_ADAPTER: LanguageAdapter = {
 
       // Step 3: deadline backstop — canary probe (mirrors GO_ADAPTER path B,
       // but zero samples → true is a deliberate deviation from GO_ADAPTER).
+      _scheduleHeartbeat();
       timer = setTimeout(() => {
         if (settled) return;
         void (async () => {

--- a/gitnexus/src/core/ingestion/lsp/lsp-client.ts
+++ b/gitnexus/src/core/ingestion/lsp/lsp-client.ts
@@ -103,6 +103,11 @@ export interface LspClientOptions {
    */
   maxInFlight?: number;
   /**
+   * WI-1 (heartbeat): forwarded to `AdapterReadyCtx.onHeartbeat` so adapters
+   * can report warm-up progress. Optional — omitting it preserves existing behaviour.
+   */
+  onHeartbeat?: (elapsedMs: number) => void;
+  /**
    * Optional factory hook used by tests to inject a fake
    * subprocess + a fake JSON-RPC connection. Production code
    * leaves this undefined. When set, the client does not
@@ -359,6 +364,7 @@ export class LspClient {
   private readonly maxRestarts: number;
   private readonly inject: LspClientOptions['_inject'];
   private readonly adapter: LanguageAdapter;
+  private readonly onHeartbeat: ((elapsedMs: number) => void) | undefined;
 
   /**
    * Realpath-resolved workspace root, computed once lazily.
@@ -391,6 +397,7 @@ export class LspClient {
     this.maxRestarts = opts.maxRestarts ?? MAX_RESTARTS;
     this.inject = opts._inject;
     this.adapter = opts.adapter ?? TYPESCRIPT_ADAPTER;
+    this.onHeartbeat = opts.onHeartbeat;
     // Lever 13: clamp to a sane positive integer; default 1 (serial).
     this.maxInFlight = Math.max(1, Math.floor(opts.maxInFlight ?? 1));
     this.slots = this.maxInFlight;
@@ -1071,6 +1078,7 @@ export class LspClient {
         // deadlineMs omitted → adapter default (120 000 ms for jdtls)
         ...progressSeam,
         ...serverStatusSeam,
+        onHeartbeat: this.onHeartbeat,
       };
       if (!(await this.adapter.awaitReady(ctx))) {
         this.cleanupAfterFailure();

--- a/gitnexus/src/core/ingestion/mode-a-reconciler.ts
+++ b/gitnexus/src/core/ingestion/mode-a-reconciler.ts
@@ -370,6 +370,17 @@ export interface WithReconciliationSessionDeps {
    * exactly, so all existing tests that never pass this dep are unaffected.
    */
   onGateFailure?: (reason: 'no-server' | 'not-ready' | 'dispatch-error', elapsedS: string) => void;
+  /**
+   * WI-1 (heartbeat): forwarded to `LspClientOptions.onHeartbeat` so the
+   * language adapter can emit live readiness progress. Absent → no heartbeat.
+   */
+  onHeartbeat?: (elapsedMs: number) => void;
+  /**
+   * WI-2 (candidate progress): called after each `handToEngine` completion,
+   * throttled to every 25 calls. `done` is the number of completed
+   * `handToEngine` calls; `total` is `selected.length`. Absent → no callback.
+   */
+  onCandidateProgress?: (done: number, total: number) => void;
 }
 
 // ─── Defaults (KD-9, KD-10) ────────────────────────────────────────────
@@ -460,8 +471,9 @@ function defaultCreateLspClient(
   repo: ReconciliationRepo,
   adapter: LanguageAdapter,
   maxInFlight?: number,
+  onHeartbeat?: (elapsedMs: number) => void,
 ): ReconciliationLspClient {
-  return new LspClient({ workspaceRoot: repo.repoPath, adapter, maxInFlight });
+  return new LspClient({ workspaceRoot: repo.repoPath, adapter, maxInFlight, onHeartbeat });
 }
 
 /**
@@ -593,7 +605,7 @@ export async function withReconciliationSession<T>(
   // WI-6: inline the adapter-aware default so the factory closes
   // over the selected adapter (TS or Java) — the module-level
   // `defaultCreateLspClient` now accepts adapter as second arg.
-  const factory = deps.createLspClient ?? ((r: ReconciliationRepo) => defaultCreateLspClient(r, adapter, deps.maxInFlight));
+  const factory = deps.createLspClient ?? ((r: ReconciliationRepo) => defaultCreateLspClient(r, adapter, deps.maxInFlight, deps.onHeartbeat));
   const client = factory(repo);
   try {
     await client.start();
@@ -669,6 +681,7 @@ export async function withReconciliationSession<T>(
     // files. Cache the file→uri mapping for the lifetime of
     // this dispatch loop; the cache dies with the session.
     const uriCache = new Map<string, string>();
+    let _candidateDone = 0;
     await runWithConcurrency(
       selected,
       CONCURRENT_DEFINITION_REQUESTS,
@@ -716,6 +729,10 @@ export async function withReconciliationSession<T>(
           }
         }
         await handToEngine(candidate, result.locations);
+        _candidateDone++;
+        if (deps.onCandidateProgress && _candidateDone % 25 === 0) {
+          try { deps.onCandidateProgress(_candidateDone, selected.length); } catch { /* progress callback must never break the session */ }
+        }
         // Adaptive early-bail accounting: a non-empty Location[] is a "hit".
         // After a full 0-hit sample, trip the bail so the remaining candidates
         // are skipped (kept). Only fires on probed candidates (preFiltered ones

--- a/gitnexus/src/core/ingestion/mode-a-reconciler.ts
+++ b/gitnexus/src/core/ingestion/mode-a-reconciler.ts
@@ -60,7 +60,7 @@ import type { DiscoveredServers } from './lsp/server-discovery.js';
 import type { GraphRelationship, KnowledgeGraph, EdgeSource } from '../graph/types.js';
 import { CALLABLE_SYMBOL_TYPES } from './call-processor.js';
 import { generateId } from '../../lib/utils.js';
-import { pathToFileURL } from 'node:url';
+import { pathToFileURL, fileURLToPath } from 'node:url';
 import { isAbsolute as pathIsAbsolute, resolve as pathResolve } from 'node:path';
 
 // ─── Public types ──────────────────────────────────────────────────────
@@ -155,6 +155,15 @@ export interface SessionMeta {
    * entered the dispatch loop). Populated before calling the work fn.
    */
   preFilteredExternal: number;
+  /**
+   * Count of candidates skipped because adaptive early-bail had already
+   * tripped (LSP_EARLY_BAIL_SAMPLE probed with 0 resolutions). These keep
+   * their heuristic edge — identical to probing-and-getting-empty under the
+   * observed 0-hit rate. 0 when bail never triggers (the common case).
+   */
+  bailed?: number;
+  /** True once early-bail tripped during this session. */
+  earlyBailed?: boolean;
 }
 
 /**
@@ -283,6 +292,14 @@ export interface WithReconciliationSessionDeps {
    */
   definitionCache?: DefinitionCache;
   /**
+   * Adaptive early-bail. `false` forces exhaustive probing; otherwise
+   * (default, undefined) the dispatch stops after probing
+   * LSP_EARLY_BAIL_SAMPLE candidates with 0 resolutions and keeps the
+   * heuristic for the rest. Only trips on a strict 0-hit sample → resolving
+   * repos are byte-identical.
+   */
+  earlyBail?: boolean;
+  /**
    * Server version, captured upstream (production may pass the
    * discovered version here so the summary line can attribute
    * results to a specific binary). When omitted, the session
@@ -380,6 +397,41 @@ export const CONCURRENT_DEFINITION_REQUESTS = 8;
 
 /** Probe request method — kept as a constant for clarity. */
 const TEXT_DOCUMENT_DEFINITION = 'textDocument/definition';
+
+/**
+ * Vendor/stdlib path segments. A `textDocument/definition` that resolves INTO
+ * one of these (e.g. pylsp answering a numpy call with a path under
+ * site-packages, or the Python stdlib under `lib/python3.x/`) never maps to an
+ * indexed node, so it is NOT a useful resolution for early-bail purposes.
+ */
+const VENDOR_SEGMENT_RE = /[/\\](?:site-packages|dist-packages|node_modules|__pycache__|\.venv|venv|lib[/\\]python[0-9.]*)[/\\]/;
+
+/**
+ * Early-bail "useful resolution" predicate. Returns true if the probe resolved
+ * to at least one NON-vendor location (a plausible in-repo definition). This is
+ * a PERFORMANCE heuristic only — it decides WHEN to stop probing, never graph
+ * correctness (bailed candidates keep their heuristic edge regardless). Errs
+ * toward "useful" (no bail) on anything it can't parse, so it never bails a repo
+ * the server is actually resolving.
+ */
+function resolvesUseful(locations: Location[]): boolean {
+  for (const loc of locations) {
+    let p: string;
+    try { p = fileURLToPath(loc.uri); } catch { return true; }
+    if (!VENDOR_SEGMENT_RE.test(p)) return true;
+  }
+  return false;
+}
+
+/**
+ * Adaptive early-bail sample size. Once the dispatch loop has probed this many
+ * candidates with ZERO resolutions (every `textDocument/definition` came back
+ * empty), the server is demonstrably not resolving this repo — continuing would
+ * only add latency, not edges. We stop and keep the heuristic for the rest.
+ * Set high enough to be representative; only a strict 0-hit sample bails, so any
+ * repo the server resolves at all is never affected (byte-identical).
+ */
+export const LSP_EARLY_BAIL_SAMPLE = 150;
 
 // ─── Defaults: real-foundation wiring ─────────────────────────────────
 
@@ -571,7 +623,13 @@ export async function withReconciliationSession<T>(
   // WI-5: probed/preFilteredExternal start at 0 and are incremented
   // in the dispatch loop below. meta is built here so the fields
   // exist; values are written before fn() is called.
-  const meta: SessionMeta = { serverVersion, requestTimeoutMs, cap, probed: 0, preFilteredExternal: 0 };
+  const meta: SessionMeta = { serverVersion, requestTimeoutMs, cap, probed: 0, preFilteredExternal: 0, bailed: 0 };
+  // Adaptive early-bail state. Once we have probed `earlyBailThreshold`
+  // candidates with `hits === 0` (every definition came back empty), stop
+  // dispatching: the server is not resolving this repo. `Infinity` disables it.
+  const earlyBailThreshold = deps.earlyBail === false ? Infinity : LSP_EARLY_BAIL_SAMPLE;
+  let lspHits = 0;
+  let earlyBailed = false;
   // Measure elapsed time from here so the not-ready message can carry
   // a meaningful duration (the probe itself may spin for up to 600s on
   // a slow jdtls workspace build).
@@ -615,6 +673,13 @@ export async function withReconciliationSession<T>(
       selected,
       CONCURRENT_DEFINITION_REQUESTS,
       async (candidate) => {
+        // Adaptive early-bail: once tripped, skip every remaining candidate.
+        // No probe, no handToEngine → locs=[] → NO_NODE → KEEP heuristic,
+        // identical to probing-and-getting-empty under the observed 0-hit rate.
+        if (earlyBailed) {
+          meta.bailed = (meta.bailed ?? 0) + 1;
+          return;
+        }
         // WI-8: external pre-filter seam fires BEFORE the LSP request.
         // Return true ONLY for provably-external correction candidates
         // (I-2c: no false skips). Recall candidates must always probe.
@@ -651,6 +716,27 @@ export async function withReconciliationSession<T>(
           }
         }
         await handToEngine(candidate, result.locations);
+        // Adaptive early-bail accounting: a non-empty Location[] is a "hit".
+        // After a full 0-hit sample, trip the bail so the remaining candidates
+        // are skipped (kept). Only fires on probed candidates (preFiltered ones
+        // never reach here with a probe). `>=` + the `!earlyBailed` guard make
+        // the trip idempotent under concurrency (a few in-flight probes past
+        // the threshold are harmless — they just add to the sample).
+        if (resolvesUseful(result.locations)) lspHits++;
+        // Only trip when candidates actually remain to skip (so a feed sized
+        // exactly at the threshold never bails pointlessly).
+        const processed = meta.probed + (meta.preFilteredExternal ?? 0) + (meta.bailed ?? 0);
+        if (!earlyBailed && lspHits === 0 && meta.probed >= earlyBailThreshold && processed < selected.length) {
+          earlyBailed = true;
+          meta.earlyBailed = true;
+          const bailS = ((Date.now() - sessionStart) / 1000).toFixed(1);
+          console.warn(
+            `  LSP early-bail: 0/${meta.probed} candidates resolved after ${bailS}s — ` +
+            `server not resolving this repo; keeping heuristic for the remaining ` +
+            `~${Math.max(0, selected.length - meta.probed - (meta.preFilteredExternal ?? 0))} candidates ` +
+            `(disable with --lsp-no-early-bail).`,
+          );
+        }
       },
     );
     return await fn(selected, meta, skipped);

--- a/gitnexus/src/core/ingestion/parsing-processor.ts
+++ b/gitnexus/src/core/ingestion/parsing-processor.ts
@@ -44,11 +44,124 @@ export interface WorkerExtractedData {
   constructorBindings: FileConstructorBindings[];
   typeEnvBindings: FileTypeEnvBindings[];
   angularMetadata: import('./workers/parse-worker.js').ExtractedAngularEdge[];
+  /**
+   * Set to true when processParsingWithWorkers threw and sequential fallback was
+   * used for this chunk. The pipeline checks this to call processImports (which
+   * reads files directly) instead of processImportsFromExtracted (which would
+   * receive empty imports and silently drop all import edges for the chunk).
+   */
+  workerFailed?: true;
 }
 
 // ============================================================================
 // Worker-based parallel parsing
 // ============================================================================
+
+/**
+ * Recompute the Laravel + Spring route channel for a chunk on the WORKER path so
+ * it is byte-identical to what `processParsingSequential` produces for the same
+ * chunk. Workers extract Spring routes per-file in isolation via the 2-arg
+ * `extractSpringRoutes(tree, path)` — they cannot resolve constant-based mapping
+ * paths (no repo-wide `javaConstants`) and cannot see base controllers declared
+ * in other files (no cross-file inherited pass). That divergence drops every
+ * constant-path route and every cross-file inherited route (WI-90) on the worker
+ * path. This helper mirrors the sequential route logic exactly:
+ *   1. pre-pass: collect `javaConstants` + parsed Java trees (chunk-scoped, same
+ *      scope the sequential path uses since both run per 20MB chunk);
+ *   2. per-file pass in `files` order: Laravel (PHP route files) + constant-aware
+ *      3-arg `extractSpringRoutes(tree, path, javaConstants)` (Java controllers);
+ *   3. repo/chunk-wide inherited pass (`buildSpringClassRegistry` +
+ *      `extractInheritedSpringRoutes`), deduped with the SAME key the sequential
+ *      path uses.
+ * It intentionally duplicates `processParsingSequential`'s route extraction (kept
+ * inline there so the sequential path is not perturbed). The `result.routes`
+ * emitted by the workers is discarded in favour of this output. Determinism: the
+ * per-file order follows `files`; the inherited pass follows registry insertion
+ * (= file walk) order — identical to the sequential path.
+ */
+const extractSpringRoutesForWorkerParity = async (
+  files: { path: string; content: string }[],
+  parser: Parser,
+): Promise<ExtractedRoute[]> => {
+  const allRoutes: ExtractedRoute[] = [];
+  const javaConstants = new Map<string, string>();
+  const javaFileMap = new Map<string, { tree: Parser.Tree }>();
+
+  // ── Pre-pass: parse Java files, collect constants + trees (mirror seq 262-290) ──
+  for (const file of files) {
+    const language = getLanguageFromFilename(file.path);
+    if (language !== SupportedLanguages.Java) continue;
+    try {
+      await loadLanguage(language, file.path);
+    } catch {
+      continue;
+    }
+    if (file.content.length > TREE_SITTER_MAX_BUFFER) continue;
+    let tree;
+    try {
+      tree = parser.parse(file.content, undefined, { bufferSize: getTreeSitterBufferSize(file.content.length) });
+    } catch {
+      continue;
+    }
+    javaFileMap.set(file.path, { tree });
+    const fileConstants = collectFileConstants(tree.rootNode);
+    for (const [k, v] of fileConstants) {
+      if (!javaConstants.has(k)) javaConstants.set(k, v);
+    }
+  }
+
+  // ── Per-file pass in file order: Laravel + Spring only (mirror seq 343-355) ──
+  for (const file of files) {
+    const language = getLanguageFromFilename(file.path);
+    if (!language) continue;
+    if (!isLanguageAvailable(language)) continue;
+    if (file.content.length > TREE_SITTER_MAX_BUFFER) continue;
+
+    // Laravel routes from PHP route files
+    if (language === SupportedLanguages.PHP && (file.path.includes('/routes/') || file.path.startsWith('routes/')) && file.path.endsWith('.php')) {
+      try {
+        await loadLanguage(language, file.path);
+      } catch {
+        continue;
+      }
+      let tree;
+      try {
+        tree = parser.parse(file.content, undefined, { bufferSize: getTreeSitterBufferSize(file.content.length) });
+      } catch {
+        continue;
+      }
+      allRoutes.push(...extractLaravelRoutes(tree, file.path));
+    }
+
+    // Spring routes from Java controller files (constant-aware, reuse pre-pass tree)
+    if (language === SupportedLanguages.Java && (file.content.includes('@Controller') || file.content.includes('@RestController'))) {
+      const entry = javaFileMap.get(file.path);
+      if (!entry) continue;
+      allRoutes.push(...extractSpringRoutes(entry.tree, file.path, javaConstants));
+    }
+  }
+
+  // ── Repo/chunk-wide cross-file @RequestMapping inheritance (mirror seq 760-776) ──
+  if (javaFileMap.size > 0) {
+    const springRegistry = buildSpringClassRegistry(
+      Array.from(javaFileMap.entries()).map(([filePath, { tree }]) => ({ filePath, tree })),
+      javaConstants,
+    );
+    const inheritedRoutes = extractInheritedSpringRoutes(springRegistry);
+    if (inheritedRoutes.length > 0) {
+      const seenRouteKeys = new Set(allRoutes.map(r => `${r.filePath}:${r.httpMethod}:${r.routePath}`));
+      for (const r of inheritedRoutes) {
+        const key = `${r.filePath}:${r.httpMethod}:${r.routePath}`;
+        if (!seenRouteKeys.has(key)) {
+          seenRouteKeys.add(key);
+          allRoutes.push(r);
+        }
+      }
+    }
+  }
+
+  return allRoutes;
+};
 
 const processParsingWithWorkers = async (
   graph: KnowledgeGraph,
@@ -69,6 +182,10 @@ const processParsingWithWorkers = async (
 
   const total = files.length;
 
+  // Main-thread parser for the Spring/Laravel route parity recompute below — the
+  // worker's per-file `result.routes` are discarded for the route channel (R-parity).
+  const parser = await loadParser();
+
   // Dispatch to worker pool — pool handles splitting into chunks and sub-batching
   const chunkResults = await workerPool.dispatch<ParseWorkerInput, ParseWorkerResult>(
     parseableFiles,
@@ -79,7 +196,7 @@ const processParsingWithWorkers = async (
 
   // Merge results from all workers into graph and symbol table
   const allImports: ExtractedImport[] = [];
-  const allCalls: ExtractedCall[] = [];
+  const allAngularCalls: ExtractedCall[] = [];
   const allAssignments: ExtractedAssignment[] = [];
   const allHeritage: ExtractedHeritage[] = [];
   const allRoutes: ExtractedRoute[] = [];
@@ -120,10 +237,15 @@ const processParsingWithWorkers = async (
     }
 
     allImports.push(...result.imports);
-    allCalls.push(...result.calls);
+    // #31: Angular DI/template CALLS — the only calls the worker path emits
+    // here (general calls are resolved separately via processCalls re-extraction).
+    allAngularCalls.push(...(result.angularCalls ?? []));
     if (result.assignments) allAssignments.push(...result.assignments);
     allHeritage.push(...result.heritage);
-    allRoutes.push(...result.routes);
+    // result.routes (per-file 2-arg Spring + Laravel) is intentionally NOT merged
+    // here — the Spring/Laravel route channel is recomputed below via
+    // extractSpringRoutesForWorkerParity so it matches the sequential path
+    // (constant resolution + cross-file inherited routes). See helper doc.
     if (result.fetchCalls) allFetchCalls.push(...result.fetchCalls);
     if (result.expoNavCalls) allExpoNavCalls.push(...result.expoNavCalls);
     if (result.decoratorRoutes) allDecoratorRoutes.push(...result.decoratorRoutes);
@@ -133,6 +255,13 @@ const processParsingWithWorkers = async (
     if (result.typeEnvBindings) allTypeEnvBindings.push(...result.typeEnvBindings);
     if (result.angularMetadata) allAngularMetadata.push(...result.angularMetadata);
   }
+
+  // Recompute the Laravel + Spring route channel on the main thread so the worker
+  // path is byte-identical to the sequential path: workers cannot resolve
+  // constant-based mapping paths (no repo-wide javaConstants) nor emit cross-file
+  // inherited routes (WI-90), which dropped ~137 Route DEFINES + CALLS on large
+  // Spring repos. Mirrors processParsingSequential's route logic per chunk.
+  allRoutes.push(...(await extractSpringRoutesForWorkerParity(files, parser)));
 
   // Count nodes by label
   const nodesByLabel: Record<string, number> = {};
@@ -164,7 +293,7 @@ const processParsingWithWorkers = async (
 
   // Final progress
   onFileProgress?.(total, total, 'done');
-  return { imports: allImports, calls: allCalls, assignments: allAssignments, heritage: allHeritage, routes: allRoutes, fetchCalls: allFetchCalls, expoNavCalls: allExpoNavCalls, decoratorRoutes: allDecoratorRoutes, toolDefs: allToolDefs, ormQueries: allORMQueries, constructorBindings: allConstructorBindings, typeEnvBindings: allTypeEnvBindings, angularMetadata: allAngularMetadata };
+  return { imports: allImports, calls: allAngularCalls, assignments: allAssignments, heritage: allHeritage, routes: allRoutes, fetchCalls: allFetchCalls, expoNavCalls: allExpoNavCalls, decoratorRoutes: allDecoratorRoutes, toolDefs: allToolDefs, ormQueries: allORMQueries, constructorBindings: allConstructorBindings, typeEnvBindings: allTypeEnvBindings, angularMetadata: allAngularMetadata };
 };
 
 // ============================================================================
@@ -802,9 +931,14 @@ export const processParsing = async (
       return await processParsingWithWorkers(graph, files, symbolTable, astCache, workerPool, onFileProgress);
     } catch (err) {
       console.warn('Worker pool parsing failed, falling back to sequential:', err instanceof Error ? err.message : err);
+      // Signal the fallback via workerFailed so the pipeline takes the sequential
+      // branch (processImports) instead of processImportsFromExtracted — otherwise
+      // imports: [] would silently drop all import edges for this chunk (R5).
+      const result = await processParsingSequential(graph, files, symbolTable, astCache, onFileProgress);
+      return { ...result, workerFailed: true };
     }
   }
 
-  // Fallback: sequential parsing
+  // Fallback: sequential parsing (no worker pool or explicit opt-out)
   return processParsingSequential(graph, files, symbolTable, astCache, onFileProgress);
 };

--- a/gitnexus/src/core/ingestion/pipeline.ts
+++ b/gitnexus/src/core/ingestion/pipeline.ts
@@ -51,6 +51,12 @@ export interface PipelineOptions {
   /** Skip MRO, community detection, and process extraction for faster test runs. */
   skipGraphPhases?: boolean;
   /**
+   * Run parse workers in parallel (default: true — opt-out). Set to false or
+   * pass GITNEXUS_PARALLEL_PARSE=0 env to force sequential. Useful for
+   * debugging or very memory-constrained environments.
+   */
+  parallelParse?: boolean;
+  /**
    * #50: when provided, unresolved imports whose package maps to an indexed
    * dependency repo create an external File node + CROSS_IMPORTS edge. When
    * omitted (the default), ingestion is single-repo and creates no external nodes.
@@ -304,9 +310,9 @@ export const runPipelineFromRepo = async (
     });
 
     // Don't spawn workers for tiny repos — overhead exceeds benefit.
-    // Gate on GITNEXUS_PARALLEL_PARSE=1 so the default analyze path stays
-    // byte-identical to the sequential baseline (STEP 0).
-    const PARALLEL_PARSE_ENABLED = process.env.GITNEXUS_PARALLEL_PARSE === '1';
+    // Default ON (opt-out). Disable via GITNEXUS_PARALLEL_PARSE=0 env or
+    // options.parallelParse===false (--no-parallel-parse CLI flag).
+    const PARALLEL_PARSE_ENABLED = options?.parallelParse !== false && process.env.GITNEXUS_PARALLEL_PARSE !== '0';
     const MIN_FILES_FOR_WORKERS = 100;
     const MIN_BYTES_FOR_WORKERS = 512 * 1024;  // 512KB threshold
     const totalBytes = parseableScanned.reduce((s, f) => s + f.size, 0);
@@ -327,7 +333,9 @@ export const runPipelineFromRepo = async (
         }
         workerPool = createWorkerPool(workerUrl);
       } catch (err) {
-        if (isDev) console.warn('Worker pool creation failed, using sequential fallback:', (err as Error).message);
+        // Unconditional user-visible warn: we WANTED workers (above threshold) but
+        // couldn't spawn them. Not emitted for the normal under-threshold sequential path.
+        console.warn(`  Parallel parse unavailable, falling back to sequential (slower): ${(err as Error).message}`);
       }
     }
 
@@ -449,8 +457,8 @@ export const runPipelineFromRepo = async (
 
         const chunkBasePercent = 20 + ((filesParsedSoFar / totalParseable) * 62);
 
-        if (workerPool && chunkWorkerData) {
-          // Worker path (GITNEXUS_PARALLEL_PARSE=1): parallel-parse-only lossless strategy.
+        if (workerPool && chunkWorkerData && !chunkWorkerData.workerFailed) {
+          // Worker path (parallel parse, default ON): parallel-parse-only lossless strategy.
           //
           // Workers extract nodes/symbols (stored directly in graph/symbolTable by
           // processParsingWithWorkers). Import edges are resolved here from the extracted
@@ -516,6 +524,7 @@ export const runPipelineFromRepo = async (
             allToolDefs.push(...chunkWorkerData.toolDefs);
           }
         } else {
+          if (chunkWorkerData?.workerFailed) workerPool = undefined; // dead worker — stop re-dispatching to a broken pool
           // Sequential path: processImports adds symbols, then heritage/calls are resolved
           // in the sequential fallback loop below (lines 351-365)
           await processImports(graph, chunkFiles, astCache, ctx, undefined, repoPath, allPaths, options?.crossRepoRegistry, javaExternalFqnIndex, pythonExternalFqnIndex);
@@ -1082,6 +1091,22 @@ export const runPipelineFromRepo = async (
           onGateFailure: (reason, elapsedS) => {
             gateFailureReason = reason;
             gateFailureElapsedS = elapsedS;
+          },
+          onHeartbeat: (elapsedMs) => {
+            onProgress({
+              phase: 'lsp',
+              percent: 80,
+              message: `LSP: waiting for ${lspAdapter?.serverBinary ?? 'server'} to index… ${Math.round(elapsedMs / 1000)}s`,
+              stats: { filesProcessed: totalFiles, totalFiles, nodesCreated: graph.nodeCount },
+            });
+          },
+          onCandidateProgress: (done, total) => {
+            onProgress({
+              phase: 'lsp',
+              percent: Math.round(80 + (done / total) * 10),
+              message: `LSP: resolved ${done}/${total} candidates`,
+              stats: { filesProcessed: totalFiles, totalFiles, nodesCreated: graph.nodeCount },
+            });
           },
         },
       );

--- a/gitnexus/src/core/ingestion/pipeline.ts
+++ b/gitnexus/src/core/ingestion/pipeline.ts
@@ -109,6 +109,18 @@ export interface PipelineOptions {
      * the git/commit/clean-tree checks). Absent → no caching.
      */
     definitionCache?: DefinitionCache;
+    /**
+     * Adaptive early-bail. When true (default), the reconciler stops the
+     * per-candidate dispatch once it has probed LSP_EARLY_BAIL_SAMPLE
+     * candidates with ZERO resolutions — the server is demonstrably not
+     * resolving this repo (e.g. pylsp on a dynamic-Python tree), so the
+     * remaining probes would only add latency, not edges. Bailed candidates
+     * keep their heuristic edge (identical to probing-and-getting-empty under
+     * the 0-hit observation). `false` forces exhaustive probing. Only ever
+     * triggers on a strict 0/150 sample, so resolving repos are unaffected
+     * (byte-identical).
+     */
+    earlyBail?: boolean;
   };
 }
 
@@ -291,14 +303,17 @@ export const runPipelineFromRepo = async (
       stats: { filesProcessed: 0, totalFiles: totalParseable, nodesCreated: graph.nodeCount },
     });
 
-    // Don't spawn workers for tiny repos — overhead exceeds benefit
-    const MIN_FILES_FOR_WORKERS = 1000000;
-    const MIN_BYTES_FOR_WORKERS = 1024 * 1024 * 1024;  // 512KB threshold
+    // Don't spawn workers for tiny repos — overhead exceeds benefit.
+    // Gate on GITNEXUS_PARALLEL_PARSE=1 so the default analyze path stays
+    // byte-identical to the sequential baseline (STEP 0).
+    const PARALLEL_PARSE_ENABLED = process.env.GITNEXUS_PARALLEL_PARSE === '1';
+    const MIN_FILES_FOR_WORKERS = 100;
+    const MIN_BYTES_FOR_WORKERS = 512 * 1024;  // 512KB threshold
     const totalBytes = parseableScanned.reduce((s, f) => s + f.size, 0);
 
     // Create worker pool once, reuse across chunks
     let workerPool: WorkerPool | undefined;
-    if (totalParseable >= MIN_FILES_FOR_WORKERS || totalBytes >= MIN_BYTES_FOR_WORKERS) {
+    if (PARALLEL_PARSE_ENABLED && (totalParseable >= MIN_FILES_FOR_WORKERS || totalBytes >= MIN_BYTES_FOR_WORKERS)) {
       try {
         let workerUrl = new URL('./workers/parse-worker.js', import.meta.url);
         // When running under vitest, import.meta.url points to src/ where no .js exists.
@@ -362,12 +377,20 @@ export const runPipelineFromRepo = async (
     const javaExternalFqnIndex: Map<string, Map<string, string>> | undefined =
       options?.lsp?.enabled ? new Map() : undefined;
 
+    // ADR-002 Lever 10: pythonExternalFqnIndex — same lifecycle as javaExternalFqnIndex.
+    // Allocated ONLY under the lsp gate; absent on the default analyze path (I-9).
+    // Maps filePath → boundName → module (e.g. 'np' → 'numpy', 'getcwd' → 'os').
+    // Populated by both import-processor paths; consumed by both call-processor paths.
+    const pythonExternalFqnIndex: Map<string, Map<string, string>> | undefined =
+      options?.lsp?.enabled ? new Map() : undefined;
+
     const lspFeedsOpt: ProcessCallsOpts | undefined = options?.lsp?.enabled
       ? {
           lsp: true,
           correctionFeed,
           recallFeed,
           javaExternalFqnIndex,
+          pythonExternalFqnIndex,
           highTierSampleRate: options.lsp.highTierSampleRate,
         }
       : undefined;
@@ -392,6 +415,9 @@ export const runPipelineFromRepo = async (
       ? { lsp: true, heritageFeed }
       : undefined;
 
+    // TEMP perf split (GITNEXUS_PHASE_TIMING): accumulate per-step wall time.
+    const _pt = process.env.GITNEXUS_PHASE_TIMING === '1';
+    let _tParse = 0, _tImp = 0, _tHer = 0, _tCall = 0;
     try {
       for (let chunkIdx = 0; chunkIdx < numChunks; chunkIdx++) {
         const chunkPaths = chunks[chunkIdx];
@@ -403,6 +429,7 @@ export const runPipelineFromRepo = async (
           .map(p => ({ path: p, content: chunkContents.get(p)! }));
 
         // Parse this chunk (workers or sequential fallback)
+        const _sP = _pt ? Date.now() : 0;
         const chunkWorkerData = await processParsing(
           graph, chunkFiles, symbolTable, astCache,
           (current, _total, filePath) => {
@@ -418,12 +445,32 @@ export const runPipelineFromRepo = async (
           },
           workerPool,
         );
+        if (_pt) _tParse += Date.now() - _sP;
 
         const chunkBasePercent = 20 + ((filesParsedSoFar / totalParseable) * 62);
 
         if (workerPool && chunkWorkerData) {
-          // Worker path: use extracted data for imports, heritage, calls, routes
-          // Imports
+          // Worker path (GITNEXUS_PARALLEL_PARSE=1): parallel-parse-only lossless strategy.
+          //
+          // Workers extract nodes/symbols (stored directly in graph/symbolTable by
+          // processParsingWithWorkers). Import edges are resolved here from the extracted
+          // data — those paths are symbolTable-independent and already correct.
+          //
+          // CALLS and HERITAGE are intentionally NOT resolved from extracted data.
+          // The worker's buildTypeEnv() runs without symbolTable/parentMap/importedReturnTypes,
+          // so the extracted receiverTypeName is degraded and would lose ~473 CALLS edges vs
+          // the sequential baseline. Heritage resolution also needs the full globalParentMap
+          // that processCalls builds internally.
+          //
+          // Instead, we push chunkPaths to sequentialChunkPaths so the existing sequential
+          // re-parse path (processHeritage + processCalls below) resolves both with the
+          // complete context — edge-ID-identical to the baseline by construction.
+          //
+          // Net effect: parallel parse (fast) + sequential resolution (correct).
+
+          // Imports: resolve from extracted data (namedImportMap, IMPORTS edges).
+          // This populates ctx so the sequential call resolution pass has import context.
+          const _sI = _pt ? Date.now() : 0;
           await processImportsFromExtracted(graph, allPathObjects, chunkWorkerData.imports, ctx, (current, total) => {
             onProgress({
               phase: 'parsing',
@@ -432,62 +479,13 @@ export const runPipelineFromRepo = async (
               detail: `${current}/${total} files`,
               stats: { filesProcessed: filesParsedSoFar, totalFiles: totalParseable, nodesCreated: graph.nodeCount },
             });
-          }, repoPath, importCtx, options?.crossRepoRegistry, javaExternalFqnIndex);
-          // Calls + Heritage + Routes — resolve in parallel (no shared mutable state between them)
-          // This is safe because each writes disjoint relationship types into idempotent id-keyed Maps,
-          // and the single-threaded event loop prevents races between synchronous addRelationship calls.
+          }, repoPath, importCtx, options?.crossRepoRegistry, javaExternalFqnIndex, pythonExternalFqnIndex);
+          if (_pt) _tImp += Date.now() - _sI;
 
-          // Heritage MUST run before calls: IMPLEMENTS edges (from heritage) are needed
-          // for D5 call resolution to work correctly. Call resolution depends on
-          // interface/implementation edges being established first.
-          await processHeritageFromExtracted(
-            graph,
-            chunkWorkerData.heritage,
-            ctx,
-            (current, total) => {
-              onProgress({
-                phase: 'parsing',
-                percent: Math.round(chunkBasePercent),
-                message: `Resolving heritage (chunk ${chunkIdx + 1}/${numChunks})...`,
-                detail: `${current}/${total} records`,
-                stats: { filesProcessed: filesParsedSoFar, totalFiles: totalParseable, nodesCreated: graph.nodeCount },
-              });
-            },
-            lspHeritageOpt,
-          );
+          // Calls + Heritage + Routes: deferred to sequential re-parse path (lossless).
+          sequentialChunkPaths.push(chunkPaths);
+          sequentialChunkRoutes.push(chunkWorkerData.routes ?? []);
 
-          await processCallsFromExtracted(
-            graph,
-            chunkWorkerData.calls,
-            ctx,
-            (current, total) => {
-              onProgress({
-                phase: 'parsing',
-                percent: Math.round(chunkBasePercent),
-                message: `Resolving calls (chunk ${chunkIdx + 1}/${numChunks})...`,
-                detail: `${current}/${total} files`,
-                stats: { filesProcessed: filesParsedSoFar, totalFiles: totalParseable, nodesCreated: graph.nodeCount },
-              });
-            },
-            chunkWorkerData.constructorBindings,
-            undefined, // typeEnvBindings — not used in the worker path
-            lspFeedsOpt,
-          );
-
-          await processRoutesFromExtracted(
-            graph,
-            chunkWorkerData.routes ?? [],
-            ctx,
-            (current, total) => {
-              onProgress({
-                phase: 'parsing',
-                percent: Math.round(chunkBasePercent),
-                message: `Resolving routes (chunk ${chunkIdx + 1}/${numChunks})...`,
-                detail: `${current}/${total} routes`,
-                stats: { filesProcessed: filesParsedSoFar, totalFiles: totalParseable, nodesCreated: graph.nodeCount },
-              });
-            },
-          );
           // Accumulate expoNavCalls and ormQueries for post-processing after all chunks
           if (chunkWorkerData.expoNavCalls) {
             allExpoNavCalls.push(...chunkWorkerData.expoNavCalls);
@@ -503,6 +501,12 @@ export const runPipelineFromRepo = async (
           if (chunkWorkerData.angularMetadata) {
             allAngularMetadata.push(...chunkWorkerData.angularMetadata);
           }
+          // #31: Angular CALLS extracted by the worker parsing pass.
+          // General calls are deferred to the sequential re-parse path;
+          // chunkWorkerData.calls carries ONLY Angular DI/template calls here.
+          if (chunkWorkerData.calls && chunkWorkerData.calls.length > 0) {
+            allSequentialCalls.push(...chunkWorkerData.calls);
+          }
           // Accumulate fetchCalls for post-processing
           if (chunkWorkerData.fetchCalls) {
             allFetchCalls.push(...chunkWorkerData.fetchCalls);
@@ -514,7 +518,7 @@ export const runPipelineFromRepo = async (
         } else {
           // Sequential path: processImports adds symbols, then heritage/calls are resolved
           // in the sequential fallback loop below (lines 351-365)
-          await processImports(graph, chunkFiles, astCache, ctx, undefined, repoPath, allPaths, options?.crossRepoRegistry, javaExternalFqnIndex);
+          await processImports(graph, chunkFiles, astCache, ctx, undefined, repoPath, allPaths, options?.crossRepoRegistry, javaExternalFqnIndex, pythonExternalFqnIndex);
           sequentialChunkPaths.push(chunkPaths);
           sequentialChunkRoutes.push(chunkWorkerData.routes ?? []);
           // Accumulate expoNavCalls and ormQueries for sequential path too
@@ -554,6 +558,9 @@ export const runPipelineFromRepo = async (
       }
     } finally {
       await workerPool?.terminate();
+    }
+    if (_pt) {
+      console.warn(`  [phase-timing] parse=${(_tParse / 1000).toFixed(1)}s imports=${(_tImp / 1000).toFixed(1)}s heritage=${(_tHer / 1000).toFixed(1)}s calls=${(_tCall / 1000).toFixed(1)}s`);
     }
 
     // Sequential fallback chunks: re-read source for call/heritage resolution
@@ -897,10 +904,16 @@ export const runPipelineFromRepo = async (
       // dryRun).
       const locations = new Map<string, Location[]>();
 
+      // Distinct 'lsp' phase (not 'parsing') so the CLI labels this window
+      // "LSP augmentation (Ns)" instead of "Parsing code (Ns)". The whole
+      // warm-up + per-candidate dispatch runs under this single emit (the
+      // reconciler issues no progress callbacks), and the CLI's 1s elapsed
+      // timer keeps the seconds ticking — so a long pylsp/jdtls run reads as
+      // a named, live phase rather than a hung parser.
       onProgress({
-        phase: 'parsing',
+        phase: 'lsp',
         percent: 80,
-        message: dryRun ? 'LSP dry-run: resolving candidates...' : 'LSP reconciliation: resolving candidates...',
+        message: dryRun ? 'LSP dry-run: resolving candidates...' : 'LSP augmentation: resolving call graph via language server (first run can take a while)...',
         stats: { filesProcessed: totalFiles, totalFiles, nodesCreated: graph.nodeCount },
       });
 
@@ -1000,6 +1013,9 @@ export const runPipelineFromRepo = async (
           maxInFlight: options?.lsp?.pipeline,
           // Lever 14: persisted definition cache (undefined → no caching).
           definitionCache: options?.lsp?.definitionCache,
+          // Adaptive early-bail (default on): stop probing once a 0/150 sample
+          // shows the server resolves nothing for this repo. undefined → on.
+          earlyBail: options?.lsp?.earlyBail,
           // WI-8: external pre-filter. Uses graph.getNode(oldTargetId)
           // to detect correction candidates whose heuristic target is
           // an external-zone node (NodeProperties.isExternal===true).

--- a/gitnexus/src/core/ingestion/process-processor.ts
+++ b/gitnexus/src/core/ingestion/process-processor.ts
@@ -10,7 +10,7 @@
  * Processes help agents understand how features work through the codebase.
  */
 
-import { KnowledgeGraph, GraphNode, GraphRelationship, NodeLabel } from '../graph/types.js';
+import { KnowledgeGraph, GraphNode, NodeLabel } from '../graph/types.js';
 import { CommunityMembership } from './community-processor.js';
 import { calculateEntryPointScore, isTestFile } from './entry-point-scoring.js';
 import { SupportedLanguages } from '../../config/supported-languages.js';
@@ -239,6 +239,14 @@ const buildCallsGraph = (graph: KnowledgeGraph): AdjacencyList => {
     }
   }
 
+  // Canonicalize callee order by targetId. iterRelationships() yields edges in
+  // graph INSERTION order, which differs between the sequential and parallel-parse
+  // (GITNEXUS_PARALLEL_PARSE) paths even though the edge SET is identical.
+  // traceFromEntryPoint slices callees to maxBranching, so an insertion-order-
+  // dependent list would pick different callees → different traces. Sorting by id
+  // makes tracing insertion-order-independent (parity + run-to-run determinism).
+  for (const callees of adj.values()) callees.sort();
+
   return adj;
 };
 
@@ -315,8 +323,14 @@ const findEntryPoints = (
     }
   }
   
-  // Sort by score descending and return top candidates
-  const sorted = entryPointCandidates.sort((a, b) => b.score - a.score);
+  // Sort by score descending and return top candidates. Total order: equal
+  // scores tie-break by node id so the slice(200) cap below selects the SAME
+  // candidate set regardless of iterNodes() (insertion-order) traversal —
+  // `b.score - a.score` alone left ties in insertion order (worker-vs-seq drift).
+  const sorted = entryPointCandidates.sort((a, b) => {
+    if (b.score !== a.score) return b.score - a.score;
+    return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+  });
   
   // DEBUG: Log top candidates with new scoring details
   if (sorted.length > 0 && isDev) {
@@ -404,8 +418,14 @@ const traceFromEntryPoint = (
 const deduplicateTraces = (traces: string[][]): string[][] => {
   if (traces.length === 0) return [];
   
-  // Sort by length descending
-  const sorted = [...traces].sort((a, b) => b.length - a.length);
+  // Sort by length descending. Total order: equal-length traces tie-break by
+  // full-path lexicographic so the subset-dedup keeps a canonical trace
+  // independent of the order traces were collected (worker-vs-seq drift).
+  const sorted = [...traces].sort((a, b) => {
+    if (b.length !== a.length) return b.length - a.length;
+    const aj = a.join(''), bj = b.join('');
+    return aj < bj ? -1 : aj > bj ? 1 : 0;
+  });
   const unique: string[][] = [];
   
   for (const trace of sorted) {
@@ -436,8 +456,14 @@ const deduplicateByEndpoints = (traces: string[][]): string[][] => {
   if (traces.length === 0) return [];
   
   const byEndpoints = new Map<string, string[]>();
-  // Sort longest first so the first seen per key is the longest
-  const sorted = [...traces].sort((a, b) => b.length - a.length);
+  // Sort longest first so the first seen per key is the longest. Total order:
+  // equal-length traces tie-break by full-path lexicographic so the trace kept
+  // per endpoint pair is canonical regardless of collection order.
+  const sorted = [...traces].sort((a, b) => {
+    if (b.length !== a.length) return b.length - a.length;
+    const aj = a.join(''), bj = b.join('');
+    return aj < bj ? -1 : aj > bj ? 1 : 0;
+  });
   
   for (const trace of sorted) {
     const key = `${trace[0]}::${trace[trace.length - 1]}`;

--- a/gitnexus/src/core/ingestion/process-processor.ts
+++ b/gitnexus/src/core/ingestion/process-processor.ts
@@ -128,9 +128,17 @@ export const processProcesses = async (
   
   onProgress?.(`Deduped ${uniqueTraces.length} → ${endpointDeduped.length} unique endpoint pairs`, 70);
   
-  // Step 4: Limit to max processes (prioritize longer traces)
+  // Step 4: Limit to max processes (prioritize longer traces). Total-order sort:
+  // length desc, then full-path lexicographic tie-break — so the proc_<idx>
+  // numbering (and thus STEP_IN_PROCESS ids) is stable run-to-run. The bare
+  // `b.length - a.length` left equal-length traces in unstable input order,
+  // churning ~180 STEP_IN_PROCESS edges per run (phantom detect_changes diffs).
   const limitedTraces = endpointDeduped
-    .sort((a, b) => b.length - a.length)
+    .sort((a, b) => {
+      if (b.length !== a.length) return b.length - a.length;
+      const aj = a.join(''), bj = b.join('');
+      return aj < bj ? -1 : aj > bj ? 1 : 0;
+    })
     .slice(0, cfg.maxProcesses);
   
   onProgress?.(`Creating ${limitedTraces.length} process nodes...`, 80);

--- a/gitnexus/src/core/ingestion/workers/parse-worker.ts
+++ b/gitnexus/src/core/ingestion/workers/parse-worker.ts
@@ -47,6 +47,7 @@ import {
   isPythonClassMethod,
   isKotlinClassMethod,
   isCppInsideClassOrStruct,
+  CLASS_CONTAINER_TYPES,
 } from '../utils/ast-helpers.js';
 import {
   countCallArguments,
@@ -85,6 +86,23 @@ import { typeConfig as phpTypeConfig } from '../type-extractors/php.js';
 import { typeConfig as rubyTypeConfig } from '../type-extractors/ruby.js';
 import { typeConfig as swiftTypeConfig } from '../type-extractors/swift.js';
 import { typeConfig as dartTypeConfig } from '../type-extractors/dart.js';
+// Field extractors — mirror the sequential parsing-processor.ts `provider.fieldExtractor`
+// wiring so the worker emits the same Property `declaredType` (needed to type `this.<field>`).
+import { createFieldExtractor } from '../field-extractors/generic.js';
+import type { FieldExtractor } from '../field-extractor.js';
+import type { FieldInfo as ExtractedFieldInfo, FieldExtractorContext } from '../field-types.js';
+import { typescriptFieldExtractor } from '../field-extractors/typescript.js';
+import { javascriptConfig } from '../field-extractors/configs/typescript-javascript.js';
+import { javaConfig, kotlinConfig } from '../field-extractors/configs/jvm.js';
+import { pythonConfig } from '../field-extractors/configs/python.js';
+import { goConfig } from '../field-extractors/configs/go.js';
+import { rustConfig } from '../field-extractors/configs/rust.js';
+import { csharpConfig } from '../field-extractors/configs/csharp.js';
+import { cConfig, cppConfig } from '../field-extractors/configs/c-cpp.js';
+import { phpConfig } from '../field-extractors/configs/php.js';
+import { rubyConfig } from '../field-extractors/configs/ruby.js';
+import { swiftConfig } from '../field-extractors/configs/swift.js';
+import { dartConfig } from '../field-extractors/configs/dart.js';
 import { generateId } from '../../../lib/utils.js';
 import { appendKotlinWildcard } from '../import-resolvers/jvm.js';
 import type { CallRouter } from '../call-routing.js';
@@ -141,6 +159,68 @@ const typeConfigs: Record<string, any> = {
   [SupportedLanguages.Ruby]: rubyTypeConfig,
   [SupportedLanguages.Swift]: swiftTypeConfig,
   [SupportedLanguages.Dart]: dartTypeConfig,
+};
+
+/**
+ * Map languages to their field extractors. Identical wiring to LanguageProvider
+ * (languages/*.ts): TypeScript uses the bespoke `typescriptFieldExtractor`, every
+ * other language is config-driven. The worker has no provider registry, so it
+ * builds the same extractors directly — this is what lets the worker emit the same
+ * Property `declaredType` the sequential parsing-processor path does.
+ */
+const fieldExtractors: Record<string, FieldExtractor> = {
+  [SupportedLanguages.TypeScript]: typescriptFieldExtractor,
+  [SupportedLanguages.JavaScript]: createFieldExtractor(javascriptConfig),
+  [SupportedLanguages.Java]: createFieldExtractor(javaConfig),
+  [SupportedLanguages.Kotlin]: createFieldExtractor(kotlinConfig),
+  [SupportedLanguages.Python]: createFieldExtractor(pythonConfig),
+  [SupportedLanguages.Go]: createFieldExtractor(goConfig),
+  [SupportedLanguages.Rust]: createFieldExtractor(rustConfig),
+  [SupportedLanguages.CSharp]: createFieldExtractor(csharpConfig),
+  [SupportedLanguages.C]: createFieldExtractor(cConfig),
+  [SupportedLanguages.CPlusPlus]: createFieldExtractor(cppConfig),
+  [SupportedLanguages.PHP]: createFieldExtractor(phpConfig),
+  [SupportedLanguages.Ruby]: createFieldExtractor(rubyConfig),
+  [SupportedLanguages.Swift]: createFieldExtractor(swiftConfig),
+  [SupportedLanguages.Dart]: createFieldExtractor(dartConfig),
+};
+
+/** No-op SymbolTable stub for FieldExtractorContext — mirrors NOOP_SYMBOL_TABLE_SEQ
+ *  in parsing-processor.ts (the symbol table is incomplete during parsing). */
+const NOOP_SYMBOL_TABLE_FIELDS: any = {
+  lookupExactAll: () => [],
+  lookupExact: () => undefined,
+  lookupExactFull: () => undefined,
+};
+
+/** Walk up from a field declaration to its enclosing class/struct/interface node.
+ *  Mirrors seqFindEnclosingClassNode in parsing-processor.ts. */
+const findEnclosingClassNode = (node: any): any | null => {
+  let current = node?.parent;
+  while (current) {
+    if (CLASS_CONTAINER_TYPES.has(current.type)) return current;
+    current = current.parent;
+  }
+  return null;
+};
+
+/** Cached per-class field-info lookup. Mirrors seqGetFieldInfo + seqFieldInfoCache.
+ *  The cache is passed in per file so `startIndex` keys never collide across files. */
+const getFieldInfoCached = (
+  classNode: any,
+  fieldExtractor: FieldExtractor,
+  context: FieldExtractorContext,
+  cache: Map<number, Map<string, ExtractedFieldInfo>>,
+): Map<string, ExtractedFieldInfo> | undefined => {
+  const cacheKey = classNode.startIndex;
+  const cached = cache.get(cacheKey);
+  if (cached) return cached;
+  const extracted = fieldExtractor.extract(classNode, context);
+  if (!extracted?.fields?.length) return undefined;
+  const map = new Map<string, ExtractedFieldInfo>();
+  for (const field of extracted.fields) map.set(field.name, field);
+  cache.set(cacheKey, map);
+  return map;
 };
 
 /** Map languages to their named binding extractors */
@@ -287,6 +367,8 @@ interface ParsedNode {
     /** Array of parameter type names for method overloading */
     parameterTypes?: string; // JSON array of parameter type names
     returnType?: string;
+    /** Declared/inferred type of a Property node (mirrors the sequential path). */
+    declaredType?: string;
     /** JSON array of annotations on method/class: [{name: "@Transactional", attrs?: {key: value}}] */
     annotations?: string;
     /** JSON array of field info for DTO/Entity classes: [{name, type, annotations[]}] */
@@ -493,6 +575,7 @@ export interface ParseWorkerResult {
   symbols: ParsedSymbol[];
   imports: ExtractedImport[];
   calls: ExtractedCall[];
+  angularCalls: ExtractedCall[];
   heritage: ExtractedHeritage[];
   routes: ExtractedRoute[];
   constructorBindings: FileConstructorBindings[];
@@ -652,6 +735,7 @@ const processBatch = (files: ParseWorkerInput[], onProgress?: (filesProcessed: n
     symbols: [],
     imports: [],
     calls: [],
+    angularCalls: [],
     heritage: [],
     routes: [],
     constructorBindings: [],
@@ -2387,6 +2471,8 @@ const processFileGroup = (
     // Build per-file type environment + constructor bindings in a single AST walk.
     // Constructor bindings are verified against the SymbolTable in processCallsFromExtracted.
     const typeEnv = buildTypeEnv(tree, language);
+    // Per-file cache for Property declaredType extraction (keyed by class node startIndex).
+    const fieldInfoCache = new Map<number, Map<string, ExtractedFieldInfo>>();
     const routerForLanguage = callRouters[language];
 
     // Extract FILE_SCOPE bindings for field/local variable type resolution
@@ -2453,13 +2539,22 @@ const processFileGroup = (
       if (captureMap['express_route'] && captureMap['express_route.method'] && captureMap['express_route.path']) {
         const method = captureMap['express_route.method'].text;
         const routePath = captureMap['express_route.path'].text;
-        result.decoratorRoutes.push({
-          filePath: file.path,
-          decorator: method,
-          path: routePath,
-          lineNumber: captureMap['express_route'].startPosition.row,
-        });
-        continue;
+        // Guard: reject non-route strings (header names, cache keys, etc.).
+        // Valid Express/Hono paths always start with '/'. This matches the
+        // NON_EXPRESS_OBJECTS guard in the procedural extractExpressRoutes used
+        // by the sequential path — without it the tree-sitter query is too
+        // broad and captures e.g. `.get('Content-Length')` / `cache.get('b.ts')`.
+        const cleanPath = routePath.replace(/^['"`]|['"`]$/g, '');
+        if (cleanPath.startsWith('/')) {
+          result.decoratorRoutes.push({
+            filePath: file.path,
+            decorator: method,
+            path: routePath,
+            lineNumber: captureMap['express_route'].startPosition.row,
+          });
+          continue;
+        }
+        // Not a route path — fall through to general call processing
       }
 
       // Extract HTTP decorators: @Get('/path'), @Post('/path'), @RequestMapping('/path')
@@ -2905,6 +3000,28 @@ const processFileGroup = (
         }
       }
 
+      // ── Declared type for Property nodes (mirrors parsing-processor.ts:671-694) ──
+      // The sequential path stores declaredType on each Property symbol. The worker must
+      // too, or processCalls' resolveFieldAccessType cannot type `this.<field>` — which
+      // drops field-read ACCESSES and misresolves chained calls on typed fields.
+      let declaredType: string | undefined;
+      if (nodeLabel === 'Property' && definitionNode) {
+        const fieldExtractor = fieldExtractors[language];
+        if (fieldExtractor) {
+          const classNode = findEnclosingClassNode(definitionNode);
+          if (classNode) {
+            const fieldMap = getFieldInfoCached(
+              classNode,
+              fieldExtractor,
+              { typeEnv, symbolTable: NOOP_SYMBOL_TABLE_FIELDS, filePath: file.path, language },
+              fieldInfoCache,
+            );
+            const info = fieldMap?.get(nodeName);
+            if (info) declaredType = info.type ?? undefined;
+          }
+        }
+      }
+
       result.nodes.push({
         id: nodeId,
         label: nodeLabel,
@@ -2922,6 +3039,7 @@ const processFileGroup = (
           ...(description !== undefined ? { description } : {}),
           ...(parameterCount !== undefined ? { parameterCount } : {}),
           ...(returnType !== undefined ? { returnType } : {}),
+          ...(declaredType !== undefined ? { declaredType } : {}),
           ...(parameterTypes !== undefined ? { parameterTypes: JSON.stringify(parameterTypes) } : {}),
           ...(annotations !== undefined ? { annotations } : {}),
           ...(fields !== undefined ? { fields } : {}),
@@ -2943,6 +3061,7 @@ const processFileGroup = (
         ...(requiredParameterCount !== undefined ? { requiredParameterCount } : {}),
         ...(parameterTypes !== undefined ? { parameterTypes } : {}),
         ...(returnType !== undefined ? { returnType } : {}),
+        ...(declaredType !== undefined ? { declaredType } : {}),
         ...(enclosingClassId ? { ownerId: enclosingClassId } : {}),
       });
 
@@ -3000,17 +3119,27 @@ const processFileGroup = (
 
     // Extract FastAPI routes from Python files (Issues #79, #5, #78)
     if (language === SupportedLanguages.Python) {
-      const fastApiRoutes = extractFastApiRoutes(tree, file.path);
-      if (fastApiRoutes.length > 0) {
-        result.routes.push(...fastApiRoutes);
+      for (const r of extractFastApiRoutes(tree, file.path)) {
+        result.decoratorRoutes.push({
+          filePath: r.filePath,
+          decorator: r.httpMethod,
+          path: r.routePath,
+          lineNumber: r.lineNumber,
+          handlerName: r.methodName ?? undefined,
+        });
       }
     }
 
     // Extract Gin routes from Go files (Issues #80, #6)
     if (language === SupportedLanguages.Go) {
-      const ginRoutes = extractGinRoutes(tree, file.path);
-      if (ginRoutes.length > 0) {
-        result.routes.push(...ginRoutes);
+      for (const r of extractGinRoutes(tree, file.path)) {
+        result.decoratorRoutes.push({
+          filePath: r.filePath,
+          decorator: r.httpMethod,
+          path: r.routePath,
+          lineNumber: r.lineNumber,
+          handlerName: r.methodName ?? undefined,
+        });
       }
     }
 
@@ -3018,9 +3147,14 @@ const processFileGroup = (
     // or use `RouterModule` / `provideRouter`. Emits `ExtractedRoute` records
     // (client-side Angular routes have no HTTP method — we use GET).
     if (language === SupportedLanguages.TypeScript && isAngularFile(file.path, file.content)) {
-      const angularRoutes = extractAngularRoutes(tree, file.path);
-      if (angularRoutes.length > 0) {
-        result.routes.push(...angularRoutes);
+      for (const r of extractAngularRoutes(tree, file.path)) {
+        result.decoratorRoutes.push({
+          filePath: r.filePath,
+          decorator: r.httpMethod,
+          path: r.routePath,
+          lineNumber: r.lineNumber,
+          handlerName: r.methodName ?? undefined,
+        });
       }
     }
 
@@ -3042,7 +3176,7 @@ const processFileGroup = (
     if (language === SupportedLanguages.TypeScript || language === SupportedLanguages.JavaScript) {
       const angularCalls = extractAngularCalls(tree, file.path);
       for (const ac of angularCalls) {
-        result.calls.push({
+        result.angularCalls.push({
           filePath: ac.filePath,
           calledName: ac.calledName,
           sourceId: ac.sourceId,
@@ -3126,7 +3260,7 @@ const processFileGroup = (
 /** Accumulated result across sub-batches */
 let accumulated: ParseWorkerResult = {
   nodes: [], relationships: [], symbols: [],
-  imports: [], calls: [], heritage: [], routes: [], constructorBindings: [], typeEnvBindings: [], skippedLanguages: {}, fileCount: 0,
+  imports: [], calls: [], angularCalls: [], heritage: [], routes: [], constructorBindings: [], typeEnvBindings: [], skippedLanguages: {}, fileCount: 0,
   ormQueries: [],
   fetchCalls: [],
   expoNavCalls: [],
@@ -3140,6 +3274,7 @@ const mergeResult = (target: ParseWorkerResult, src: ParseWorkerResult) => {
   target.symbols.push(...src.symbols);
   target.imports.push(...src.imports);
   target.calls.push(...src.calls);
+  target.angularCalls.push(...src.angularCalls);
   target.heritage.push(...src.heritage);
   target.routes.push(...src.routes);
   target.constructorBindings.push(...src.constructorBindings);
@@ -3189,7 +3324,7 @@ if (parentPort) {
     if (msg && msg.type === 'flush') {
       parentPort!.postMessage({ type: 'result', data: accumulated });
       // Reset for potential reuse
-      accumulated = { nodes: [], relationships: [], symbols: [], imports: [], calls: [], heritage: [], routes: [], constructorBindings: [], typeEnvBindings: [], skippedLanguages: {}, fileCount: 0, ormQueries: [] };
+      accumulated = { nodes: [], relationships: [], symbols: [], imports: [], calls: [], angularCalls: [], heritage: [], routes: [], constructorBindings: [], typeEnvBindings: [], skippedLanguages: {}, fileCount: 0, ormQueries: [] };
       cumulativeProcessed = 0;
       return;
     }

--- a/gitnexus/src/core/ingestion/workers/parse-worker.ts
+++ b/gitnexus/src/core/ingestion/workers/parse-worker.ts
@@ -44,6 +44,9 @@ import {
   getDefinitionNodeFromCaptures,
   findEnclosingClassId,
   extractMethodSignature,
+  isPythonClassMethod,
+  isKotlinClassMethod,
+  isCppInsideClassOrStruct,
 } from '../utils/ast-helpers.js';
 import {
   countCallArguments,
@@ -297,7 +300,7 @@ interface ParsedRelationship {
   id: string;
   sourceId: string;
   targetId: string;
-  type: 'DEFINES' | 'HAS_METHOD';
+  type: 'DEFINES' | 'HAS_METHOD' | 'HAS_PROPERTY';
   confidence: number;
   reason: string;
 }
@@ -589,7 +592,7 @@ const findEnclosingFunctionId = (node: any, filePath: string): string | null => 
 // Label detection from capture map
 // ============================================================================
 
-const getLabelFromCaptures = (captureMap: Record<string, any>): string | null => {
+const getLabelFromCaptures = (captureMap: Record<string, any>, language?: string): string | null => {
   // Skip imports (handled separately) and calls
   if (captureMap['import'] || captureMap['call']) return null;
   if (!captureMap['name']) return null;
@@ -603,7 +606,14 @@ const getLabelFromCaptures = (captureMap: Record<string, any>): string | null =>
     return 'CodeElement';
   }
 
-  if (captureMap['definition.function']) return 'Function';
+  if (captureMap['definition.function']) {
+    // Mirror the language-provider labelOverride logic so node labels match
+    // the sequential (parsing-processor) path exactly.
+    if (language === 'python' && isPythonClassMethod(captureMap['definition.function'])) return 'Method';
+    if (language === 'kotlin' && isKotlinClassMethod(captureMap['definition.function'])) return 'Method';
+    if ((language === 'c' || language === 'cpp') && isCppInsideClassOrStruct(captureMap['definition.function'])) return null;
+    return 'Function';
+  }
   if (captureMap['definition.class']) return 'Class';
   if (captureMap['definition.interface']) return 'Interface';
   if (captureMap['definition.method']) return 'Method';
@@ -2639,11 +2649,12 @@ const processFileGroup = (
                     reason: '',
                   });
                   if (propEnclosingClassId) {
+                    // Property nodes use HAS_PROPERTY (mirrors parsing-processor.ts:726)
                     result.relationships.push({
-                      id: generateId('HAS_METHOD', `${propEnclosingClassId}->${nodeId}`),
+                      id: generateId('HAS_PROPERTY', `${propEnclosingClassId}->${nodeId}`),
                       sourceId: propEnclosingClassId,
                       targetId: nodeId,
-                      type: 'HAS_METHOD',
+                      type: 'HAS_PROPERTY',
                       confidence: 1.0,
                       reason: '',
                     });
@@ -2792,7 +2803,7 @@ const processFileGroup = (
         }
       }
 
-      const nodeLabel = getLabelFromCaptures(captureMap);
+      const nodeLabel = getLabelFromCaptures(captureMap, language);
       if (!nodeLabel) continue;
 
       const nameNode = captureMap['name'];
@@ -2946,13 +2957,15 @@ const processFileGroup = (
         reason: '',
       });
 
-      // ── HAS_METHOD: link method/constructor/property to enclosing class ──
+      // ── HAS_METHOD / HAS_PROPERTY: link member to enclosing class ──
+      // Mirror parsing-processor.ts: Property nodes use HAS_PROPERTY; all others use HAS_METHOD.
       if (enclosingClassId) {
+        const memberEdgeType = nodeLabel === 'Property' ? 'HAS_PROPERTY' : 'HAS_METHOD';
         result.relationships.push({
-          id: generateId('HAS_METHOD', `${enclosingClassId}->${nodeId}`),
+          id: generateId(memberEdgeType, `${enclosingClassId}->${nodeId}`),
           sourceId: enclosingClassId,
           targetId: nodeId,
-          type: 'HAS_METHOD',
+          type: memberEdgeType,
           confidence: 1.0,
           reason: '',
         });

--- a/gitnexus/src/types/pipeline.ts
+++ b/gitnexus/src/types/pipeline.ts
@@ -2,7 +2,7 @@ import { GraphNode, GraphRelationship, KnowledgeGraph } from '../core/graph/type
 import { CommunityDetectionResult } from '../core/ingestion/community-processor.js';
 import { ProcessDetectionResult } from '../core/ingestion/process-processor.js';
 
-export type PipelinePhase = 'idle' | 'extracting' | 'structure' | 'parsing' | 'imports' | 'calls' | 'heritage' | 'communities' | 'processes' | 'enriching' | 'complete' | 'error';
+export type PipelinePhase = 'idle' | 'extracting' | 'structure' | 'parsing' | 'imports' | 'calls' | 'heritage' | 'lsp' | 'communities' | 'processes' | 'enriching' | 'complete' | 'error';
 
 export interface PipelineProgress {
   phase: PipelinePhase;

--- a/gitnexus/test/integration/filesystem-walker.test.ts
+++ b/gitnexus/test/integration/filesystem-walker.test.ts
@@ -71,6 +71,26 @@ describe('filesystem-walker', () => {
       expect(onProgress).toHaveBeenCalled();
     });
 
+    // ─── Determinism guard (community-detection reproducibility) ──────
+    // `glob` v11 walks directories in parallel and does NOT sort its output,
+    // so two calls return the same SET in a DIFFERENT order. That order
+    // propagates into symbol-table insertion order, so for any globally
+    // ambiguous name `lookupFuzzy(name)[0]` can flip between runs, changing a
+    // CALLS edge's resolved target → the Leiden community partition →
+    // MEMBER_OF / STEP_IN_PROCESS edge ids. walkRepositoryPaths MUST return a
+    // deterministically-sorted list to keep the index reproducible.
+    it('returns paths in deterministic sorted order', async () => {
+      const a = await walkRepositoryPaths(tmpDir);
+      const b = await walkRepositoryPaths(tmpDir);
+      const pa = a.map(f => f.path);
+      const pb = b.map(f => f.path);
+      // Stable across repeated calls
+      expect(pa).toEqual(pb);
+      // Lexicographically sorted
+      const sorted = [...pa].sort((x, y) => (x < y ? -1 : x > y ? 1 : 0));
+      expect(pa).toEqual(sorted);
+    });
+
     // ─── Unhappy paths ────────────────────────────────────────────────
 
     it('throws or returns empty for non-existent directory', async () => {

--- a/gitnexus/test/integration/parallel-parity.test.ts
+++ b/gitnexus/test/integration/parallel-parity.test.ts
@@ -1,0 +1,655 @@
+/**
+ * Integration regression guard: the parallel-parse worker path
+ * (GITNEXUS_PARALLEL_PARSE=1 / parallelParse:true, now the DEFAULT) produces
+ * a graph BYTE-IDENTICAL to the sequential path (GITNEXUS_PARALLEL_PARSE=0 /
+ * parallelParse:false).
+ *
+ * Bug history (three separate regressions on perf/lsp-analyze-speedup):
+ *
+ *   1. General-call double-emission
+ *      The worker fed general calls into processCallsFromExtracted, causing
+ *      +678 false CALLS / −48 ACCESSES edges vs sequential.
+ *      Fixed: separate Angular calls into result.angularCalls; only those flow
+ *      into the Angular-call processor. General calls re-extracted sequentially.
+ *
+ *   2. Route channel misdirection
+ *      The worker pushed FastAPI / Gin / Angular routes to result.routes
+ *      (Spring-route bucket, later skipped because no controllerName/methodName)
+ *      instead of result.decoratorRoutes.  Sequential path extracted them
+ *      correctly → snapshot divergence on HANDLES_ROUTE edges.
+ *      Fixed: worker places framework routes in result.decoratorRoutes.
+ *
+ *   3. Worker Property nodes lacked declaredType
+ *      Property nodes emitted by the worker had no declaredType field →
+ *      this.field read-ACCESSES disappeared + chained-call receiver resolution
+ *      fell back to unresolved.
+ *      Fixed: worker applies the same field-extractor registry as the
+ *      sequential parsing-processor path.
+ *
+ *   4. Process-detection insertion-order sensitivity
+ *      findEntryPoints tied-score sort, buildCallsGraph callee order,
+ *      deduplicateTraces / deduplicateByEndpoints / limitedTraces sorts were
+ *      not total-order → STEP_IN_PROCESS edge renumbering between the two paths
+ *      (phantom detect_changes diffs, ~180 churned edges per run).
+ *      Fixed: all sorts use length-desc + full-path-lexicographic tiebreak.
+ *
+ * Test strategy:
+ *   - Generate a synthetic multi-language fixture whose TOTAL PARSEABLE BYTES
+ *     exceed MIN_BYTES_FOR_WORKERS=512KB so the worker pool actually spawns.
+ *     The fixture deliberately includes:
+ *       • 10 TypeScript service files with typed class fields (covers Bug 3)
+ *       • A FastAPI Python route file  (covers Bug 2 route-channel path)
+ *       • A Gin Go route file          (covers Bug 2 route-channel path)
+ *       • 3+ hop method call chains    (covers Bug 4 process-detection)
+ *   - Assert the pool ACTUALLY SPAWNED by spying on console.warn for the
+ *     "Parallel parse unavailable, falling back to sequential" message.
+ *     If that warning fires, the test FAILS — not skips — with an instruction
+ *     to run `npm run build`.
+ *   - Run the full pipeline once with parallelParse:false (sequential) and
+ *     once with parallelParse:true (parallel). Snapshot ALL relationships
+ *     sorted by id and assert byte-equality.
+ *   - Additional targeted assertions for STEP_IN_PROCESS and MEMBER_OF so a
+ *     process-detection regression produces a named failure, not just "snapshots differ".
+ */
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import path from 'node:path';
+import fs from 'node:fs';
+import fsPromises from 'node:fs/promises';
+import os from 'node:os';
+
+import { runPipelineFromRepo } from '../../src/core/ingestion/pipeline.js';
+import type { KnowledgeGraph } from '../../src/core/graph/types.js';
+
+// ── Fixture content ───────────────────────────────────────────────────────────
+
+/**
+ * FastAPI route file. Exercises the route-channel fix (Bug 2):
+ * routes emitted by the worker must land in result.decoratorRoutes,
+ * not result.routes (Spring bucket).
+ */
+const FASTAPI_CONTENT = `"""FastAPI route fixture for parallel-parity integration test.
+
+Exercises Bug 2 (route-channel): these routes must appear in both
+sequential and parallel snapshots — if the worker misdirects them
+to the Spring-route bucket they are silently dropped in the parallel path.
+"""
+from fastapi import FastAPI, APIRouter
+
+app = FastAPI()
+router = APIRouter()
+
+
+@app.get("/items")
+async def list_items():
+    """Return all items."""
+    return []
+
+
+@app.post("/items")
+async def create_item(name: str, price: float):
+    """Create and persist a new item."""
+    validated = validate_item(name, price)
+    return save_item(validated)
+
+
+@app.put("/items/{item_id}")
+async def update_item(item_id: int, name: str):
+    """Update an existing item."""
+    return {"id": item_id, "name": name}
+
+
+@app.delete("/items/{item_id}")
+async def delete_item(item_id: int):
+    """Remove an item by id."""
+    return {"deleted": item_id}
+
+
+@router.get("/orders")
+async def list_orders():
+    """Return all orders."""
+    return []
+
+
+@router.post("/orders")
+async def create_order(item_id: int, quantity: int):
+    """Place a new order."""
+    return {"item_id": item_id, "quantity": quantity}
+
+
+def validate_item(name: str, price: float) -> dict:
+    """Validate item fields before persistence."""
+    if price <= 0:
+        raise ValueError("price must be positive")
+    return {"name": name.strip(), "price": price}
+
+
+def save_item(item: dict) -> dict:
+    """Persist item to the database."""
+    return {**item, "id": 1}
+`;
+
+/**
+ * Gin route file. Exercises the route-channel fix (Bug 2) for Go.
+ */
+const GIN_CONTENT = `package main
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+)
+
+// Item is a data model for the inventory.
+type Item struct {
+	ID    int     \`json:"id"\`
+	Name  string  \`json:"name"\`
+	Price float64 \`json:"price"\`
+}
+
+func main() {
+	r := gin.Default()
+	r.GET("/items", listItems)
+	r.POST("/items", createItem)
+	r.PUT("/items/:id", updateItem)
+	r.DELETE("/items/:id", deleteItem)
+	r.GET("/categories", listCategories)
+	r.POST("/categories", createCategory)
+	r.Run(":8080")
+}
+
+func listItems(c *gin.Context) {
+	items := fetchAllItems()
+	enriched := enrichItems(items)
+	c.JSON(http.StatusOK, enriched)
+}
+
+func createItem(c *gin.Context) {
+	var item Item
+	if err := c.ShouldBindJSON(&item); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	saved := persistItem(item)
+	c.JSON(http.StatusCreated, saved)
+}
+
+func updateItem(c *gin.Context) {
+	id, _ := strconv.Atoi(c.Param("id"))
+	var item Item
+	c.ShouldBindJSON(&item)
+	item.ID = id
+	updated := persistItem(item)
+	c.JSON(http.StatusOK, updated)
+}
+
+func deleteItem(c *gin.Context) {
+	id, _ := strconv.Atoi(c.Param("id"))
+	removeItem(id)
+	c.JSON(http.StatusNoContent, nil)
+}
+
+func listCategories(c *gin.Context) {
+	cats := fetchCategories()
+	c.JSON(http.StatusOK, cats)
+}
+
+func createCategory(c *gin.Context) {
+	var cat map[string]string
+	c.ShouldBindJSON(&cat)
+	result := persistCategory(cat)
+	c.JSON(http.StatusCreated, result)
+}
+
+func fetchAllItems() []Item                         { return nil }
+func enrichItems(items []Item) []Item               { return items }
+func persistItem(item Item) Item                    { return item }
+func removeItem(_ int)                              {}
+func fetchCategories() []string                     { return nil }
+func persistCategory(cat map[string]string) map[string]string { return cat }
+`;
+
+/**
+ * Generate a TypeScript service file with:
+ *   - 12 exported interfaces (broad symbol surface)
+ *   - Typed class fields (exercises Bug 3 / declaredType fix)
+ *   - 25 handleX/fetchX/queryX/formatX method groups forming 3-hop call chains
+ *     (exercises Bug 4 / process-detection)
+ *   - 10 standalone exported functions
+ *
+ * Target size: ~35-45 KB per file.  10 files × 40 KB ≈ 400 KB combined
+ * TypeScript parseable bytes.  With the Python and Go files the fixture
+ * comfortably exceeds the MIN_BYTES_FOR_WORKERS = 512 KB gate.
+ *
+ * NOTE: if the total-bytes assertion in beforeAll fails, increase
+ * NUM_METHOD_GROUPS below or add more service files.
+ */
+function generateServiceFile(serviceName: string): string {
+  const NUM_INTERFACES = 12;
+  const NUM_TYPE_ALIASES = 4;
+  const NUM_METHOD_GROUPS = 25; // each group = 4 methods ≈ 40 lines
+  const NUM_STANDALONE_FUNCTIONS = 10;
+
+  const L: string[] = [];
+
+  L.push(`/**`);
+  L.push(` * ${serviceName} — auto-generated fixture for parallel-parity integration test.`);
+  L.push(` *`);
+  L.push(` * DO NOT EDIT — this file is produced by generateServiceFile() in`);
+  L.push(` * test/integration/parallel-parity.test.ts and is regenerated on each test run.`);
+  L.push(` */`);
+  L.push(``);
+
+  // Imports (give the file realistic import structure)
+  L.push(`import type { Logger } from '../utils/logger';`);
+  L.push(`import type { Database } from '../utils/database';`);
+  L.push(`import type { Cache } from '../utils/cache';`);
+  L.push(`import type { EventEmitter } from '../utils/events';`);
+  L.push(``);
+
+  // Interfaces
+  for (let i = 0; i < NUM_INTERFACES; i++) {
+    L.push(`/** ${serviceName} data transfer object ${i} */`);
+    L.push(`export interface ${serviceName}Dto${i} {`);
+    L.push(`  id: string;`);
+    L.push(`  name: string;`);
+    L.push(`  code: string;`);
+    L.push(`  description: string;`);
+    L.push(`  status: 'active' | 'inactive' | 'pending' | 'archived';`);
+    L.push(`  priority: number;`);
+    L.push(`  createdAt: Date;`);
+    L.push(`  updatedAt: Date;`);
+    L.push(`  createdBy: string;`);
+    L.push(`  metadata: Record<string, unknown>;`);
+    L.push(`  tags: string[];`);
+    L.push(`  version: number;`);
+    L.push(`}`);
+    L.push(``);
+  }
+
+  // Type aliases
+  for (let i = 0; i < NUM_TYPE_ALIASES; i++) {
+    L.push(`export type ${serviceName}Result${i} = {`);
+    L.push(`  success: boolean;`);
+    L.push(`  data: ${serviceName}Dto0 | null;`);
+    L.push(`  errors: string[];`);
+    L.push(`  warnings: string[];`);
+    L.push(`  timestamp: number;`);
+    L.push(`  requestId: string;`);
+    L.push(`};`);
+    L.push(``);
+  }
+
+  // Main service class — typed fields exercise the declaredType fix (Bug 3).
+  // The sequential path emits declaredType for each class property.
+  // The parallel (worker) path must also emit declaredType so that
+  // `this.cache.get(...)` resolves as a Cache.get() call in both paths.
+  L.push(`/** ${serviceName} — manages the full lifecycle of ${serviceName} entities. */`);
+  L.push(`export class ${serviceName} {`);
+  L.push(`  /** @type {Logger} Logger instance — used to verify declaredType parity (Bug 3) */`);
+  L.push(`  private readonly logger: Logger;`);
+  L.push(`  /** @type {Database} Primary database connection */`);
+  L.push(`  private readonly database: Database;`);
+  L.push(`  /** @type {Cache<string, ${serviceName}Dto0>} Read-through cache */`);
+  L.push(`  private readonly cache: Cache<string, ${serviceName}Dto0>;`);
+  L.push(`  /** @type {EventEmitter} Domain-event bus */`);
+  L.push(`  private readonly events: EventEmitter;`);
+  L.push(`  /** @type {Map<string, ${serviceName}Dto0>} In-flight items keyed by id */`);
+  L.push(`  private readonly pendingMap: Map<string, ${serviceName}Dto0>;`);
+  L.push(`  /** @type {Set<string>} Ids currently locked for mutation */`);
+  L.push(`  private readonly lockedIds: Set<string>;`);
+  L.push(`  /** @type {${serviceName}Dto0 | null} Currently authenticated entity context */`);
+  L.push(`  private currentContext: ${serviceName}Dto0 | null = null;`);
+  L.push(`  /** @type {number} Configured page size for pagination */`);
+  L.push(`  private readonly pageSize: number = 50;`);
+  L.push(``);
+  L.push(`  constructor(`);
+  L.push(`    logger: Logger,`);
+  L.push(`    database: Database,`);
+  L.push(`    cache: Cache<string, ${serviceName}Dto0>,`);
+  L.push(`    events: EventEmitter,`);
+  L.push(`  ) {`);
+  L.push(`    this.logger = logger;`);
+  L.push(`    this.database = database;`);
+  L.push(`    this.cache = cache;`);
+  L.push(`    this.events = events;`);
+  L.push(`    this.pendingMap = new Map();`);
+  L.push(`    this.lockedIds = new Set();`);
+  L.push(`  }`);
+  L.push(``);
+
+  // Method groups (25 groups × 4 methods × ~10 lines = ~1000 lines)
+  // Each group: handle*(id) → fetch*(id) → query*(id) → format*()
+  // This creates the 3-hop call chain that process detection traces.
+  for (let i = 0; i < NUM_METHOD_GROUPS; i++) {
+    const S = `Record${i}`;
+
+    // Entry-point method (handle*): name matches ^handle[A-Z] → high entry-point score
+    L.push(`  /**`);
+    L.push(`   * Handle ${S} lifecycle request — entry point for the ${S} flow.`);
+    L.push(`   * Calls fetch${S} which calls query${S} (3-hop chain for process detection).`);
+    L.push(`   * @param id — entity identifier`);
+    L.push(`   * @param opts — optional processing hints`);
+    L.push(`   */`);
+    L.push(`  handle${S}(id: string, opts: Record<string, unknown> = {}): ${serviceName}Result0 {`);
+    L.push(`    this.logger.info(\`[${serviceName}] handle${S} id=\${id}\`);`);
+    L.push(`    if (this.lockedIds.has(id)) {`);
+    L.push(`      return { success: false, data: null, errors: ['locked'], warnings: [], timestamp: Date.now(), requestId: id };`);
+    L.push(`    }`);
+    L.push(`    const raw = this.fetch${S}(id);`);
+    L.push(`    if (!raw) {`);
+    L.push(`      return { success: false, data: null, errors: ['not_found'], warnings: [], timestamp: Date.now(), requestId: id };`);
+    L.push(`    }`);
+    L.push(`    const formatted = this.format${S}(raw);`);
+    L.push(`    this.events.emit(\`${serviceName.toLowerCase()}.${S.toLowerCase()}.handled\`, formatted);`);
+    L.push(`    return { success: true, data: formatted, errors: [], warnings: [], timestamp: Date.now(), requestId: id };`);
+    L.push(`  }`);
+    L.push(``);
+
+    // Fetch method: calls query* and populates cache
+    L.push(`  /**`);
+    L.push(`   * Fetch ${S} by id — checks cache then delegates to query${S}.`);
+    L.push(`   */`);
+    L.push(`  private fetch${S}(id: string): ${serviceName}Dto0 | null {`);
+    L.push(`    const hit = this.cache.get(id);`);
+    L.push(`    if (hit) return hit;`);
+    L.push(`    const record = this.query${S}(id);`);
+    L.push(`    if (record) {`);
+    L.push(`      this.cache.set(id, record);`);
+    L.push(`      this.pendingMap.set(id, record);`);
+    L.push(`    }`);
+    L.push(`    return record;`);
+    L.push(`  }`);
+    L.push(``);
+
+    // Query method: terminal step (hits database, no further service calls)
+    L.push(`  /**`);
+    L.push(`   * Query ${S} from the database — terminal step in the ${S} flow.`);
+    L.push(`   */`);
+    L.push(`  private query${S}(id: string): ${serviceName}Dto0 | null {`);
+    L.push(`    return this.database.findById<${serviceName}Dto0>('${serviceName.toLowerCase()}_${i}', id) ?? null;`);
+    L.push(`  }`);
+    L.push(``);
+
+    // Format method: data transformation, no further service calls
+    L.push(`  /**`);
+    L.push(`   * Apply output formatting and normalization for ${S}.`);
+    L.push(`   */`);
+    L.push(`  private format${S}(dto: ${serviceName}Dto0): ${serviceName}Dto0 {`);
+    L.push(`    return {`);
+    L.push(`      ...dto,`);
+    L.push(`      name: dto.name.trim(),`);
+    L.push(`      description: dto.description.trim(),`);
+    L.push(`      updatedAt: new Date(),`);
+    L.push(`      version: dto.version + 1,`);
+    L.push(`    };`);
+    L.push(`  }`);
+    L.push(``);
+  }
+
+  L.push(`}`);
+  L.push(``);
+
+  // Standalone exported functions (add to symbol surface, exercise process detection)
+  for (let i = 0; i < NUM_STANDALONE_FUNCTIONS; i++) {
+    L.push(`/**`);
+    L.push(` * Process a batch of ${serviceName} entities — standalone utility #${i}.`);
+    L.push(` * Exported for cross-file use (isExported=true → higher entry-point score).`);
+    L.push(` */`);
+    L.push(`export function process${serviceName}Batch${i}(`);
+    L.push(`  items: ${serviceName}Dto0[],`);
+    L.push(`  opts: { limit?: number; sortKey?: keyof ${serviceName}Dto0 } = {},`);
+    L.push(`): ${serviceName}Dto0[] {`);
+    L.push(`  const { limit = 100, sortKey = 'id' } = opts;`);
+    L.push(`  const sorted = [...items].sort((a, b) => {`);
+    L.push(`    const av = String(a[sortKey] ?? '');`);
+    L.push(`    const bv = String(b[sortKey] ?? '');`);
+    L.push(`    return av < bv ? -1 : av > bv ? 1 : 0;`);
+    L.push(`  });`);
+    L.push(`  return sorted.slice(0, limit);`);
+    L.push(`}`);
+    L.push(``);
+  }
+
+  return L.join('\n');
+}
+
+// ── Snapshot helper (mirrors mode-a-golden.test.ts) ──────────────────────────
+
+/**
+ * Produce a stable, sorted JSON string for all relationships in `graph`.
+ * Sorted by id so the comparison is order-independent.
+ * Includes step and source so STEP_IN_PROCESS regressions are visible.
+ */
+function snapshotRels(graph: KnowledgeGraph): string {
+  const rels = [...graph.iterRelationships()].map(r => ({
+    id: r.id,
+    sourceId: r.sourceId,
+    targetId: r.targetId,
+    type: r.type,
+    confidence: r.confidence,
+    reason: r.reason,
+    step: r.step ?? null,
+    source: r.source ?? null,
+  }));
+  rels.sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
+  return JSON.stringify(rels, null, 2);
+}
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+const DIST_WORKER = path.resolve(
+  __dirname, '..', '..', 'dist', 'core', 'ingestion', 'workers', 'parse-worker.js',
+);
+
+/**
+ * The pipeline emits this warning when it intended to use workers (total
+ * parseable bytes > 512KB) but could NOT spawn them — e.g. because dist/ is
+ * missing or stale.  If we detect this warning in the parallel run, both
+ * pipeline runs went sequential and the "parity" snapshot comparison would be
+ * a false-green tautology.
+ */
+const FALLBACK_WARN_PATTERN = /Parallel parse unavailable, falling back to sequential/;
+
+/**
+ * 10 TypeScript service class names — enough files to comfortably exceed
+ * the MIN_BYTES_FOR_WORKERS = 512 KB gate when combined with the route files.
+ */
+const SERVICE_NAMES = [
+  'UserService',
+  'OrderService',
+  'ProductService',
+  'PaymentService',
+  'NotificationService',
+  'AuthService',
+  'AuditService',
+  'CacheService',
+  'EmailService',
+  'ReportService',
+];
+
+// ── Test state ────────────────────────────────────────────────────────────────
+
+let fixtureDir = '';
+let seqSnapshot = '';
+let parSnapshot = '';
+let parallelFallbackWarns: string[] = [];
+
+// ── Setup/teardown ────────────────────────────────────────────────────────────
+
+beforeAll(async () => {
+  // ── 1. Gate: dist worker must exist ───────────────────────────────────────
+  //
+  // The parallel parse path spawns a Worker thread from dist/.  If dist/ is
+  // missing the pool silently falls back to sequential (with a console.warn).
+  // We assert its existence BEFORE generating the fixture so the error message
+  // is clear and actionable.
+  expect(
+    fs.existsSync(DIST_WORKER),
+    `dist/core/ingestion/workers/parse-worker.js not found.\n` +
+    `The parallel-parse integration test requires a compiled worker script.\n` +
+    `Fix: cd gitnexus && npm run build`,
+  ).toBe(true);
+
+  // ── 2. Generate fixture in a temporary directory ──────────────────────────
+  fixtureDir = await fsPromises.mkdtemp(
+    path.join(os.tmpdir(), 'gitnexus-parallel-parity-'),
+  );
+
+  const apiDir = path.join(fixtureDir, 'src', 'api');
+  const svcDir = path.join(fixtureDir, 'src', 'services');
+  await fsPromises.mkdir(apiDir, { recursive: true });
+  await fsPromises.mkdir(svcDir, { recursive: true });
+
+  // Route files — exercises route-channel fix (Bug 2)
+  await fsPromises.writeFile(path.join(apiDir, 'routes.py'), FASTAPI_CONTENT, 'utf-8');
+  await fsPromises.writeFile(path.join(apiDir, 'gin_routes.go'), GIN_CONTENT, 'utf-8');
+
+  // TypeScript service files — exercises declaredType (Bug 3) + process detection (Bug 4)
+  for (const svcName of SERVICE_NAMES) {
+    await fsPromises.writeFile(
+      path.join(svcDir, `${svcName.toLowerCase()}.ts`),
+      generateServiceFile(svcName),
+      'utf-8',
+    );
+  }
+
+  // ── 3. Gate: fixture must trip the worker-pool byte threshold ────────────
+  //
+  // If total parseable bytes ≤ 512 KB both pipeline runs go sequential and
+  // the parity test is a false-green tautology.  Fail with an actionable hint
+  // rather than silently passing.
+  let totalBytes = FASTAPI_CONTENT.length + GIN_CONTENT.length;
+  const tsFiles = await fsPromises.readdir(svcDir);
+  for (const f of tsFiles) {
+    const stat = await fsPromises.stat(path.join(svcDir, f));
+    totalBytes += stat.size;
+  }
+
+  expect(
+    totalBytes,
+    `Fixture total parseable bytes (${totalBytes}) must exceed 512 KB ` +
+    `(MIN_BYTES_FOR_WORKERS=${512 * 1024}) so the worker pool actually spawns.\n` +
+    `Increase NUM_METHOD_GROUPS in generateServiceFile() or add more SERVICE_NAMES.`,
+  ).toBeGreaterThan(512 * 1024);
+
+  // ── 4. Sequential run ─────────────────────────────────────────────────────
+  const seqResult = await runPipelineFromRepo(fixtureDir, () => {}, {
+    parallelParse: false,
+  });
+  seqSnapshot = snapshotRels(seqResult.graph);
+
+  // ── 5. Parallel run — capture console.warn to detect pool fallback ────────
+  //
+  // The spy is scoped to the parallel run only so sequential-path warnings
+  // (if any) don't pollute the fallback check.
+  const warnSpy = vi.spyOn(console, 'warn');
+  const parResult = await runPipelineFromRepo(fixtureDir, () => {}, {
+    parallelParse: true,
+  });
+  parallelFallbackWarns = warnSpy.mock.calls
+    .map(args => String(args[0]))
+    .filter(msg => FALLBACK_WARN_PATTERN.test(msg));
+  vi.restoreAllMocks();
+
+  parSnapshot = snapshotRels(parResult.graph);
+}, 300_000); // 5-minute budget for two full pipeline runs
+
+afterAll(async () => {
+  vi.restoreAllMocks();
+  if (fixtureDir) {
+    await fsPromises.rm(fixtureDir, { recursive: true, force: true });
+  }
+});
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('parallel-parse parity (GITNEXUS_PARALLEL_PARSE=1 vs =0)', () => {
+  // ── Pool-spawn gate (must pass before parity tests are meaningful) ─────────
+
+  it('worker pool actually spawned during parallel run (no silent sequential fallback)', () => {
+    // If the fallback warning fires, both runs went sequential and the parity
+    // snapshot comparison below would be a false-green tautology.
+    expect(
+      parallelFallbackWarns,
+      `Worker pool fell back to sequential during the parallel run.\n` +
+      `Ensure dist/ is built: cd gitnexus && npm run build\n` +
+      `Fallback message(s): ${parallelFallbackWarns.join('; ')}`,
+    ).toHaveLength(0);
+  });
+
+  // ── Primary parity assertion ───────────────────────────────────────────────
+
+  it('parallel and sequential pipeline runs produce byte-identical relationship snapshots', () => {
+    // This is the master assertion. It covers ALL edge types (CALLS, CONTAINS,
+    // IMPORTS, HAS_METHOD, HAS_PROPERTY, MEMBER_OF, STEP_IN_PROCESS,
+    // HANDLES_ROUTE, …). A regression in ANY of the four bug areas will cause
+    // a diff here.
+    expect(parSnapshot).toBe(seqSnapshot);
+  });
+
+  // ── Targeted assertions (give named failures when parity breaks) ───────────
+
+  it('(Bug 4) STEP_IN_PROCESS edges are byte-identical between paths', () => {
+    // Process-detection insertion-order bugs produce different proc_<idx>
+    // numbering → different STEP_IN_PROCESS edge ids and step numbers.
+    const seqRels: Array<Record<string, unknown>> = JSON.parse(seqSnapshot);
+    const parRels: Array<Record<string, unknown>> = JSON.parse(parSnapshot);
+
+    const seqStep = seqRels.filter(r => r['type'] === 'STEP_IN_PROCESS');
+    const parStep = parRels.filter(r => r['type'] === 'STEP_IN_PROCESS');
+
+    // There must be at least one STEP_IN_PROCESS edge (fixture has 3-hop chains)
+    expect(seqStep.length).toBeGreaterThan(0);
+    expect(parStep).toEqual(seqStep);
+  });
+
+  it('(Bug 4) MEMBER_OF edges are byte-identical between paths', () => {
+    // Community-detection produces MEMBER_OF edges. If insertion order affects
+    // community assignment, MEMBER_OF edges diverge between paths.
+    const seqRels: Array<Record<string, unknown>> = JSON.parse(seqSnapshot);
+    const parRels: Array<Record<string, unknown>> = JSON.parse(parSnapshot);
+
+    const seqMember = seqRels.filter(r => r['type'] === 'MEMBER_OF');
+    const parMember = parRels.filter(r => r['type'] === 'MEMBER_OF');
+
+    expect(seqMember.length).toBeGreaterThan(0);
+    expect(parMember).toEqual(seqMember);
+  });
+
+  it('(Bug 2) HANDLES_ROUTE edges from FastAPI and Gin files are present in both paths', () => {
+    // Route-channel bug: if the worker misdirects FastAPI/Gin routes to the
+    // Spring bucket (result.routes) instead of result.decoratorRoutes, the
+    // parallel path produces no HANDLES_ROUTE edges from route files while
+    // the sequential path re-extracts them correctly → snapshot divergence.
+    //
+    // This assertion confirms the fixture exercises the route-channel path
+    // and that routes are non-zero in both snapshots. The byte-identical
+    // assertion above catches any count/content divergence.
+    const seqRels: Array<Record<string, unknown>> = JSON.parse(seqSnapshot);
+    const parRels: Array<Record<string, unknown>> = JSON.parse(parSnapshot);
+
+    const seqRoutes = seqRels.filter(r => r['type'] === 'HANDLES_ROUTE');
+    const parRoutes = parRels.filter(r => r['type'] === 'HANDLES_ROUTE');
+
+    expect(seqRoutes.length).toBeGreaterThan(0);
+    expect(parRoutes.length).toBeGreaterThan(0);
+    expect(parRoutes).toEqual(seqRoutes);
+  });
+
+  it('(Bug 3) CALLS edge counts are non-zero and identical (declaredType chained-call fix)', () => {
+    // The declaredType fix ensures that this.field receiver-type resolution
+    // works in the worker path. Without it, chained calls via typed fields
+    // (e.g. this.cache.get()) fail to resolve → fewer CALLS edges in the
+    // parallel path than in the sequential path.
+    const seqRels: Array<Record<string, unknown>> = JSON.parse(seqSnapshot);
+    const parRels: Array<Record<string, unknown>> = JSON.parse(parSnapshot);
+
+    const seqCalls = seqRels.filter(r => r['type'] === 'CALLS');
+    const parCalls = parRels.filter(r => r['type'] === 'CALLS');
+
+    expect(seqCalls.length).toBeGreaterThan(0);
+    expect(parCalls.length).toBe(seqCalls.length);
+  });
+});

--- a/gitnexus/test/unit/lsp/lsp-early-bail.test.ts
+++ b/gitnexus/test/unit/lsp/lsp-early-bail.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Unit Tests: adaptive early-bail (mode-a-reconciler).
+ *
+ * The dispatch loop stops probing once it has issued LSP_EARLY_BAIL_SAMPLE
+ * `textDocument/definition` requests with ZERO useful resolutions — the server
+ * is demonstrably not resolving this repo (e.g. pylsp on dynamic Python). The
+ * remaining candidates are skipped and KEEP their heuristic edge (identical to
+ * probing-and-getting-empty under the observed 0-hit rate).
+ *
+ * Invariants:
+ *   EB-1  0-hit feed > sample  → bail trips; probed ≈ sample, bailed > 0.
+ *   EB-2  server resolves (non-vendor location) → NEVER bails; all probed.
+ *   EB-3  earlyBail:false      → never bails even on a 0-hit feed; all probed.
+ *   EB-4  vendor-only resolutions (site-packages) count as 0 hits → bail trips.
+ *   EB-5  feed ≤ sample        → never bails (nothing to gain).
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+import {
+  withReconciliationSession,
+  LSP_EARLY_BAIL_SAMPLE,
+  type WithReconciliationSessionDeps,
+  type ReconciliationProbeFn,
+  type ReconciliationLspClient,
+  type ReconciliationRepo,
+  type Candidate,
+  type SessionMeta,
+} from '../../../src/core/ingestion/mode-a-reconciler.js';
+
+const REPO: ReconciliationRepo = { id: 'r1', repoPath: '/workspace/repo' };
+
+function makeClient(requestImpl: () => Promise<unknown>): ReconciliationLspClient {
+  return {
+    start: vi.fn(async () => undefined),
+    stop: vi.fn(async () => undefined),
+    request: vi.fn(requestImpl),
+    getState: vi.fn(() => 'ready'),
+  } as unknown as ReconciliationLspClient;
+}
+
+function makeDeps(
+  client: ReconciliationLspClient,
+  over: Partial<WithReconciliationSessionDeps> = {},
+): WithReconciliationSessionDeps {
+  return {
+    discoverServers: vi.fn(async () => ({
+      typescript: { path: '/bin/typescript-language-server', version: '4.3.3' },
+    })),
+    createLspClient: vi.fn(() => client),
+    probe: vi.fn(async () => ({ ready: true })) as unknown as ReconciliationProbeFn,
+    handToEngine: vi.fn(async () => undefined),
+    ...over,
+  };
+}
+
+function recallCandidates(n: number): Candidate[] {
+  return Array.from({ length: n }, (_, i) => ({
+    sourceId: `src:${i}`,
+    calledName: `fn${i}`,
+    file: `src/m${i}.py`,
+    line: i,
+    character: 0,
+  })) as Candidate[];
+}
+
+async function runMeta(
+  candidates: Candidate[],
+  deps: WithReconciliationSessionDeps,
+): Promise<SessionMeta> {
+  let captured: SessionMeta | undefined;
+  await withReconciliationSession(REPO, candidates, async (_sel, meta) => {
+    captured = meta;
+    return undefined;
+  }, deps);
+  if (!captured) throw new Error('work-fn never called — gate refused');
+  return captured;
+}
+
+const inRepoLoc = [{ uri: 'file:///workspace/repo/src/target.py', range: { start: { line: 1, character: 0 } } }];
+const vendorLoc = [{ uri: 'file:///workspace/repo/.venv/lib/python3.12/site-packages/numpy/core.py', range: { start: { line: 1, character: 0 } } }];
+
+describe('adaptive early-bail', () => {
+  const TOTAL = LSP_EARLY_BAIL_SAMPLE + 50;
+
+  it('EB-1: 0-hit feed larger than the sample → bail trips, remaining kept', async () => {
+    const client = makeClient(async () => null); // every probe empty
+    const meta = await runMeta(recallCandidates(TOTAL), makeDeps(client));
+    expect(meta.earlyBailed).toBe(true);
+    // probed ≈ sample (a few extra in-flight under the 8-way pool are allowed).
+    expect(meta.probed).toBeGreaterThanOrEqual(LSP_EARLY_BAIL_SAMPLE);
+    expect(meta.probed).toBeLessThan(TOTAL);
+    expect(meta.bailed ?? 0).toBeGreaterThan(0);
+    // Every candidate is accounted for exactly once.
+    expect(meta.probed + (meta.bailed ?? 0) + (meta.preFilteredExternal ?? 0)).toBe(TOTAL);
+  });
+
+  it('EB-2: server resolves in-repo → never bails, all probed', async () => {
+    const client = makeClient(async () => inRepoLoc);
+    const meta = await runMeta(recallCandidates(TOTAL), makeDeps(client));
+    expect(meta.earlyBailed).toBeFalsy();
+    expect(meta.bailed ?? 0).toBe(0);
+    expect(meta.probed).toBe(TOTAL);
+  });
+
+  it('EB-3: earlyBail:false → exhaustive probing even on a 0-hit feed', async () => {
+    const client = makeClient(async () => null);
+    const meta = await runMeta(recallCandidates(TOTAL), makeDeps(client, { earlyBail: false }));
+    expect(meta.earlyBailed).toBeFalsy();
+    expect(meta.bailed ?? 0).toBe(0);
+    expect(meta.probed).toBe(TOTAL);
+  });
+
+  it('EB-4: vendor-only resolutions count as 0 hits → bail trips', async () => {
+    const client = makeClient(async () => vendorLoc); // non-empty but site-packages
+    const meta = await runMeta(recallCandidates(TOTAL), makeDeps(client));
+    expect(meta.earlyBailed).toBe(true);
+    expect(meta.bailed ?? 0).toBeGreaterThan(0);
+  });
+
+  it('EB-5: feed at or below the sample → never bails', async () => {
+    const client = makeClient(async () => null);
+    const meta = await runMeta(recallCandidates(LSP_EARLY_BAIL_SAMPLE), makeDeps(client));
+    expect(meta.earlyBailed).toBeFalsy();
+    expect(meta.probed).toBe(LSP_EARLY_BAIL_SAMPLE);
+  });
+});

--- a/gitnexus/test/unit/lsp/python-recall-external-prefilter.test.ts
+++ b/gitnexus/test/unit/lsp/python-recall-external-prefilter.test.ts
@@ -1,0 +1,728 @@
+/**
+ * Unit Tests: Python external pre-filter (ADR-002 Lever 10).
+ *
+ * Covers the pythonExternalFqnIndex population (import-processor) and injection
+ * (call-processor), plus the end-to-end soundness invariants:
+ *
+ *   (a) BYTE-IDENTITY   — identical graph outcome with and without the pre-filter
+ *                         (skipped externals → locs=[] → NO_NODE → KEEP, identical to
+ *                         probing the external and getting a null LSP response).
+ *   (b) NO FALSE SKIP   — in-repo imports (relative or resolved) are NEVER classified
+ *                         external; they must be probed.
+ *   (c) AMBIGUITY GUARD — two recall items sharing a candidate key where one is external
+ *                         and one is not → key absent from map → both probed.
+ *
+ * These tests are unit tests (no real LSP, no real ingestion pipeline) — they verify:
+ *   1. pythonExternalFqnIndex population logic (import-processor semantics).
+ *   2. RecallFeedItem.calleeExternalFqn injection (call-processor semantics).
+ *   3. buildRecallExternalFqnMap behaviour with Python-sourced feed items.
+ *   4. The canSkipCandidate recall branch skips Python external items and probes others.
+ *
+ * EP Partitions (Python-specific):
+ *   EP-PY-A: module-alias import (`import numpy as np`) → bound name 'np' → external
+ *   EP-PY-B: named import (`from os import getcwd`) → bound name 'getcwd' → external
+ *   EP-PY-C: bare import (`import os`) → bound name 'os' → external
+ *   EP-PY-D: relative import (`from .helpers import foo`) → NOT external → probe
+ *   EP-PY-E: in-repo import that resolves → NOT external → probe
+ *   EP-PY-F: two recall items at same key; one external, one not → key absent → probe
+ *   EP-PY-G: receiver-name lookup (`np.array()` → receiverName='np') → external
+ *   EP-PY-H: calledName fallback (`getcwd()` → receiverName undefined → calledName='getcwd') → external
+ *   EP-PY-I: .ts file → pythonExternalFqnIndex absent → no injection → probe
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+import {
+  withReconciliationSession,
+  type WithReconciliationSessionDeps,
+  type ReconciliationProbeFn,
+  type ReconciliationLspClient,
+  type ReconciliationRepo,
+  type Location,
+  type Candidate,
+  type SessionMeta,
+} from '../../../src/core/ingestion/mode-a-reconciler.js';
+import { buildRecallExternalFqnMap } from '../../../src/core/ingestion/pipeline.js';
+import type { RecallFeedItem } from '../../../src/core/ingestion/call-processor.js';
+
+// ─── Shared test infrastructure (mirrors mode-a-external-prefilter.test.ts) ───
+
+function makeMockClient(over: {
+  requestImpl?: (method: string, params: unknown, timeoutMs: number) => Promise<unknown>;
+} = {}) {
+  const start = vi.fn(async () => undefined);
+  const stop = vi.fn(async () => undefined);
+  const request = vi.fn(over.requestImpl ?? (async () => null));
+  const getState = vi.fn(() => 'ready');
+  return {
+    client: { start, stop, request, getState } as unknown as ReconciliationLspClient,
+    start,
+    stop,
+    request,
+  };
+}
+
+function makeClientFactory(client: ReconciliationLspClient) {
+  return vi.fn(() => client);
+}
+
+function makeReadyProbe(): ReconciliationProbeFn {
+  return vi.fn(async () => ({ ready: true })) as unknown as ReconciliationProbeFn;
+}
+
+function makeDeps(
+  client: ReconciliationLspClient,
+  over: Partial<WithReconciliationSessionDeps> = {},
+): WithReconciliationSessionDeps {
+  return {
+    // Session uses the default TYPESCRIPT_ADAPTER (adapter.id = 'typescript').
+    // discoverServers must return a 'typescript' entry for the gate to pass.
+    // The Python external FQN pre-filter is server-side logic (recallFqnMap /
+    // canSkipCandidate) — it is independent of which language server is used.
+    discoverServers: vi.fn(async () => ({
+      typescript: { path: '/bin/typescript-language-server', version: '4.3.3' },
+    })),
+    createLspClient: makeClientFactory(client),
+    probe: makeReadyProbe(),
+    ...over,
+  };
+}
+
+const REPO: ReconciliationRepo = {
+  id: 'r1',
+  repoPath: '/workspace/repo',
+};
+
+function mkRecallCandidate(over: Partial<Candidate> = {}): Candidate {
+  return {
+    sourceId: 'src:py',
+    calledName: 'array',
+    file: 'src/analysis.py',
+    line: 5,
+    character: 3,
+    ...over,
+  };
+}
+
+/** candidateLocationKey mirrors pipeline.ts / mode-a-reconciler.ts */
+function locationKey(c: Candidate): string {
+  const base = `${c.sourceId}|${c.calledName}|${c.line}|${c.character}`;
+  const relType = (c as unknown as Record<string, unknown>).relType;
+  return relType ? `${base}|${relType}` : base;
+}
+
+async function runAndCaptureMeta(
+  candidates: Candidate[],
+  deps: WithReconciliationSessionDeps,
+): Promise<{ meta: SessionMeta; handCalls: number }> {
+  const handFn = vi.fn(async (_cand: Candidate, _locs: Location[]) => undefined);
+  let captured: SessionMeta | undefined;
+  await withReconciliationSession(REPO, candidates, async (_selected, meta) => {
+    captured = meta;
+    return undefined;
+  }, { ...deps, handToEngine: handFn as unknown as (cand: Candidate, locs: Location[]) => Promise<void> });
+  if (!captured) throw new Error('work-fn never called — gate refused (check discoverServers returns typescript key)');
+  return { meta: captured, handCalls: handFn.mock.calls.length };
+}
+
+// ─── Helper: build a canSkipCandidate closure mirroring pipeline.ts WI-A3 ────
+
+function makeA3ClosurePy(
+  graphNodes: Map<string, { properties: { isExternal?: boolean } }>,
+  recallFqnMap: Map<string, string>,
+  preFilteredKeys: Set<string>,
+): (candidate: Candidate) => boolean {
+  return (candidate: Candidate): boolean => {
+    if (!candidate.oldTargetId) {
+      const key = locationKey(candidate);
+      const fqn = recallFqnMap.get(key);
+      if (fqn) {
+        preFilteredKeys.add(key);
+        return true;
+      }
+      return false;
+    }
+    const node = graphNodes.get(candidate.oldTargetId);
+    if (node === undefined) return false;
+    const skip = node.properties.isExternal === true;
+    if (skip) preFilteredKeys.add(locationKey(candidate));
+    return skip;
+  };
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// SECTION 1: pythonExternalFqnIndex population semantics
+//
+// These tests exercise the MAP-BUILDING logic that import-processor applies.
+// We simulate it inline (the actual processImports fn is tested via integration;
+// here we verify the key/value shape the call-processor consumes).
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/**
+ * Simulate what import-processor writes to pythonExternalFqnIndex.
+ * Covers both slow path (processImports) and fast path (processImportsFromExtracted).
+ *
+ * Rules:
+ *   - `!result` (unresolved in-repo) + `!rawImportPath.startsWith('.')` → external
+ *   - Named bindings: record b.local → rawImportPath for each binding
+ *   - No bindings: record topLevelSegment → rawImportPath
+ */
+function simulatePythonIndexPopulation(
+  entries: Array<{
+    filePath: string;
+    rawImportPath: string;
+    namedBindings?: Array<{ local: string; exported: string }>;
+    isRelative?: boolean;
+    resolvedInRepo?: boolean;
+  }>,
+): Map<string, Map<string, string>> {
+  const idx = new Map<string, Map<string, string>>();
+  for (const e of entries) {
+    // Skip if resolved in-repo (result != null) or relative
+    if (e.resolvedInRepo || e.isRelative) continue;
+    let fileMap = idx.get(e.filePath);
+    if (!fileMap) { fileMap = new Map(); idx.set(e.filePath, fileMap); }
+    if (e.namedBindings && e.namedBindings.length > 0) {
+      for (const b of e.namedBindings) {
+        fileMap.set(b.local, e.rawImportPath);
+      }
+    } else {
+      const topLevel = e.rawImportPath.split('.')[0];
+      fileMap.set(topLevel, e.rawImportPath);
+    }
+  }
+  return idx;
+}
+
+describe('PY-INDEX-1 [EP-PY-A]: module-alias import populates bound alias as key', () => {
+  it('import numpy as np → pythonExternalFqnIndex["analysis.py"]["np"] = "numpy"', () => {
+    const idx = simulatePythonIndexPopulation([{
+      filePath: '/repo/analysis.py',
+      rawImportPath: 'numpy',
+      namedBindings: [{ local: 'np', exported: 'numpy' }],
+    }]);
+
+    const fileMap = idx.get('/repo/analysis.py');
+    expect(fileMap).toBeDefined();
+    expect(fileMap!.get('np')).toBe('numpy');
+    // 'numpy' itself must NOT be a key — bound name is 'np'
+    expect(fileMap!.has('numpy')).toBe(false);
+  });
+});
+
+describe('PY-INDEX-2 [EP-PY-B]: named import from module populates local name as key', () => {
+  it('from os import getcwd → pythonExternalFqnIndex["app.py"]["getcwd"] = "os"', () => {
+    const idx = simulatePythonIndexPopulation([{
+      filePath: '/repo/app.py',
+      rawImportPath: 'os',
+      namedBindings: [{ local: 'getcwd', exported: 'getcwd' }],
+    }]);
+
+    const fileMap = idx.get('/repo/app.py');
+    expect(fileMap).toBeDefined();
+    expect(fileMap!.get('getcwd')).toBe('os');
+  });
+});
+
+describe('PY-INDEX-3 [EP-PY-B multi]: from os import getcwd, path → two entries', () => {
+  it('from os import getcwd, path → both keys recorded with module "os"', () => {
+    const idx = simulatePythonIndexPopulation([{
+      filePath: '/repo/app.py',
+      rawImportPath: 'os',
+      namedBindings: [
+        { local: 'getcwd', exported: 'getcwd' },
+        { local: 'path', exported: 'path' },
+      ],
+    }]);
+
+    const fileMap = idx.get('/repo/app.py');
+    expect(fileMap).toBeDefined();
+    expect(fileMap!.get('getcwd')).toBe('os');
+    expect(fileMap!.get('path')).toBe('os');
+  });
+});
+
+describe('PY-INDEX-4 [EP-PY-C]: bare import populates top-level module segment', () => {
+  it('import os → pythonExternalFqnIndex["script.py"]["os"] = "os"', () => {
+    const idx = simulatePythonIndexPopulation([{
+      filePath: '/repo/script.py',
+      rawImportPath: 'os',
+    }]);
+
+    expect(idx.get('/repo/script.py')?.get('os')).toBe('os');
+  });
+
+  it('import os.path → key is "os" (top-level segment), value is "os.path"', () => {
+    const idx = simulatePythonIndexPopulation([{
+      filePath: '/repo/script.py',
+      rawImportPath: 'os.path',
+    }]);
+
+    const fileMap = idx.get('/repo/script.py');
+    expect(fileMap?.get('os')).toBe('os.path');
+    // 'os.path' must NOT be a key — only the top segment
+    expect(fileMap?.has('os.path')).toBe(false);
+  });
+});
+
+describe('PY-INDEX-5 [EP-PY-D]: relative import → NOT added to index', () => {
+  it('from .helpers import foo (isRelative=true) → file absent from index', () => {
+    const idx = simulatePythonIndexPopulation([{
+      filePath: '/repo/app.py',
+      rawImportPath: '.helpers',
+      namedBindings: [{ local: 'foo', exported: 'foo' }],
+      isRelative: true,
+    }]);
+
+    expect(idx.has('/repo/app.py')).toBe(false);
+  });
+});
+
+describe('PY-INDEX-6 [EP-PY-E]: resolved in-repo import → NOT added to index', () => {
+  it('import helpers (resolves to /repo/helpers.py) → file absent from index', () => {
+    const idx = simulatePythonIndexPopulation([{
+      filePath: '/repo/app.py',
+      rawImportPath: 'helpers',
+      namedBindings: [{ local: 'foo', exported: 'foo' }],
+      resolvedInRepo: true,
+    }]);
+
+    expect(idx.has('/repo/app.py')).toBe(false);
+  });
+});
+
+describe('PY-INDEX-7 [multi-file]: multiple files populated independently', () => {
+  it('two Python files with different external imports → separate fileMap entries', () => {
+    const idx = simulatePythonIndexPopulation([
+      {
+        filePath: '/repo/analysis.py',
+        rawImportPath: 'numpy',
+        namedBindings: [{ local: 'np', exported: 'numpy' }],
+      },
+      {
+        filePath: '/repo/stats.py',
+        rawImportPath: 'scipy',
+        namedBindings: [{ local: 'sp', exported: 'scipy' }],
+      },
+    ]);
+
+    expect(idx.get('/repo/analysis.py')?.get('np')).toBe('numpy');
+    expect(idx.get('/repo/stats.py')?.get('sp')).toBe('scipy');
+    // No cross-contamination
+    expect(idx.get('/repo/analysis.py')?.has('sp')).toBe(false);
+    expect(idx.get('/repo/stats.py')?.has('np')).toBe(false);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// SECTION 2: RecallFeedItem injection (call-processor semantics)
+//
+// Verify the RecallFeedItem.calleeExternalFqn values that the call-processor
+// would inject, then confirm buildRecallExternalFqnMap builds the right map.
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/**
+ * Simulate call-processor slow/fast path injection of calleeExternalFqn.
+ * Returns the value that would be spread onto the RecallFeedItem.
+ *
+ * Logic (mirrors call-processor.ts):
+ *   - .py file: look up receiverName first, then calledName
+ *   - .java file: look up receiverTypeName (Java gate, unchanged)
+ *   - other: undefined
+ */
+function simulatePythonFqnInjection(opts: {
+  filePath: string;
+  receiverName?: string;
+  calledName: string;
+  pythonExternalFqnIndex?: Map<string, Map<string, string>>;
+}): string | undefined {
+  const { filePath, receiverName, calledName, pythonExternalFqnIndex } = opts;
+  if (!filePath.endsWith('.py')) return undefined;
+  return pythonExternalFqnIndex?.get(filePath)?.get(receiverName ?? calledName);
+}
+
+describe('PY-INJECT-1 [EP-PY-G]: member call receiver lookup (np.array())', () => {
+  it('np.array() → receiverName="np" → calleeExternalFqn="numpy"', () => {
+    const idx = simulatePythonIndexPopulation([{
+      filePath: '/repo/analysis.py',
+      rawImportPath: 'numpy',
+      namedBindings: [{ local: 'np', exported: 'numpy' }],
+    }]);
+
+    const fqn = simulatePythonFqnInjection({
+      filePath: '/repo/analysis.py',
+      receiverName: 'np',
+      calledName: 'array',
+      pythonExternalFqnIndex: idx,
+    });
+
+    expect(fqn).toBe('numpy');
+  });
+});
+
+describe('PY-INJECT-2 [EP-PY-H]: free-function call falls back to calledName (getcwd())', () => {
+  it('getcwd() with no receiver → calledName="getcwd" → calleeExternalFqn="os"', () => {
+    const idx = simulatePythonIndexPopulation([{
+      filePath: '/repo/app.py',
+      rawImportPath: 'os',
+      namedBindings: [{ local: 'getcwd', exported: 'getcwd' }],
+    }]);
+
+    const fqn = simulatePythonFqnInjection({
+      filePath: '/repo/app.py',
+      receiverName: undefined,
+      calledName: 'getcwd',
+      pythonExternalFqnIndex: idx,
+    });
+
+    expect(fqn).toBe('os');
+  });
+});
+
+describe('PY-INJECT-3 [EP-PY-I]: non-Python file → no injection', () => {
+  it('.ts file → calleeExternalFqn=undefined regardless of index', () => {
+    // Even if a pythonExternalFqnIndex somehow contained a .ts entry, it must not fire
+    const idx = new Map([
+      ['/repo/utils.ts', new Map([['readFile', 'fs']])],
+    ]);
+
+    const fqn = simulatePythonFqnInjection({
+      filePath: '/repo/utils.ts',
+      calledName: 'readFile',
+      pythonExternalFqnIndex: idx,
+    });
+
+    expect(fqn).toBeUndefined();
+  });
+});
+
+describe('PY-INJECT-4: index absent (non-LSP path) → undefined', () => {
+  it('pythonExternalFqnIndex=undefined → calleeExternalFqn=undefined (I-9 byte-identical)', () => {
+    const fqn = simulatePythonFqnInjection({
+      filePath: '/repo/analysis.py',
+      receiverName: 'np',
+      calledName: 'array',
+      pythonExternalFqnIndex: undefined,
+    });
+
+    expect(fqn).toBeUndefined();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// SECTION 3: buildRecallExternalFqnMap with Python-sourced feed items
+//
+// buildRecallExternalFqnMap is language-agnostic; these tests confirm it handles
+// Python RecallFeedItems correctly (including I-2c ambiguity guard).
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('PY-MAP-1 [EP-PY-A]: numpy recall item → FQN in map', () => {
+  it('single Python recall item with calleeExternalFqn → map has entry', () => {
+    const feed: RecallFeedItem[] = [
+      {
+        sourceId: 'Function:/repo/analysis.py:run',
+        calledName: 'array',
+        file: '/repo/analysis.py',
+        line: 10,
+        character: 5,
+        calleeExternalFqn: 'numpy',
+      },
+    ];
+
+    const map = buildRecallExternalFqnMap(feed);
+    const key = `${feed[0].sourceId}|${feed[0].calledName}|${feed[0].line}|${feed[0].character}`;
+    expect(map.get(key)).toBe('numpy');
+  });
+});
+
+describe('PY-MAP-2 [EP-PY-B]: os.getcwd recall item → FQN in map', () => {
+  it('free-function recall from os module → map has entry keyed by calledName', () => {
+    const feed: RecallFeedItem[] = [
+      {
+        sourceId: 'Function:/repo/app.py:main',
+        calledName: 'getcwd',
+        file: '/repo/app.py',
+        line: 3,
+        character: 2,
+        calleeExternalFqn: 'os',
+      },
+    ];
+
+    const map = buildRecallExternalFqnMap(feed);
+    const key = `${feed[0].sourceId}|${feed[0].calledName}|${feed[0].line}|${feed[0].character}`;
+    expect(map.get(key)).toBe('os');
+  });
+});
+
+describe('PY-MAP-3 [EP-PY-F / I-2c]: ambiguity guard — two items at same key (one external, one not)', () => {
+  it('external-first then non-external: key absent from map → both probed', () => {
+    const sourceId = 'Function:/repo/mixed.py:run';
+    const calledName = 'compute';
+    const line = 7;
+    const character = 4;
+
+    const feed: RecallFeedItem[] = [
+      // First: external
+      { sourceId, calledName, file: '/repo/mixed.py', line, character, calleeExternalFqn: 'scipy' },
+      // Second: in-repo (no FQN) — same key
+      { sourceId, calledName, file: '/repo/mixed.py', line, character },
+    ];
+
+    const map = buildRecallExternalFqnMap(feed);
+    const key = `${sourceId}|${calledName}|${line}|${character}`;
+    // I-2c: ambiguous → key MUST be absent (deleted by the non-external item)
+    expect(map.has(key)).toBe(false);
+  });
+
+  it('non-external-first then external: key absent from map → both probed', () => {
+    const sourceId = 'Function:/repo/mixed.py:run';
+    const calledName = 'transform';
+    const line = 12;
+    const character = 6;
+
+    const feed: RecallFeedItem[] = [
+      // First: in-repo (no FQN) — marks key ambiguous
+      { sourceId, calledName, file: '/repo/mixed.py', line, character },
+      // Second: external — must NOT override the ambiguous mark
+      { sourceId, calledName, file: '/repo/mixed.py', line, character, calleeExternalFqn: 'pandas' },
+    ];
+
+    const map = buildRecallExternalFqnMap(feed);
+    const key = `${sourceId}|${calledName}|${line}|${character}`;
+    expect(map.has(key)).toBe(false);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// SECTION 4: End-to-end session behaviour
+//
+// Verify that Python external recall candidates are skipped by canSkipCandidate,
+// that in-repo Python calls are probed, and that the byte-identity invariant holds.
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('PY-E2E-1 [EP-PY-A / byte-identity]: external Python recall → skip; same meta as LSP returning null', () => {
+  it('numpy recall candidate with FQN → preFilteredExternal=1, probed=0, handToEngine not called', async () => {
+    const { client } = makeMockClient();
+
+    const recall = mkRecallCandidate({
+      sourceId: 'Function:/repo/analysis.py:run',
+      calledName: 'array',
+      line: 10,
+      character: 5,
+      file: '/repo/analysis.py',
+    });
+    const key = locationKey(recall);
+
+    const recallFqnMap = new Map([[key, 'numpy']]);
+    const preFilteredKeys = new Set<string>();
+    const canSkipCandidate = makeA3ClosurePy(new Map(), recallFqnMap, preFilteredKeys);
+    const deps = makeDeps(client, { canSkipCandidate });
+
+    const { meta, handCalls } = await runAndCaptureMeta([recall], deps);
+
+    expect(meta.preFilteredExternal).toBe(1);
+    expect(meta.probed).toBe(0);
+    expect(handCalls).toBe(0);
+    // I-8-replay: key recorded
+    expect(preFilteredKeys.has(key)).toBe(true);
+  });
+});
+
+describe('PY-E2E-2 [EP-PY-D / no false skip]: relative import → recall always probed', () => {
+  it('relative import call site has no FQN in map → probed=1', async () => {
+    const { client } = makeMockClient({ requestImpl: async () => null });
+
+    const recall = mkRecallCandidate({
+      sourceId: 'Function:/repo/app.py:main',
+      calledName: 'foo',
+      line: 4,
+      character: 2,
+      file: '/repo/app.py',
+    });
+    const key = locationKey(recall);
+
+    // Empty map — relative imports were never added
+    const recallFqnMap = new Map<string, string>();
+    const preFilteredKeys = new Set<string>();
+    const canSkipCandidate = makeA3ClosurePy(new Map(), recallFqnMap, preFilteredKeys);
+    const deps = makeDeps(client, { canSkipCandidate });
+
+    const { meta, handCalls } = await runAndCaptureMeta([recall], deps);
+
+    expect(meta.preFilteredExternal).toBe(0);
+    expect(meta.probed).toBe(1);
+    expect(handCalls).toBe(1);
+    expect(preFilteredKeys.has(key)).toBe(false);
+  });
+});
+
+describe('PY-E2E-3 [EP-PY-E / no false skip]: in-repo Python import → recall probed', () => {
+  it('in-repo import site has no FQN in map → probed=1; never skipped', async () => {
+    const { client } = makeMockClient({ requestImpl: async () => null });
+
+    const recall = mkRecallCandidate({
+      sourceId: 'Function:/repo/service.py:handler',
+      calledName: 'process',
+      line: 7,
+      character: 4,
+      file: '/repo/service.py',
+    });
+
+    // Map is empty — in-repo imports were excluded from index at population time
+    const recallFqnMap = new Map<string, string>();
+    const preFilteredKeys = new Set<string>();
+    const canSkipCandidate = makeA3ClosurePy(new Map(), recallFqnMap, preFilteredKeys);
+    const deps = makeDeps(client, { canSkipCandidate });
+
+    const { meta } = await runAndCaptureMeta([recall], deps);
+
+    expect(meta.preFilteredExternal).toBe(0);
+    expect(meta.probed).toBe(1);
+    expect(preFilteredKeys.size).toBe(0);
+  });
+});
+
+describe('PY-E2E-4 [EP-PY-F / I-2c]: ambiguous key → probe, never skip', () => {
+  it('two recalls at same key (one external, one not) → key absent from map → both probed', async () => {
+    const { client } = makeMockClient({ requestImpl: async () => null });
+
+    const sourceId = 'Function:/repo/mixed.py:run';
+    const calledName = 'compute';
+    const line = 7;
+    const character = 4;
+
+    const feedItems: RecallFeedItem[] = [
+      { sourceId, calledName, file: '/repo/mixed.py', line, character, calleeExternalFqn: 'scipy' },
+      { sourceId, calledName, file: '/repo/mixed.py', line, character },
+    ];
+
+    // buildRecallExternalFqnMap enforces I-2c: ambiguous key deleted
+    const recallFqnMap = buildRecallExternalFqnMap(feedItems);
+    const key = `${sourceId}|${calledName}|${line}|${character}`;
+    expect(recallFqnMap.has(key)).toBe(false);
+
+    // The recall candidate maps to the ambiguous key → must probe
+    const recall = mkRecallCandidate({ sourceId, calledName, line, character, file: '/repo/mixed.py' });
+    const preFilteredKeys = new Set<string>();
+    const canSkipCandidate = makeA3ClosurePy(new Map(), recallFqnMap, preFilteredKeys);
+    const deps = makeDeps(client, { canSkipCandidate });
+
+    const { meta } = await runAndCaptureMeta([recall], deps);
+
+    expect(meta.preFilteredExternal).toBe(0);
+    expect(meta.probed).toBe(1);
+  });
+});
+
+describe('PY-E2E-5 [batch]: mixed numpy/os/in-repo batch → correct counts', () => {
+  it('2 external (numpy + os) + 1 in-repo → preFilteredExternal=2, probed=1', async () => {
+    const { client } = makeMockClient({ requestImpl: async () => null });
+
+    const numpyRecall = mkRecallCandidate({
+      sourceId: 's1', calledName: 'array', line: 1, character: 0, file: '/repo/analysis.py',
+    });
+    const osRecall = mkRecallCandidate({
+      sourceId: 's2', calledName: 'getcwd', line: 2, character: 0, file: '/repo/app.py',
+    });
+    const inRepoRecall = mkRecallCandidate({
+      sourceId: 's3', calledName: 'process', line: 3, character: 0, file: '/repo/service.py',
+    });
+
+    const recallFqnMap = new Map([
+      [locationKey(numpyRecall), 'numpy'],
+      [locationKey(osRecall), 'os'],
+      // inRepoRecall has no entry → probe
+    ]);
+
+    const preFilteredKeys = new Set<string>();
+    const canSkipCandidate = makeA3ClosurePy(new Map(), recallFqnMap, preFilteredKeys);
+    const deps = makeDeps(client, { canSkipCandidate });
+
+    const { meta, handCalls } = await runAndCaptureMeta(
+      [numpyRecall, osRecall, inRepoRecall],
+      deps,
+    );
+
+    expect(meta.preFilteredExternal).toBe(2);
+    expect(meta.probed).toBe(1);
+    expect(handCalls).toBe(1);
+    expect(preFilteredKeys.size).toBe(2);
+  });
+});
+
+describe('PY-E2E-6 [I-9 / non-LSP path]: no pythonExternalFqnIndex → all recalls probed', () => {
+  it('recallFqnMap empty (non-LSP: index was never built) → probed=2, preFilteredExternal=0', async () => {
+    const { client } = makeMockClient({ requestImpl: async () => null });
+
+    // Without LSP, the index is never built → no FQNs → empty recallFqnMap
+    const recallFqnMap = new Map<string, string>();
+    const preFilteredKeys = new Set<string>();
+    const canSkipCandidate = makeA3ClosurePy(new Map(), recallFqnMap, preFilteredKeys);
+    const deps = makeDeps(client, { canSkipCandidate });
+
+    const r1 = mkRecallCandidate({ sourceId: 's1', calledName: 'array', line: 1, character: 0 });
+    const r2 = mkRecallCandidate({ sourceId: 's2', calledName: 'getcwd', line: 2, character: 0 });
+
+    const { meta } = await runAndCaptureMeta([r1, r2], deps);
+
+    // Non-LSP path: byte-identical to baseline (no skips at all)
+    expect(meta.probed).toBe(2);
+    expect(meta.preFilteredExternal).toBe(0);
+  });
+});
+
+describe('PY-E2E-7 [soundness / I-2c]: "unknown ≠ external" — unrecognised module not in index', () => {
+  it('import someUnknownLib where resolver failed but lib is not in index → probed (conservative)', async () => {
+    const { client } = makeMockClient({ requestImpl: async () => null });
+
+    // The import-processor never adds 'someUnknownLib' to the index if it could not
+    // classify it definitively — but in practice all !result + !startsWith('.') entries
+    // ARE added.  The conservative invariant here: if the index does NOT have an entry
+    // for this recall candidate, it must be probed, not skipped.
+    const recall = mkRecallCandidate({
+      sourceId: 'Function:/repo/app.py:main',
+      calledName: 'frobnicate',
+      line: 99,
+      character: 0,
+      file: '/repo/app.py',
+    });
+
+    // No entry for this candidate → no FQN
+    const recallFqnMap = new Map<string, string>();
+    const preFilteredKeys = new Set<string>();
+    const canSkipCandidate = makeA3ClosurePy(new Map(), recallFqnMap, preFilteredKeys);
+    const deps = makeDeps(client, { canSkipCandidate });
+
+    const { meta } = await runAndCaptureMeta([recall], deps);
+
+    expect(meta.preFilteredExternal).toBe(0);
+    expect(meta.probed).toBe(1);
+  });
+});
+
+describe('PY-E2E-8 [pandas]: real-world pandas recall → preFilteredExternal=1', () => {
+  it('import pandas as pd; pd.DataFrame() recall → skipped via recallFqnMap', async () => {
+    const { client } = makeMockClient();
+
+    const recall = mkRecallCandidate({
+      sourceId: 'Function:/repo/data.py:load',
+      calledName: 'DataFrame',
+      line: 15,
+      character: 7,
+      file: '/repo/data.py',
+    });
+    const key = locationKey(recall);
+
+    const recallFqnMap = new Map([[key, 'pandas']]);
+    const preFilteredKeys = new Set<string>();
+    const canSkipCandidate = makeA3ClosurePy(new Map(), recallFqnMap, preFilteredKeys);
+    const deps = makeDeps(client, { canSkipCandidate });
+
+    const { meta, handCalls } = await runAndCaptureMeta([recall], deps);
+
+    expect(meta.preFilteredExternal).toBe(1);
+    expect(meta.probed).toBe(0);
+    expect(handCalls).toBe(0);
+    expect(preFilteredKeys.has(key)).toBe(true);
+  });
+});

--- a/gitnexus/test/unit/process-processor-insertion-order.test.ts
+++ b/gitnexus/test/unit/process-processor-insertion-order.test.ts
@@ -1,0 +1,365 @@
+/**
+ * Regression guard: `processProcesses` is insertion-order-independent.
+ *
+ * Bug history (three separate regressions on perf/lsp-analyze-speedup):
+ *   Bug 1 — findEntryPoints tied-score candidates were in Map insertion order
+ *            → proc_<idx> numbering churned between sequential and parallel-parse paths.
+ *            Fixed: sort uses total-order comparator with id tiebreak.
+ *   Bug 2 — buildCallsGraph callees were in edge insertion order; slice(0, maxBranching)
+ *            picked different callees between the two paths.
+ *            Fixed: adjacency lists sorted by targetId after construction.
+ *   Bug 3 — deduplicateTraces / deduplicateByEndpoints / limitedTraces sorts were
+ *            not total-order → equal-length traces kept/numbered in insertion order.
+ *            Fixed: all three sorts use length-desc + full-path-lexicographic comparator.
+ *
+ * This test builds the same graph twice with nodes and edges added in two
+ * different insertion orders and asserts `processProcesses` produces IDENTICAL
+ * results. "Same" means: same process IDs, same trace arrays, same step numbers.
+ *
+ * Graph topology (designed to exercise all three bug classes):
+ *
+ *   func:hub (name="handleUsers", exported, 5 callees > maxBranching=4)
+ *     → func:hub_callee_alpha → func:hub_term_alpha   ← Bug 2: callee sort
+ *     → func:hub_callee_beta  → func:hub_term_beta
+ *     → func:hub_callee_gamma → func:hub_term_gamma
+ *     → func:hub_callee_delta → func:hub_term_delta
+ *     → func:hub_callee_zeta  → func:hub_term_zeta    ← dropped (last alphabetically)
+ *
+ *   func:ep_a (name="handleA", exported, tied-score 9.0 with ep_b)   ← Bug 1
+ *     → func:mid_a1 → func:term_a1
+ *     → func:mid_a2 → func:term_a2
+ *     → func:mid_a3 → func:term_a3
+ *
+ *   func:ep_b (name="handleB", exported, tied-score 9.0 with ep_a)   ← Bug 1
+ *     → func:mid_b1 → func:term_b1
+ *     → func:mid_b2 → func:term_b2
+ *     → func:mid_b3 → func:term_b3
+ *
+ * Score formula:
+ *   hub:  (5 callees / (0 callers + 1)) × 2.0 × 1.5 × 1.0 = 15.0
+ *   ep_a: (3 callees / (0 callers + 1)) × 2.0 × 1.5 × 1.0 =  9.0  (tied with ep_b)
+ *   ep_b: (3 callees / (0 callers + 1)) × 2.0 × 1.5 × 1.0 =  9.0  (tied with ep_a)
+ *
+ * ORDER_A: hub → ep_a → ep_b (callees in ascending id order, edges forward)
+ * ORDER_B: ep_b → ep_a → hub (callees in descending id order, edges reversed)
+ */
+
+import { describe, it, expect } from 'vitest';
+import { processProcesses } from '../../src/core/ingestion/process-processor.js';
+import { createKnowledgeGraph } from '../../src/core/graph/graph.js';
+import type { KnowledgeGraph } from '../../src/core/graph/types.js';
+import type { CommunityMembership } from '../../src/core/ingestion/community-processor.js';
+
+// ── Graph construction helpers ────────────────────────────────────────────────
+
+function addFn(
+  graph: KnowledgeGraph,
+  id: string,
+  name: string,
+  opts: { exported?: boolean } = {},
+) {
+  graph.addNode({
+    id,
+    label: 'Function',
+    properties: {
+      name,
+      filePath: `src/${id.replace('func:', '')}.ts`,
+      startLine: 1,
+      endLine: 20,
+      isExported: opts.exported ?? false,
+      language: 'typescript' as any,
+    },
+  });
+}
+
+function addCall(
+  graph: KnowledgeGraph,
+  edgeId: string,
+  sourceId: string,
+  targetId: string,
+) {
+  graph.addRelationship({
+    id: edgeId,
+    sourceId,
+    targetId,
+    type: 'CALLS',
+    confidence: 0.9,
+    reason: 'import-resolved',
+  });
+}
+
+// ── Snapshot helpers ──────────────────────────────────────────────────────────
+
+type ProcessResult = Awaited<ReturnType<typeof processProcesses>>;
+
+function snapshotProcesses(result: ProcessResult) {
+  return result.processes
+    .map(p => ({
+      id: p.id,
+      entryPointId: p.entryPointId,
+      terminalId: p.terminalId,
+      trace: [...p.trace],
+    }))
+    .sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
+}
+
+function snapshotSteps(result: ProcessResult) {
+  return result.steps
+    .map(s => ({ nodeId: s.nodeId, processId: s.processId, step: s.step }))
+    .sort((a, b) => {
+      if (a.processId !== b.processId) return a.processId < b.processId ? -1 : 1;
+      return a.step - b.step;
+    });
+}
+
+// ── Fixture definition ────────────────────────────────────────────────────────
+
+const HUB_CALLEES = [
+  { calleeId: 'func:hub_callee_alpha', termId: 'func:hub_term_alpha',
+    callEdgeId: 'call:hub_to_alpha', termEdgeId: 'call:alpha_to_term' },
+  { calleeId: 'func:hub_callee_beta',  termId: 'func:hub_term_beta',
+    callEdgeId: 'call:hub_to_beta',  termEdgeId: 'call:beta_to_term' },
+  { calleeId: 'func:hub_callee_gamma', termId: 'func:hub_term_gamma',
+    callEdgeId: 'call:hub_to_gamma', termEdgeId: 'call:gamma_to_term' },
+  { calleeId: 'func:hub_callee_delta', termId: 'func:hub_term_delta',
+    callEdgeId: 'call:hub_to_delta', termEdgeId: 'call:delta_to_term' },
+  // zeta sorts LAST alphabetically → gets dropped after sort+slice(0, maxBranching=4)
+  { calleeId: 'func:hub_callee_zeta',  termId: 'func:hub_term_zeta',
+    callEdgeId: 'call:hub_to_zeta',  termEdgeId: 'call:zeta_to_term' },
+];
+
+const EP_A_CHAINS = [
+  { midId: 'func:mid_a1', termId: 'func:term_a1',
+    callEdgeId: 'call:a_to_mid1', termEdgeId: 'call:mid1_to_term' },
+  { midId: 'func:mid_a2', termId: 'func:term_a2',
+    callEdgeId: 'call:a_to_mid2', termEdgeId: 'call:mid2_to_term' },
+  { midId: 'func:mid_a3', termId: 'func:term_a3',
+    callEdgeId: 'call:a_to_mid3', termEdgeId: 'call:mid3_to_term' },
+];
+
+const EP_B_CHAINS = [
+  { midId: 'func:mid_b1', termId: 'func:term_b1',
+    callEdgeId: 'call:b_to_mid1', termEdgeId: 'call:mid_b1_to_term' },
+  { midId: 'func:mid_b2', termId: 'func:term_b2',
+    callEdgeId: 'call:b_to_mid2', termEdgeId: 'call:mid_b2_to_term' },
+  { midId: 'func:mid_b3', termId: 'func:term_b3',
+    callEdgeId: 'call:b_to_mid3', termEdgeId: 'call:mid_b3_to_term' },
+];
+
+/**
+ * Populate a KnowledgeGraph with the parity fixture.
+ *
+ * @param insertionOrder
+ *   'ab' — hub first, then ep_a, then ep_b; callees/edges in ascending-id order
+ *   'ba' — ep_b first, then ep_a, then hub; callees/edges in descending-id order
+ *
+ * Both graphs contain identical node and edge SETS; only the insertion (Map) order
+ * differs. Without the three determinism fixes, `processProcesses` would produce
+ * different proc_<idx> numbering and different trace selections between the two.
+ */
+function populateGraph(graph: KnowledgeGraph, insertionOrder: 'ab' | 'ba') {
+  const isAB = insertionOrder === 'ab';
+
+  // ── Entry-point nodes ────────────────────────────────────────────────────
+  //
+  // Score formula: calleeCount/(callerCount+1) × exportMultiplier × nameMultiplier
+  //   hub:  (5/1) × 2.0 × 1.5 = 15.0   ← higher, sorts before ep_a/ep_b
+  //   ep_a: (3/1) × 2.0 × 1.5 =  9.0   ← tied with ep_b; tiebreak by id
+  //   ep_b: (3/1) × 2.0 × 1.5 =  9.0   ← "func:ep_a" < "func:ep_b" → ep_a first
+  //
+  const entryPointDefs = [
+    { id: 'func:hub',  name: 'handleUsers' },
+    { id: 'func:ep_a', name: 'handleA' },
+    { id: 'func:ep_b', name: 'handleB' },
+  ];
+  const epOrder = isAB ? entryPointDefs : [...entryPointDefs].reverse();
+  for (const ep of epOrder) {
+    addFn(graph, ep.id, ep.name, { exported: true });
+  }
+
+  // ── Hub callees + terminals (5 pairs; zeta dropped by sort+slice) ────────
+  const hubOrder = isAB ? HUB_CALLEES : [...HUB_CALLEES].reverse();
+  for (const { calleeId, termId } of hubOrder) {
+    // Use neutral names (no entry-point pattern match, not exported)
+    // to keep their scores well below hub/ep_a/ep_b so they never
+    // become dominant entry points themselves.
+    addFn(graph, calleeId, calleeId.replace('func:hub_callee_', 'step_'));
+    addFn(graph, termId, termId.replace('func:hub_term_', 'sink_'));
+  }
+
+  // ── ep_a mid + terminal nodes ────────────────────────────────────────────
+  const aOrder = isAB ? EP_A_CHAINS : [...EP_A_CHAINS].reverse();
+  for (const { midId, termId } of aOrder) {
+    addFn(graph, midId, midId.replace('func:', ''));
+    addFn(graph, termId, termId.replace('func:', ''));
+  }
+
+  // ── ep_b mid + terminal nodes ────────────────────────────────────────────
+  const bOrder = isAB ? EP_B_CHAINS : [...EP_B_CHAINS].reverse();
+  for (const { midId, termId } of bOrder) {
+    addFn(graph, midId, midId.replace('func:', ''));
+    addFn(graph, termId, termId.replace('func:', ''));
+  }
+
+  // ── CALLS edges ──────────────────────────────────────────────────────────
+  // Edge insertion order is the core of Bug 2: buildCallsGraph iterates
+  // iterRelationships() (insertion order) to build the adjacency list.
+  // Without the callee sort, the 5th callee pushed into adj[hub] would be
+  // whichever was added last, not whichever has the last alphabetical id.
+
+  const hubEdges = hubOrder.flatMap(({ calleeId, termId, callEdgeId, termEdgeId }) => [
+    { id: callEdgeId, src: 'func:hub', tgt: calleeId },
+    { id: termEdgeId, src: calleeId, tgt: termId },
+  ]);
+  const aEdges = aOrder.flatMap(({ midId, termId, callEdgeId, termEdgeId }) => [
+    { id: callEdgeId, src: 'func:ep_a', tgt: midId },
+    { id: termEdgeId, src: midId, tgt: termId },
+  ]);
+  const bEdges = bOrder.flatMap(({ midId, termId, callEdgeId, termEdgeId }) => [
+    { id: callEdgeId, src: 'func:ep_b', tgt: midId },
+    { id: termEdgeId, src: midId, tgt: termId },
+  ]);
+
+  const allEdges = isAB
+    ? [...hubEdges, ...aEdges, ...bEdges]
+    : [...bEdges, ...aEdges, ...hubEdges];
+
+  for (const e of allEdges) {
+    addCall(graph, e.id, e.src, e.tgt);
+  }
+}
+
+// No memberships — all nodes are community-less → processType 'intra_community'
+const NO_MEMBERSHIPS: CommunityMembership[] = [];
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('processProcesses — insertion-order independence', () => {
+  // -----------------------------------------------------------------
+  // Primary regression: run twice with different insertion orders and
+  // assert the output is byte-identical.
+  // -----------------------------------------------------------------
+
+  it('(Bug 1+2+3) process IDs and traces are identical regardless of node/edge insertion order', async () => {
+    const graphAB = createKnowledgeGraph();
+    const graphBA = createKnowledgeGraph();
+
+    populateGraph(graphAB, 'ab');
+    populateGraph(graphBA, 'ba');
+
+    const resultAB = await processProcesses(graphAB, NO_MEMBERSHIPS);
+    const resultBA = await processProcesses(graphBA, NO_MEMBERSHIPS);
+
+    expect(resultAB.processes.length).toBeGreaterThan(0);
+    expect(resultAB.processes.length).toBe(resultBA.processes.length);
+
+    // Snapshot comparison covers id (proc_<idx>), entryPointId, terminalId, trace
+    expect(snapshotProcesses(resultAB)).toEqual(snapshotProcesses(resultBA));
+  });
+
+  it('(Bug 1+2+3) STEP_IN_PROCESS step numbers are identical regardless of insertion order', async () => {
+    const graphAB = createKnowledgeGraph();
+    const graphBA = createKnowledgeGraph();
+
+    populateGraph(graphAB, 'ab');
+    populateGraph(graphBA, 'ba');
+
+    const resultAB = await processProcesses(graphAB, NO_MEMBERSHIPS);
+    const resultBA = await processProcesses(graphBA, NO_MEMBERSHIPS);
+
+    expect(snapshotSteps(resultAB)).toEqual(snapshotSteps(resultBA));
+  });
+
+  // -----------------------------------------------------------------
+  // Bug 2 isolation: callee sort drops the CORRECT 5th callee (zeta)
+  // regardless of which insertion order was used.
+  // -----------------------------------------------------------------
+
+  it('(Bug 2) drops the last-alphabetical callee when >maxBranching callees exist', async () => {
+    const graph = createKnowledgeGraph();
+    populateGraph(graph, 'ab'); // insertion order does not matter for this assertion
+    const result = await processProcesses(graph, NO_MEMBERSHIPS);
+
+    const allTraceNodes = result.processes.flatMap(p => p.trace);
+
+    // func:hub_callee_zeta sorts last → must be dropped by slice(0, maxBranching=4)
+    expect(allTraceNodes).not.toContain('func:hub_callee_zeta');
+    expect(allTraceNodes).not.toContain('func:hub_term_zeta');
+
+    // All four kept callees must appear in traces
+    expect(allTraceNodes).toContain('func:hub_callee_alpha');
+    expect(allTraceNodes).toContain('func:hub_callee_beta');
+    expect(allTraceNodes).toContain('func:hub_callee_gamma');
+    expect(allTraceNodes).toContain('func:hub_callee_delta');
+  });
+
+  it('(Bug 2) insertion order in reverse produces the SAME 4 hub callees', async () => {
+    const graphBA = createKnowledgeGraph();
+    populateGraph(graphBA, 'ba'); // callees added in reverse id order (zeta first)
+    const result = await processProcesses(graphBA, NO_MEMBERSHIPS);
+
+    const allTraceNodes = result.processes.flatMap(p => p.trace);
+
+    // Even though zeta was inserted FIRST in ORDER_B, the callee sort must
+    // still drop it because it sorts last by id — not by insertion position.
+    expect(allTraceNodes).not.toContain('func:hub_callee_zeta');
+    expect(allTraceNodes).not.toContain('func:hub_term_zeta');
+
+    expect(allTraceNodes).toContain('func:hub_callee_alpha');
+    expect(allTraceNodes).toContain('func:hub_callee_beta');
+    expect(allTraceNodes).toContain('func:hub_callee_gamma');
+    expect(allTraceNodes).toContain('func:hub_callee_delta');
+  });
+
+  // -----------------------------------------------------------------
+  // Bug 1 isolation: tied-score entry points (ep_a and ep_b both score
+  // 9.0) must always be ordered by node id, never by insertion order.
+  // -----------------------------------------------------------------
+
+  it('(Bug 1) tied-score entry points always ordered by node id, not insertion order', async () => {
+    const graphAB = createKnowledgeGraph(); // hub, ep_a, ep_b  (ep_a inserted first)
+    const graphBA = createKnowledgeGraph(); // ep_b, ep_a, hub  (ep_b inserted first)
+
+    populateGraph(graphAB, 'ab');
+    populateGraph(graphBA, 'ba');
+
+    const resultAB = await processProcesses(graphAB, NO_MEMBERSHIPS);
+    const resultBA = await processProcesses(graphBA, NO_MEMBERSHIPS);
+
+    // Find the first process index where ep_a / ep_b is the entry point.
+    const firstEpAIdxAB = resultAB.processes.findIndex(p => p.entryPointId === 'func:ep_a');
+    const firstEpBIdxAB = resultAB.processes.findIndex(p => p.entryPointId === 'func:ep_b');
+    const firstEpAIdxBA = resultBA.processes.findIndex(p => p.entryPointId === 'func:ep_a');
+    const firstEpBIdxBA = resultBA.processes.findIndex(p => p.entryPointId === 'func:ep_b');
+
+    // "func:ep_a" < "func:ep_b" → ep_a must always appear before ep_b in both runs
+    expect(firstEpAIdxAB).not.toBe(-1);
+    expect(firstEpBIdxAB).not.toBe(-1);
+    expect(firstEpAIdxAB).toBeLessThan(firstEpBIdxAB);
+
+    expect(firstEpAIdxBA).not.toBe(-1);
+    expect(firstEpBIdxBA).not.toBe(-1);
+    expect(firstEpAIdxBA).toBeLessThan(firstEpBIdxBA);
+
+    // Positions must be IDENTICAL between the two insertion orders
+    expect(firstEpAIdxAB).toBe(firstEpAIdxBA);
+    expect(firstEpBIdxAB).toBe(firstEpBIdxBA);
+  });
+
+  // -----------------------------------------------------------------
+  // Stats sanity: determinism extends to aggregate statistics too.
+  // -----------------------------------------------------------------
+
+  it('stats fields are identical regardless of insertion order', async () => {
+    const graphAB = createKnowledgeGraph();
+    const graphBA = createKnowledgeGraph();
+
+    populateGraph(graphAB, 'ab');
+    populateGraph(graphBA, 'ba');
+
+    const resultAB = await processProcesses(graphAB, NO_MEMBERSHIPS);
+    const resultBA = await processProcesses(graphBA, NO_MEMBERSHIPS);
+
+    expect(resultAB.stats).toEqual(resultBA.stats);
+  });
+});


### PR DESCRIPTION
Ships two verified, independent improvements to `analyze`. The Stream-C worker-pool parallelization stays parked behind `GITNEXUS_PARALLEL_PARSE` (default-OFF, inert) and is NOT in this PR.

## `6ae880c` — deterministic indexing (prereq for #189)
`walkRepositoryPaths` returned glob's unsorted order → symbol-table insertion order varied run-to-run → `lookupFuzzy()[0]` flipped for ambiguous names → CALLS targetIds flipped → community/process churn. Fixed: sort file discovery + seeded Leiden rng + id-sorted graph build + content-derived community ids + total-order process sort. Two `analyze --force` runs → 0 edge-id diff (25,373 edges byte-identical). Also fixes the `detect_changes` phantom MEMBER_OF/STEP_IN_PROCESS churn.

## `9aea85b` — bound `analyze --lsp` cost (#188)
On a dynamic-Python repo `analyze --lsp` ran >10min adding 0 edges (pylsp resolves nothing; ~1795 doomed serial probes). Now ~13s. Adaptive early-bail (stop after 150 probes resolve 0 useful; `--lsp-no-early-bail` to disable), Python external pre-filter (I-2c sound), `--lsp-pipeline` default 1→4, distinct `lsp` phase label + non-git hint. Verified: mode-a golden byte-identity 28/28, LSP suite 1206/1206, Java prefilter 53/53, Python prefilter 24/24, early-bail 5/5.

## Also
- Restores `.mcp.json` (an unrelated deletion accidentally bundled into 6ae880c).

Closes #188.