### PR TITLE
perf(ingestion): lossless parallel parse (default ON) + analyze --lsp observability

### DIFF
--- a/gitnexus/src/cli/analyze.ts
+++ b/gitnexus/src/cli/analyze.ts
@@ -105,6 +105,13 @@ export interface AnalyzeOptions {
    * Requires `--lsp`.
    */
   lspNoEarlyBail?: boolean;
+  /**
+   * When false (or when GITNEXUS_PARALLEL_PARSE=0 env is set), disable parallel
+   * parse workers and use sequential parsing. Default: true (parallel ON).
+   * Set via --no-parallel-parse CLI flag; Commander populates this as false when
+   * --no-parallel-parse is passed, true otherwise.
+   */
+  parallelParse?: boolean;
 }
 
 /** Threshold: auto-skip embeddings for repos with more nodes than this */
@@ -404,7 +411,7 @@ export const analyzeCommand = async (
   // cache whenever caching would be unsound (dirty tree / unknown commit), so
   // a stale hit is impossible by construction.
   const lspDefinitionCache =
-    options?.lspCache && (options?.lsp || options?.lspDryRun)
+    options?.lspCache !== false && (options?.lsp || options?.lspDryRun)
       ? buildDefinitionCache({
           enabled: true,
           commit: getCurrentCommit(repoPath) || null,
@@ -413,9 +420,6 @@ export const analyzeCommand = async (
           repoId: repoPath,
         })
       : undefined;
-  if (options?.lspCache && !options?.lsp && !options?.lspDryRun) {
-    console.warn('  Warning: --lsp-cache ignored: --lsp not enabled');
-  }
   // Non-git tree: the commit-namespaced cache and changed-since scoping both
   // need git, so they silently no-op here. Say so once, up front, so the user
   // isn't surprised the speed levers had no effect.
@@ -436,7 +440,9 @@ export const analyzeCommand = async (
   let timedPhase: string | null = null;
   let timedPhaseStart = Date.now();
   const pipelineResult = await runPipelineFromRepo(repoPath, (progress) => {
-    const phaseLabel = PHASE_LABELS[progress.phase] || progress.phase;
+    const phaseLabel = (progress.phase === 'lsp' && progress.message)
+      ? progress.message
+      : (PHASE_LABELS[progress.phase] || progress.phase);
     const scaled = Math.round(progress.percent * 0.6);
     if (phaseTiming && progress.phase !== timedPhase) {
       const now = Date.now();
@@ -448,6 +454,7 @@ export const analyzeCommand = async (
     }
     updateBar(scaled, phaseLabel);
   }, {
+    parallelParse: options?.parallelParse !== false,
     lsp: {
       enabled: options?.lsp === true || options?.lspDryRun === true,
       dryRun: options?.lspDryRun === true,

--- a/gitnexus/src/cli/index.ts
+++ b/gitnexus/src/cli/index.ts
@@ -34,11 +34,12 @@ program
    .option('--lsp-dry-run', 'Preview every LSP reconciliation decision and write nothing; implies --lsp')
    .option('--lsp-budget <n>', 'Limit LSP candidate cap to n (positive integer; default 2000); requires --lsp', (v) => Number(v))
    .option('--lsp-high-tier-sample <rate>', 'Spot-check fraction [0,1] of import-scoped (0.90) CALLS edges via LSP to catch confidently-wrong edges (default 0 = off); requires --lsp', (v) => Number(v))
-   .option('--lsp-pipeline <n>', 'Allow n LSP requests in flight concurrently (default 1 = serial); speeds up dispatch on jdtls/tsserver; requires --lsp', (v) => Number(v))
+   .option('--lsp-pipeline <n>', 'Allow n LSP requests in flight concurrently (default 4); speeds up dispatch on jdtls/tsserver; requires --lsp', (v) => Number(v))
    .option('--lsp-changed-since <ref>', 'Scope LSP augmentation to call/heritage sites in files changed since <ref> (git diff); requires --lsp')
-   .option('--lsp-cache', 'Cache textDocument/definition results across runs (clean working tree only); speeds re-indexing; requires --lsp')
+   .option('--no-lsp-cache', 'Disable the definition cache (on by default when --lsp is active on a clean git tree); cache is commit-namespaced so stale hits are impossible')
    .option('--lsp-no-early-bail', 'Disable adaptive early-bail; probe every candidate even when the language server resolves none (default: bail after 150 unresolved probes); requires --lsp')
-   .addHelpText('after', '\nEnvironment variables:\n  GITNEXUS_NO_GITIGNORE=1  Skip .gitignore parsing (still reads .gitnexusignore)')
+   .option('--no-parallel-parse', 'Disable parallel parse workers (only affects repos above the 100-file / 512KB threshold; for debugging or memory-constrained environments)')
+   .addHelpText('after', '\nEnvironment variables:\n  GITNEXUS_NO_GITIGNORE=1  Skip .gitignore parsing (still reads .gitnexusignore)\n  GITNEXUS_PARALLEL_PARSE=0  Disable parallel parse workers (same as --no-parallel-parse)')
    .action(createLazyAction(() => import('./analyze.js'), 'analyzeCommand'));
 
 program

--- a/gitnexus/src/core/ingestion/lsp/language-adapter.ts
+++ b/gitnexus/src/core/ingestion/lsp/language-adapter.ts
@@ -189,6 +189,14 @@ export interface AdapterReadyCtx {
    *   sub?.dispose();
    */
   onServerStatus?: (cb: (payload: { quiescent: boolean; health: string }) => void) => { dispose(): void };
+
+  /**
+   * WI-1 (heartbeat): optional callback fired every ~2 s while the adapter
+   * is waiting in `awaitReady`. Callers use it to emit live progress messages
+   * so a long warm-up does not look hung. `elapsedMs` is measured from the
+   * start of the `awaitReady` call. Never throws — callers must guard.
+   */
+  onHeartbeat?: (elapsedMs: number) => void;
 }
 
 // ─── ClientCapabilities ───────────────────────────────────────────────
@@ -510,6 +518,18 @@ export const JAVA_ADAPTER: LanguageAdapter = {
       let quietTimer: ReturnType<typeof setTimeout> | null = null;
       let canaryTimer: ReturnType<typeof setTimeout> | null = null;
       let deadlineTimer: ReturnType<typeof setTimeout> | null = null;
+      let _heartbeatTimer: ReturnType<typeof setTimeout> | null = null;
+
+      const _heartbeatStart = Date.now();
+      function _scheduleHeartbeat(): void {
+        if (settled) return;
+        _heartbeatTimer = setTimeout(() => {
+          if (settled) return;
+          try { ctx.onHeartbeat?.(Date.now() - _heartbeatStart); } catch { /* progress callback must never break readiness */ }
+          _scheduleHeartbeat();
+        }, 2000);
+        _heartbeatTimer.unref?.();
+      }
 
       function dispose(): void {
         if (langStatusHandler !== null) {
@@ -523,6 +543,7 @@ export const JAVA_ADAPTER: LanguageAdapter = {
         if (quietTimer !== null) { clearTimeout(quietTimer); quietTimer = null; }
         if (canaryTimer !== null) { clearTimeout(canaryTimer); canaryTimer = null; }
         if (deadlineTimer !== null) { clearTimeout(deadlineTimer); deadlineTimer = null; }
+        if (_heartbeatTimer !== null) { clearTimeout(_heartbeatTimer); _heartbeatTimer = null; }
       }
 
       function settle(value: boolean): void {
@@ -669,6 +690,7 @@ export const JAVA_ADAPTER: LanguageAdapter = {
       schedulePeriodicCanary();
 
       // ── Step 4: hard deadline ──────────────────────────────────────────
+      _scheduleHeartbeat();
       deadlineTimer = setTimeout(() => {
         settle(false);
       }, deadline);
@@ -775,6 +797,18 @@ export const PYTHON_ADAPTER: LanguageAdapter = {
       let settled = false;
       let timer: ReturnType<typeof setTimeout> | null = null;
 
+      const _heartbeatStart = Date.now();
+      let _heartbeatTimer: ReturnType<typeof setTimeout> | null = null;
+      function _scheduleHeartbeat(): void {
+        if (settled) return;
+        _heartbeatTimer = setTimeout(() => {
+          if (settled) return;
+          try { ctx.onHeartbeat?.(Date.now() - _heartbeatStart); } catch { /* progress callback must never break readiness */ }
+          _scheduleHeartbeat();
+        }, 2000);
+        _heartbeatTimer.unref?.();
+      }
+
       function settle(value: boolean): void {
         if (settled) return;
         settled = true;
@@ -782,11 +816,13 @@ export const PYTHON_ADAPTER: LanguageAdapter = {
           clearTimeout(timer);
           timer = null;
         }
+        if (_heartbeatTimer !== null) { clearTimeout(_heartbeatTimer); _heartbeatTimer = null; }
         resolve(value);
       }
 
       // Set the hard deadline — resolves false if the probe loop does not
       // produce a ready signal before it elapses.
+      _scheduleHeartbeat();
       timer = setTimeout(() => {
         settle(false);
       }, deadline);
@@ -1005,10 +1041,23 @@ export const GO_ADAPTER: LanguageAdapter = {
       let progressSub: { dispose(): void } | null = null;
       let timer: ReturnType<typeof setTimeout> | null = null;
 
+      const _heartbeatStart = Date.now();
+      let _heartbeatTimer: ReturnType<typeof setTimeout> | null = null;
+      function _scheduleHeartbeat(): void {
+        if (settled) return;
+        _heartbeatTimer = setTimeout(() => {
+          if (settled) return;
+          try { ctx.onHeartbeat?.(Date.now() - _heartbeatStart); } catch { /* progress callback must never break readiness */ }
+          _scheduleHeartbeat();
+        }, 2000);
+        _heartbeatTimer.unref?.();
+      }
+
       function settle(value: boolean): void {
         if (settled) return;
         settled = true;
         if (timer !== null) { clearTimeout(timer); timer = null; }
+        if (_heartbeatTimer !== null) { clearTimeout(_heartbeatTimer); _heartbeatTimer = null; }
         try { progressSub?.dispose(); } catch { /* ignore */ }
         resolve(value);
       }
@@ -1043,6 +1092,7 @@ export const GO_ADAPTER: LanguageAdapter = {
       }
 
       // Step 3: deadline backstop — canary probe (mirrors JAVA_ADAPTER path B).
+      _scheduleHeartbeat();
       timer = setTimeout(() => {
         if (settled) return;
         void (async () => {
@@ -1216,10 +1266,23 @@ export const RUST_ADAPTER: LanguageAdapter = {
       let statusSub: { dispose(): void } | null = null;
       let timer: ReturnType<typeof setTimeout> | null = null;
 
+      const _heartbeatStart = Date.now();
+      let _heartbeatTimer: ReturnType<typeof setTimeout> | null = null;
+      function _scheduleHeartbeat(): void {
+        if (settled) return;
+        _heartbeatTimer = setTimeout(() => {
+          if (settled) return;
+          try { ctx.onHeartbeat?.(Date.now() - _heartbeatStart); } catch { /* progress callback must never break readiness */ }
+          _scheduleHeartbeat();
+        }, 2000);
+        _heartbeatTimer.unref?.();
+      }
+
       function settle(value: boolean): void {
         if (settled) return;
         settled = true;
         if (timer !== null) { clearTimeout(timer); timer = null; }
+        if (_heartbeatTimer !== null) { clearTimeout(_heartbeatTimer); _heartbeatTimer = null; }
         try { statusSub?.dispose(); } catch { /* ignore */ }
         resolve(value);
       }
@@ -1253,6 +1316,7 @@ export const RUST_ADAPTER: LanguageAdapter = {
 
       // Step 3: deadline backstop — canary probe (mirrors GO_ADAPTER path B,
       // but zero samples → true is a deliberate deviation from GO_ADAPTER).
+      _scheduleHeartbeat();
       timer = setTimeout(() => {
         if (settled) return;
         void (async () => {

--- a/gitnexus/src/core/ingestion/lsp/lsp-client.ts
+++ b/gitnexus/src/core/ingestion/lsp/lsp-client.ts
@@ -103,6 +103,11 @@ export interface LspClientOptions {
    */
   maxInFlight?: number;
   /**
+   * WI-1 (heartbeat): forwarded to `AdapterReadyCtx.onHeartbeat` so adapters
+   * can report warm-up progress. Optional — omitting it preserves existing behaviour.
+   */
+  onHeartbeat?: (elapsedMs: number) => void;
+  /**
    * Optional factory hook used by tests to inject a fake
    * subprocess + a fake JSON-RPC connection. Production code
    * leaves this undefined. When set, the client does not
@@ -359,6 +364,7 @@ export class LspClient {
   private readonly maxRestarts: number;
   private readonly inject: LspClientOptions['_inject'];
   private readonly adapter: LanguageAdapter;
+  private readonly onHeartbeat: ((elapsedMs: number) => void) | undefined;
 
   /**
    * Realpath-resolved workspace root, computed once lazily.
@@ -391,6 +397,7 @@ export class LspClient {
     this.maxRestarts = opts.maxRestarts ?? MAX_RESTARTS;
     this.inject = opts._inject;
     this.adapter = opts.adapter ?? TYPESCRIPT_ADAPTER;
+    this.onHeartbeat = opts.onHeartbeat;
     // Lever 13: clamp to a sane positive integer; default 1 (serial).
     this.maxInFlight = Math.max(1, Math.floor(opts.maxInFlight ?? 1));
     this.slots = this.maxInFlight;
@@ -1071,6 +1078,7 @@ export class LspClient {
         // deadlineMs omitted → adapter default (120 000 ms for jdtls)
         ...progressSeam,
         ...serverStatusSeam,
+        onHeartbeat: this.onHeartbeat,
       };
       if (!(await this.adapter.awaitReady(ctx))) {
         this.cleanupAfterFailure();

--- a/gitnexus/src/core/ingestion/mode-a-reconciler.ts
+++ b/gitnexus/src/core/ingestion/mode-a-reconciler.ts
@@ -370,6 +370,17 @@ export interface WithReconciliationSessionDeps {
    * exactly, so all existing tests that never pass this dep are unaffected.
    */
   onGateFailure?: (reason: 'no-server' | 'not-ready' | 'dispatch-error', elapsedS: string) => void;
+  /**
+   * WI-1 (heartbeat): forwarded to `LspClientOptions.onHeartbeat` so the
+   * language adapter can emit live readiness progress. Absent → no heartbeat.
+   */
+  onHeartbeat?: (elapsedMs: number) => void;
+  /**
+   * WI-2 (candidate progress): called after each `handToEngine` completion,
+   * throttled to every 25 calls. `done` is the number of completed
+   * `handToEngine` calls; `total` is `selected.length`. Absent → no callback.
+   */
+  onCandidateProgress?: (done: number, total: number) => void;
 }
 
 // ─── Defaults (KD-9, KD-10) ────────────────────────────────────────────
@@ -460,8 +471,9 @@ function defaultCreateLspClient(
   repo: ReconciliationRepo,
   adapter: LanguageAdapter,
   maxInFlight?: number,
+  onHeartbeat?: (elapsedMs: number) => void,
 ): ReconciliationLspClient {
-  return new LspClient({ workspaceRoot: repo.repoPath, adapter, maxInFlight });
+  return new LspClient({ workspaceRoot: repo.repoPath, adapter, maxInFlight, onHeartbeat });
 }
 
 /**
@@ -593,7 +605,7 @@ export async function withReconciliationSession<T>(
   // WI-6: inline the adapter-aware default so the factory closes
   // over the selected adapter (TS or Java) — the module-level
   // `defaultCreateLspClient` now accepts adapter as second arg.
-  const factory = deps.createLspClient ?? ((r: ReconciliationRepo) => defaultCreateLspClient(r, adapter, deps.maxInFlight));
+  const factory = deps.createLspClient ?? ((r: ReconciliationRepo) => defaultCreateLspClient(r, adapter, deps.maxInFlight, deps.onHeartbeat));
   const client = factory(repo);
   try {
     await client.start();
@@ -669,6 +681,7 @@ export async function withReconciliationSession<T>(
     // files. Cache the file→uri mapping for the lifetime of
     // this dispatch loop; the cache dies with the session.
     const uriCache = new Map<string, string>();
+    let _candidateDone = 0;
     await runWithConcurrency(
       selected,
       CONCURRENT_DEFINITION_REQUESTS,
@@ -716,6 +729,10 @@ export async function withReconciliationSession<T>(
           }
         }
         await handToEngine(candidate, result.locations);
+        _candidateDone++;
+        if (deps.onCandidateProgress && _candidateDone % 25 === 0) {
+          try { deps.onCandidateProgress(_candidateDone, selected.length); } catch { /* progress callback must never break the session */ }
+        }
         // Adaptive early-bail accounting: a non-empty Location[] is a "hit".
         // After a full 0-hit sample, trip the bail so the remaining candidates
         // are skipped (kept). Only fires on probed candidates (preFiltered ones

--- a/gitnexus/src/core/ingestion/parsing-processor.ts
+++ b/gitnexus/src/core/ingestion/parsing-processor.ts
@@ -44,11 +44,124 @@ export interface WorkerExtractedData {
   constructorBindings: FileConstructorBindings[];
   typeEnvBindings: FileTypeEnvBindings[];
   angularMetadata: import('./workers/parse-worker.js').ExtractedAngularEdge[];
+  /**
+   * Set to true when processParsingWithWorkers threw and sequential fallback was
+   * used for this chunk. The pipeline checks this to call processImports (which
+   * reads files directly) instead of processImportsFromExtracted (which would
+   * receive empty imports and silently drop all import edges for the chunk).
+   */
+  workerFailed?: true;
 }
 
 // ============================================================================
 // Worker-based parallel parsing
 // ============================================================================
+
+/**
+ * Recompute the Laravel + Spring route channel for a chunk on the WORKER path so
+ * it is byte-identical to what `processParsingSequential` produces for the same
+ * chunk. Workers extract Spring routes per-file in isolation via the 2-arg
+ * `extractSpringRoutes(tree, path)` — they cannot resolve constant-based mapping
+ * paths (no repo-wide `javaConstants`) and cannot see base controllers declared
+ * in other files (no cross-file inherited pass). That divergence drops every
+ * constant-path route and every cross-file inherited route (WI-90) on the worker
+ * path. This helper mirrors the sequential route logic exactly:
+ *   1. pre-pass: collect `javaConstants` + parsed Java trees (chunk-scoped, same
+ *      scope the sequential path uses since both run per 20MB chunk);
+ *   2. per-file pass in `files` order: Laravel (PHP route files) + constant-aware
+ *      3-arg `extractSpringRoutes(tree, path, javaConstants)` (Java controllers);
+ *   3. repo/chunk-wide inherited pass (`buildSpringClassRegistry` +
+ *      `extractInheritedSpringRoutes`), deduped with the SAME key the sequential
+ *      path uses.
+ * It intentionally duplicates `processParsingSequential`'s route extraction (kept
+ * inline there so the sequential path is not perturbed). The `result.routes`
+ * emitted by the workers is discarded in favour of this output. Determinism: the
+ * per-file order follows `files`; the inherited pass follows registry insertion
+ * (= file walk) order — identical to the sequential path.
+ */
+const extractSpringRoutesForWorkerParity = async (
+  files: { path: string; content: string }[],
+  parser: Parser,
+): Promise<ExtractedRoute[]> => {
+  const allRoutes: ExtractedRoute[] = [];
+  const javaConstants = new Map<string, string>();
+  const javaFileMap = new Map<string, { tree: Parser.Tree }>();
+
+  // ── Pre-pass: parse Java files, collect constants + trees (mirror seq 262-290) ──
+  for (const file of files) {
+    const language = getLanguageFromFilename(file.path);
+    if (language !== SupportedLanguages.Java) continue;
+    try {
+      await loadLanguage(language, file.path);
+    } catch {
+      continue;
+    }
+    if (file.content.length > TREE_SITTER_MAX_BUFFER) continue;
+    let tree;
+    try {
+      tree = parser.parse(file.content, undefined, { bufferSize: getTreeSitterBufferSize(file.content.length) });
+    } catch {
+      continue;
+    }
+    javaFileMap.set(file.path, { tree });
+    const fileConstants = collectFileConstants(tree.rootNode);
+    for (const [k, v] of fileConstants) {
+      if (!javaConstants.has(k)) javaConstants.set(k, v);
+    }
+  }
+
+  // ── Per-file pass in file order: Laravel + Spring only (mirror seq 343-355) ──
+  for (const file of files) {
+    const language = getLanguageFromFilename(file.path);
+    if (!language) continue;
+    if (!isLanguageAvailable(language)) continue;
+    if (file.content.length > TREE_SITTER_MAX_BUFFER) continue;
+
+    // Laravel routes from PHP route files
+    if (language === SupportedLanguages.PHP && (file.path.includes('/routes/') || file.path.startsWith('routes/')) && file.path.endsWith('.php')) {
+      try {
+        await loadLanguage(language, file.path);
+      } catch {
+        continue;
+      }
+      let tree;
+      try {
+        tree = parser.parse(file.content, undefined, { bufferSize: getTreeSitterBufferSize(file.content.length) });
+      } catch {
+        continue;
+      }
+      allRoutes.push(...extractLaravelRoutes(tree, file.path));
+    }
+
+    // Spring routes from Java controller files (constant-aware, reuse pre-pass tree)
+    if (language === SupportedLanguages.Java && (file.content.includes('@Controller') || file.content.includes('@RestController'))) {
+      const entry = javaFileMap.get(file.path);
+      if (!entry) continue;
+      allRoutes.push(...extractSpringRoutes(entry.tree, file.path, javaConstants));
+    }
+  }
+
+  // ── Repo/chunk-wide cross-file @RequestMapping inheritance (mirror seq 760-776) ──
+  if (javaFileMap.size > 0) {
+    const springRegistry = buildSpringClassRegistry(
+      Array.from(javaFileMap.entries()).map(([filePath, { tree }]) => ({ filePath, tree })),
+      javaConstants,
+    );
+    const inheritedRoutes = extractInheritedSpringRoutes(springRegistry);
+    if (inheritedRoutes.length > 0) {
+      const seenRouteKeys = new Set(allRoutes.map(r => `${r.filePath}:${r.httpMethod}:${r.routePath}`));
+      for (const r of inheritedRoutes) {
+        const key = `${r.filePath}:${r.httpMethod}:${r.routePath}`;
+        if (!seenRouteKeys.has(key)) {
+          seenRouteKeys.add(key);
+          allRoutes.push(r);
+        }
+      }
+    }
+  }
+
+  return allRoutes;
+};
 
 const processParsingWithWorkers = async (
   graph: KnowledgeGraph,
@@ -69,6 +182,10 @@ const processParsingWithWorkers = async (
 
   const total = files.length;
 
+  // Main-thread parser for the Spring/Laravel route parity recompute below — the
+  // worker's per-file `result.routes` are discarded for the route channel (R-parity).
+  const parser = await loadParser();
+
   // Dispatch to worker pool — pool handles splitting into chunks and sub-batching
   const chunkResults = await workerPool.dispatch<ParseWorkerInput, ParseWorkerResult>(
     parseableFiles,
@@ -79,7 +196,7 @@ const processParsingWithWorkers = async (
 
   // Merge results from all workers into graph and symbol table
   const allImports: ExtractedImport[] = [];
-  const allCalls: ExtractedCall[] = [];
+  const allAngularCalls: ExtractedCall[] = [];
   const allAssignments: ExtractedAssignment[] = [];
   const allHeritage: ExtractedHeritage[] = [];
   const allRoutes: ExtractedRoute[] = [];
@@ -120,10 +237,15 @@ const processParsingWithWorkers = async (
     }
 
     allImports.push(...result.imports);
-    allCalls.push(...result.calls);
+    // #31: Angular DI/template CALLS — the only calls the worker path emits
+    // here (general calls are resolved separately via processCalls re-extraction).
+    allAngularCalls.push(...(result.angularCalls ?? []));
     if (result.assignments) allAssignments.push(...result.assignments);
     allHeritage.push(...result.heritage);
-    allRoutes.push(...result.routes);
+    // result.routes (per-file 2-arg Spring + Laravel) is intentionally NOT merged
+    // here — the Spring/Laravel route channel is recomputed below via
+    // extractSpringRoutesForWorkerParity so it matches the sequential path
+    // (constant resolution + cross-file inherited routes). See helper doc.
     if (result.fetchCalls) allFetchCalls.push(...result.fetchCalls);
     if (result.expoNavCalls) allExpoNavCalls.push(...result.expoNavCalls);
     if (result.decoratorRoutes) allDecoratorRoutes.push(...result.decoratorRoutes);
@@ -133,6 +255,13 @@ const processParsingWithWorkers = async (
     if (result.typeEnvBindings) allTypeEnvBindings.push(...result.typeEnvBindings);
     if (result.angularMetadata) allAngularMetadata.push(...result.angularMetadata);
   }
+
+  // Recompute the Laravel + Spring route channel on the main thread so the worker
+  // path is byte-identical to the sequential path: workers cannot resolve
+  // constant-based mapping paths (no repo-wide javaConstants) nor emit cross-file
+  // inherited routes (WI-90), which dropped ~137 Route DEFINES + CALLS on large
+  // Spring repos. Mirrors processParsingSequential's route logic per chunk.
+  allRoutes.push(...(await extractSpringRoutesForWorkerParity(files, parser)));
 
   // Count nodes by label
   const nodesByLabel: Record<string, number> = {};
@@ -164,7 +293,7 @@ const processParsingWithWorkers = async (
 
   // Final progress
   onFileProgress?.(total, total, 'done');
-  return { imports: allImports, calls: allCalls, assignments: allAssignments, heritage: allHeritage, routes: allRoutes, fetchCalls: allFetchCalls, expoNavCalls: allExpoNavCalls, decoratorRoutes: allDecoratorRoutes, toolDefs: allToolDefs, ormQueries: allORMQueries, constructorBindings: allConstructorBindings, typeEnvBindings: allTypeEnvBindings, angularMetadata: allAngularMetadata };
+  return { imports: allImports, calls: allAngularCalls, assignments: allAssignments, heritage: allHeritage, routes: allRoutes, fetchCalls: allFetchCalls, expoNavCalls: allExpoNavCalls, decoratorRoutes: allDecoratorRoutes, toolDefs: allToolDefs, ormQueries: allORMQueries, constructorBindings: allConstructorBindings, typeEnvBindings: allTypeEnvBindings, angularMetadata: allAngularMetadata };
 };
 
 // ============================================================================
@@ -802,9 +931,14 @@ export const processParsing = async (
       return await processParsingWithWorkers(graph, files, symbolTable, astCache, workerPool, onFileProgress);
     } catch (err) {
       console.warn('Worker pool parsing failed, falling back to sequential:', err instanceof Error ? err.message : err);
+      // Signal the fallback via workerFailed so the pipeline takes the sequential
+      // branch (processImports) instead of processImportsFromExtracted — otherwise
+      // imports: [] would silently drop all import edges for this chunk (R5).
+      const result = await processParsingSequential(graph, files, symbolTable, astCache, onFileProgress);
+      return { ...result, workerFailed: true };
     }
   }
 
-  // Fallback: sequential parsing
+  // Fallback: sequential parsing (no worker pool or explicit opt-out)
   return processParsingSequential(graph, files, symbolTable, astCache, onFileProgress);
 };

--- a/gitnexus/src/core/ingestion/pipeline.ts
+++ b/gitnexus/src/core/ingestion/pipeline.ts
@@ -51,6 +51,12 @@ export interface PipelineOptions {
   /** Skip MRO, community detection, and process extraction for faster test runs. */
   skipGraphPhases?: boolean;
   /**
+   * Run parse workers in parallel (default: true — opt-out). Set to false or
+   * pass GITNEXUS_PARALLEL_PARSE=0 env to force sequential. Useful for
+   * debugging or very memory-constrained environments.
+   */
+  parallelParse?: boolean;
+  /**
    * #50: when provided, unresolved imports whose package maps to an indexed
    * dependency repo create an external File node + CROSS_IMPORTS edge. When
    * omitted (the default), ingestion is single-repo and creates no external nodes.
@@ -304,9 +310,9 @@ export const runPipelineFromRepo = async (
     });
 
     // Don't spawn workers for tiny repos — overhead exceeds benefit.
-    // Gate on GITNEXUS_PARALLEL_PARSE=1 so the default analyze path stays
-    // byte-identical to the sequential baseline (STEP 0).
-    const PARALLEL_PARSE_ENABLED = process.env.GITNEXUS_PARALLEL_PARSE === '1';
+    // Default ON (opt-out). Disable via GITNEXUS_PARALLEL_PARSE=0 env or
+    // options.parallelParse===false (--no-parallel-parse CLI flag).
+    const PARALLEL_PARSE_ENABLED = options?.parallelParse !== false && process.env.GITNEXUS_PARALLEL_PARSE !== '0';
     const MIN_FILES_FOR_WORKERS = 100;
     const MIN_BYTES_FOR_WORKERS = 512 * 1024;  // 512KB threshold
     const totalBytes = parseableScanned.reduce((s, f) => s + f.size, 0);
@@ -327,7 +333,9 @@ export const runPipelineFromRepo = async (
         }
         workerPool = createWorkerPool(workerUrl);
       } catch (err) {
-        if (isDev) console.warn('Worker pool creation failed, using sequential fallback:', (err as Error).message);
+        // Unconditional user-visible warn: we WANTED workers (above threshold) but
+        // couldn't spawn them. Not emitted for the normal under-threshold sequential path.
+        console.warn(`  Parallel parse unavailable, falling back to sequential (slower): ${(err as Error).message}`);
       }
     }
 
@@ -449,8 +457,8 @@ export const runPipelineFromRepo = async (
 
         const chunkBasePercent = 20 + ((filesParsedSoFar / totalParseable) * 62);
 
-        if (workerPool && chunkWorkerData) {
-          // Worker path (GITNEXUS_PARALLEL_PARSE=1): parallel-parse-only lossless strategy.
+        if (workerPool && chunkWorkerData && !chunkWorkerData.workerFailed) {
+          // Worker path (parallel parse, default ON): parallel-parse-only lossless strategy.
           //
           // Workers extract nodes/symbols (stored directly in graph/symbolTable by
           // processParsingWithWorkers). Import edges are resolved here from the extracted
@@ -516,6 +524,7 @@ export const runPipelineFromRepo = async (
             allToolDefs.push(...chunkWorkerData.toolDefs);
           }
         } else {
+          if (chunkWorkerData?.workerFailed) workerPool = undefined; // dead worker — stop re-dispatching to a broken pool
           // Sequential path: processImports adds symbols, then heritage/calls are resolved
           // in the sequential fallback loop below (lines 351-365)
           await processImports(graph, chunkFiles, astCache, ctx, undefined, repoPath, allPaths, options?.crossRepoRegistry, javaExternalFqnIndex, pythonExternalFqnIndex);
@@ -1082,6 +1091,22 @@ export const runPipelineFromRepo = async (
           onGateFailure: (reason, elapsedS) => {
             gateFailureReason = reason;
             gateFailureElapsedS = elapsedS;
+          },
+          onHeartbeat: (elapsedMs) => {
+            onProgress({
+              phase: 'lsp',
+              percent: 80,
+              message: `LSP: waiting for ${lspAdapter?.serverBinary ?? 'server'} to index… ${Math.round(elapsedMs / 1000)}s`,
+              stats: { filesProcessed: totalFiles, totalFiles, nodesCreated: graph.nodeCount },
+            });
+          },
+          onCandidateProgress: (done, total) => {
+            onProgress({
+              phase: 'lsp',
+              percent: Math.round(80 + (done / total) * 10),
+              message: `LSP: resolved ${done}/${total} candidates`,
+              stats: { filesProcessed: totalFiles, totalFiles, nodesCreated: graph.nodeCount },
+            });
           },
         },
       );

--- a/gitnexus/src/core/ingestion/process-processor.ts
+++ b/gitnexus/src/core/ingestion/process-processor.ts
@@ -10,7 +10,7 @@
  * Processes help agents understand how features work through the codebase.
  */
 
-import { KnowledgeGraph, GraphNode, GraphRelationship, NodeLabel } from '../graph/types.js';
+import { KnowledgeGraph, GraphNode, NodeLabel } from '../graph/types.js';
 import { CommunityMembership } from './community-processor.js';
 import { calculateEntryPointScore, isTestFile } from './entry-point-scoring.js';
 import { SupportedLanguages } from '../../config/supported-languages.js';
@@ -239,6 +239,14 @@ const buildCallsGraph = (graph: KnowledgeGraph): AdjacencyList => {
     }
   }
 
+  // Canonicalize callee order by targetId. iterRelationships() yields edges in
+  // graph INSERTION order, which differs between the sequential and parallel-parse
+  // (GITNEXUS_PARALLEL_PARSE) paths even though the edge SET is identical.
+  // traceFromEntryPoint slices callees to maxBranching, so an insertion-order-
+  // dependent list would pick different callees → different traces. Sorting by id
+  // makes tracing insertion-order-independent (parity + run-to-run determinism).
+  for (const callees of adj.values()) callees.sort();
+
   return adj;
 };
 
@@ -315,8 +323,14 @@ const findEntryPoints = (
     }
   }
   
-  // Sort by score descending and return top candidates
-  const sorted = entryPointCandidates.sort((a, b) => b.score - a.score);
+  // Sort by score descending and return top candidates. Total order: equal
+  // scores tie-break by node id so the slice(200) cap below selects the SAME
+  // candidate set regardless of iterNodes() (insertion-order) traversal —
+  // `b.score - a.score` alone left ties in insertion order (worker-vs-seq drift).
+  const sorted = entryPointCandidates.sort((a, b) => {
+    if (b.score !== a.score) return b.score - a.score;
+    return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+  });
   
   // DEBUG: Log top candidates with new scoring details
   if (sorted.length > 0 && isDev) {
@@ -404,8 +418,14 @@ const traceFromEntryPoint = (
 const deduplicateTraces = (traces: string[][]): string[][] => {
   if (traces.length === 0) return [];
   
-  // Sort by length descending
-  const sorted = [...traces].sort((a, b) => b.length - a.length);
+  // Sort by length descending. Total order: equal-length traces tie-break by
+  // full-path lexicographic so the subset-dedup keeps a canonical trace
+  // independent of the order traces were collected (worker-vs-seq drift).
+  const sorted = [...traces].sort((a, b) => {
+    if (b.length !== a.length) return b.length - a.length;
+    const aj = a.join(''), bj = b.join('');
+    return aj < bj ? -1 : aj > bj ? 1 : 0;
+  });
   const unique: string[][] = [];
   
   for (const trace of sorted) {
@@ -436,8 +456,14 @@ const deduplicateByEndpoints = (traces: string[][]): string[][] => {
   if (traces.length === 0) return [];
   
   const byEndpoints = new Map<string, string[]>();
-  // Sort longest first so the first seen per key is the longest
-  const sorted = [...traces].sort((a, b) => b.length - a.length);
+  // Sort longest first so the first seen per key is the longest. Total order:
+  // equal-length traces tie-break by full-path lexicographic so the trace kept
+  // per endpoint pair is canonical regardless of collection order.
+  const sorted = [...traces].sort((a, b) => {
+    if (b.length !== a.length) return b.length - a.length;
+    const aj = a.join(''), bj = b.join('');
+    return aj < bj ? -1 : aj > bj ? 1 : 0;
+  });
   
   for (const trace of sorted) {
     const key = `${trace[0]}::${trace[trace.length - 1]}`;

--- a/gitnexus/src/core/ingestion/workers/parse-worker.ts
+++ b/gitnexus/src/core/ingestion/workers/parse-worker.ts
@@ -47,6 +47,7 @@ import {
   isPythonClassMethod,
   isKotlinClassMethod,
   isCppInsideClassOrStruct,
+  CLASS_CONTAINER_TYPES,
 } from '../utils/ast-helpers.js';
 import {
   countCallArguments,
@@ -85,6 +86,23 @@ import { typeConfig as phpTypeConfig } from '../type-extractors/php.js';
 import { typeConfig as rubyTypeConfig } from '../type-extractors/ruby.js';
 import { typeConfig as swiftTypeConfig } from '../type-extractors/swift.js';
 import { typeConfig as dartTypeConfig } from '../type-extractors/dart.js';
+// Field extractors — mirror the sequential parsing-processor.ts `provider.fieldExtractor`
+// wiring so the worker emits the same Property `declaredType` (needed to type `this.<field>`).
+import { createFieldExtractor } from '../field-extractors/generic.js';
+import type { FieldExtractor } from '../field-extractor.js';
+import type { FieldInfo as ExtractedFieldInfo, FieldExtractorContext } from '../field-types.js';
+import { typescriptFieldExtractor } from '../field-extractors/typescript.js';
+import { javascriptConfig } from '../field-extractors/configs/typescript-javascript.js';
+import { javaConfig, kotlinConfig } from '../field-extractors/configs/jvm.js';
+import { pythonConfig } from '../field-extractors/configs/python.js';
+import { goConfig } from '../field-extractors/configs/go.js';
+import { rustConfig } from '../field-extractors/configs/rust.js';
+import { csharpConfig } from '../field-extractors/configs/csharp.js';
+import { cConfig, cppConfig } from '../field-extractors/configs/c-cpp.js';
+import { phpConfig } from '../field-extractors/configs/php.js';
+import { rubyConfig } from '../field-extractors/configs/ruby.js';
+import { swiftConfig } from '../field-extractors/configs/swift.js';
+import { dartConfig } from '../field-extractors/configs/dart.js';
 import { generateId } from '../../../lib/utils.js';
 import { appendKotlinWildcard } from '../import-resolvers/jvm.js';
 import type { CallRouter } from '../call-routing.js';
@@ -141,6 +159,68 @@ const typeConfigs: Record<string, any> = {
   [SupportedLanguages.Ruby]: rubyTypeConfig,
   [SupportedLanguages.Swift]: swiftTypeConfig,
   [SupportedLanguages.Dart]: dartTypeConfig,
+};
+
+/**
+ * Map languages to their field extractors. Identical wiring to LanguageProvider
+ * (languages/*.ts): TypeScript uses the bespoke `typescriptFieldExtractor`, every
+ * other language is config-driven. The worker has no provider registry, so it
+ * builds the same extractors directly — this is what lets the worker emit the same
+ * Property `declaredType` the sequential parsing-processor path does.
+ */
+const fieldExtractors: Record<string, FieldExtractor> = {
+  [SupportedLanguages.TypeScript]: typescriptFieldExtractor,
+  [SupportedLanguages.JavaScript]: createFieldExtractor(javascriptConfig),
+  [SupportedLanguages.Java]: createFieldExtractor(javaConfig),
+  [SupportedLanguages.Kotlin]: createFieldExtractor(kotlinConfig),
+  [SupportedLanguages.Python]: createFieldExtractor(pythonConfig),
+  [SupportedLanguages.Go]: createFieldExtractor(goConfig),
+  [SupportedLanguages.Rust]: createFieldExtractor(rustConfig),
+  [SupportedLanguages.CSharp]: createFieldExtractor(csharpConfig),
+  [SupportedLanguages.C]: createFieldExtractor(cConfig),
+  [SupportedLanguages.CPlusPlus]: createFieldExtractor(cppConfig),
+  [SupportedLanguages.PHP]: createFieldExtractor(phpConfig),
+  [SupportedLanguages.Ruby]: createFieldExtractor(rubyConfig),
+  [SupportedLanguages.Swift]: createFieldExtractor(swiftConfig),
+  [SupportedLanguages.Dart]: createFieldExtractor(dartConfig),
+};
+
+/** No-op SymbolTable stub for FieldExtractorContext — mirrors NOOP_SYMBOL_TABLE_SEQ
+ *  in parsing-processor.ts (the symbol table is incomplete during parsing). */
+const NOOP_SYMBOL_TABLE_FIELDS: any = {
+  lookupExactAll: () => [],
+  lookupExact: () => undefined,
+  lookupExactFull: () => undefined,
+};
+
+/** Walk up from a field declaration to its enclosing class/struct/interface node.
+ *  Mirrors seqFindEnclosingClassNode in parsing-processor.ts. */
+const findEnclosingClassNode = (node: any): any | null => {
+  let current = node?.parent;
+  while (current) {
+    if (CLASS_CONTAINER_TYPES.has(current.type)) return current;
+    current = current.parent;
+  }
+  return null;
+};
+
+/** Cached per-class field-info lookup. Mirrors seqGetFieldInfo + seqFieldInfoCache.
+ *  The cache is passed in per file so `startIndex` keys never collide across files. */
+const getFieldInfoCached = (
+  classNode: any,
+  fieldExtractor: FieldExtractor,
+  context: FieldExtractorContext,
+  cache: Map<number, Map<string, ExtractedFieldInfo>>,
+): Map<string, ExtractedFieldInfo> | undefined => {
+  const cacheKey = classNode.startIndex;
+  const cached = cache.get(cacheKey);
+  if (cached) return cached;
+  const extracted = fieldExtractor.extract(classNode, context);
+  if (!extracted?.fields?.length) return undefined;
+  const map = new Map<string, ExtractedFieldInfo>();
+  for (const field of extracted.fields) map.set(field.name, field);
+  cache.set(cacheKey, map);
+  return map;
 };
 
 /** Map languages to their named binding extractors */
@@ -287,6 +367,8 @@ interface ParsedNode {
     /** Array of parameter type names for method overloading */
     parameterTypes?: string; // JSON array of parameter type names
     returnType?: string;
+    /** Declared/inferred type of a Property node (mirrors the sequential path). */
+    declaredType?: string;
     /** JSON array of annotations on method/class: [{name: "@Transactional", attrs?: {key: value}}] */
     annotations?: string;
     /** JSON array of field info for DTO/Entity classes: [{name, type, annotations[]}] */
@@ -493,6 +575,7 @@ export interface ParseWorkerResult {
   symbols: ParsedSymbol[];
   imports: ExtractedImport[];
   calls: ExtractedCall[];
+  angularCalls: ExtractedCall[];
   heritage: ExtractedHeritage[];
   routes: ExtractedRoute[];
   constructorBindings: FileConstructorBindings[];
@@ -652,6 +735,7 @@ const processBatch = (files: ParseWorkerInput[], onProgress?: (filesProcessed: n
     symbols: [],
     imports: [],
     calls: [],
+    angularCalls: [],
     heritage: [],
     routes: [],
     constructorBindings: [],
@@ -2387,6 +2471,8 @@ const processFileGroup = (
     // Build per-file type environment + constructor bindings in a single AST walk.
     // Constructor bindings are verified against the SymbolTable in processCallsFromExtracted.
     const typeEnv = buildTypeEnv(tree, language);
+    // Per-file cache for Property declaredType extraction (keyed by class node startIndex).
+    const fieldInfoCache = new Map<number, Map<string, ExtractedFieldInfo>>();
     const routerForLanguage = callRouters[language];
 
     // Extract FILE_SCOPE bindings for field/local variable type resolution
@@ -2453,13 +2539,22 @@ const processFileGroup = (
       if (captureMap['express_route'] && captureMap['express_route.method'] && captureMap['express_route.path']) {
         const method = captureMap['express_route.method'].text;
         const routePath = captureMap['express_route.path'].text;
-        result.decoratorRoutes.push({
-          filePath: file.path,
-          decorator: method,
-          path: routePath,
-          lineNumber: captureMap['express_route'].startPosition.row,
-        });
-        continue;
+        // Guard: reject non-route strings (header names, cache keys, etc.).
+        // Valid Express/Hono paths always start with '/'. This matches the
+        // NON_EXPRESS_OBJECTS guard in the procedural extractExpressRoutes used
+        // by the sequential path — without it the tree-sitter query is too
+        // broad and captures e.g. `.get('Content-Length')` / `cache.get('b.ts')`.
+        const cleanPath = routePath.replace(/^['"`]|['"`]$/g, '');
+        if (cleanPath.startsWith('/')) {
+          result.decoratorRoutes.push({
+            filePath: file.path,
+            decorator: method,
+            path: routePath,
+            lineNumber: captureMap['express_route'].startPosition.row,
+          });
+          continue;
+        }
+        // Not a route path — fall through to general call processing
       }
 
       // Extract HTTP decorators: @Get('/path'), @Post('/path'), @RequestMapping('/path')
@@ -2905,6 +3000,28 @@ const processFileGroup = (
         }
       }
 
+      // ── Declared type for Property nodes (mirrors parsing-processor.ts:671-694) ──
+      // The sequential path stores declaredType on each Property symbol. The worker must
+      // too, or processCalls' resolveFieldAccessType cannot type `this.<field>` — which
+      // drops field-read ACCESSES and misresolves chained calls on typed fields.
+      let declaredType: string | undefined;
+      if (nodeLabel === 'Property' && definitionNode) {
+        const fieldExtractor = fieldExtractors[language];
+        if (fieldExtractor) {
+          const classNode = findEnclosingClassNode(definitionNode);
+          if (classNode) {
+            const fieldMap = getFieldInfoCached(
+              classNode,
+              fieldExtractor,
+              { typeEnv, symbolTable: NOOP_SYMBOL_TABLE_FIELDS, filePath: file.path, language },
+              fieldInfoCache,
+            );
+            const info = fieldMap?.get(nodeName);
+            if (info) declaredType = info.type ?? undefined;
+          }
+        }
+      }
+
       result.nodes.push({
         id: nodeId,
         label: nodeLabel,
@@ -2922,6 +3039,7 @@ const processFileGroup = (
           ...(description !== undefined ? { description } : {}),
           ...(parameterCount !== undefined ? { parameterCount } : {}),
           ...(returnType !== undefined ? { returnType } : {}),
+          ...(declaredType !== undefined ? { declaredType } : {}),
           ...(parameterTypes !== undefined ? { parameterTypes: JSON.stringify(parameterTypes) } : {}),
           ...(annotations !== undefined ? { annotations } : {}),
           ...(fields !== undefined ? { fields } : {}),
@@ -2943,6 +3061,7 @@ const processFileGroup = (
         ...(requiredParameterCount !== undefined ? { requiredParameterCount } : {}),
         ...(parameterTypes !== undefined ? { parameterTypes } : {}),
         ...(returnType !== undefined ? { returnType } : {}),
+        ...(declaredType !== undefined ? { declaredType } : {}),
         ...(enclosingClassId ? { ownerId: enclosingClassId } : {}),
       });
 
@@ -3000,17 +3119,27 @@ const processFileGroup = (
 
     // Extract FastAPI routes from Python files (Issues #79, #5, #78)
     if (language === SupportedLanguages.Python) {
-      const fastApiRoutes = extractFastApiRoutes(tree, file.path);
-      if (fastApiRoutes.length > 0) {
-        result.routes.push(...fastApiRoutes);
+      for (const r of extractFastApiRoutes(tree, file.path)) {
+        result.decoratorRoutes.push({
+          filePath: r.filePath,
+          decorator: r.httpMethod,
+          path: r.routePath,
+          lineNumber: r.lineNumber,
+          handlerName: r.methodName ?? undefined,
+        });
       }
     }
 
     // Extract Gin routes from Go files (Issues #80, #6)
     if (language === SupportedLanguages.Go) {
-      const ginRoutes = extractGinRoutes(tree, file.path);
-      if (ginRoutes.length > 0) {
-        result.routes.push(...ginRoutes);
+      for (const r of extractGinRoutes(tree, file.path)) {
+        result.decoratorRoutes.push({
+          filePath: r.filePath,
+          decorator: r.httpMethod,
+          path: r.routePath,
+          lineNumber: r.lineNumber,
+          handlerName: r.methodName ?? undefined,
+        });
       }
     }
 
@@ -3018,9 +3147,14 @@ const processFileGroup = (
     // or use `RouterModule` / `provideRouter`. Emits `ExtractedRoute` records
     // (client-side Angular routes have no HTTP method — we use GET).
     if (language === SupportedLanguages.TypeScript && isAngularFile(file.path, file.content)) {
-      const angularRoutes = extractAngularRoutes(tree, file.path);
-      if (angularRoutes.length > 0) {
-        result.routes.push(...angularRoutes);
+      for (const r of extractAngularRoutes(tree, file.path)) {
+        result.decoratorRoutes.push({
+          filePath: r.filePath,
+          decorator: r.httpMethod,
+          path: r.routePath,
+          lineNumber: r.lineNumber,
+          handlerName: r.methodName ?? undefined,
+        });
       }
     }
 
@@ -3042,7 +3176,7 @@ const processFileGroup = (
     if (language === SupportedLanguages.TypeScript || language === SupportedLanguages.JavaScript) {
       const angularCalls = extractAngularCalls(tree, file.path);
       for (const ac of angularCalls) {
-        result.calls.push({
+        result.angularCalls.push({
           filePath: ac.filePath,
           calledName: ac.calledName,
           sourceId: ac.sourceId,
@@ -3126,7 +3260,7 @@ const processFileGroup = (
 /** Accumulated result across sub-batches */
 let accumulated: ParseWorkerResult = {
   nodes: [], relationships: [], symbols: [],
-  imports: [], calls: [], heritage: [], routes: [], constructorBindings: [], typeEnvBindings: [], skippedLanguages: {}, fileCount: 0,
+  imports: [], calls: [], angularCalls: [], heritage: [], routes: [], constructorBindings: [], typeEnvBindings: [], skippedLanguages: {}, fileCount: 0,
   ormQueries: [],
   fetchCalls: [],
   expoNavCalls: [],
@@ -3140,6 +3274,7 @@ const mergeResult = (target: ParseWorkerResult, src: ParseWorkerResult) => {
   target.symbols.push(...src.symbols);
   target.imports.push(...src.imports);
   target.calls.push(...src.calls);
+  target.angularCalls.push(...src.angularCalls);
   target.heritage.push(...src.heritage);
   target.routes.push(...src.routes);
   target.constructorBindings.push(...src.constructorBindings);
@@ -3189,7 +3324,7 @@ if (parentPort) {
     if (msg && msg.type === 'flush') {
       parentPort!.postMessage({ type: 'result', data: accumulated });
       // Reset for potential reuse
-      accumulated = { nodes: [], relationships: [], symbols: [], imports: [], calls: [], heritage: [], routes: [], constructorBindings: [], typeEnvBindings: [], skippedLanguages: {}, fileCount: 0, ormQueries: [] };
+      accumulated = { nodes: [], relationships: [], symbols: [], imports: [], calls: [], angularCalls: [], heritage: [], routes: [], constructorBindings: [], typeEnvBindings: [], skippedLanguages: {}, fileCount: 0, ormQueries: [] };
       cumulativeProcessed = 0;
       return;
     }

--- a/gitnexus/src/core/ingestion/workers/parse-worker.ts
+++ b/gitnexus/src/core/ingestion/workers/parse-worker.ts
@@ -44,6 +44,9 @@ import {
   getDefinitionNodeFromCaptures,
   findEnclosingClassId,
   extractMethodSignature,
+  isPythonClassMethod,
+  isKotlinClassMethod,
+  isCppInsideClassOrStruct,
 } from '../utils/ast-helpers.js';
 import {
   countCallArguments,
@@ -297,7 +300,7 @@ interface ParsedRelationship {
   id: string;
   sourceId: string;
   targetId: string;
-  type: 'DEFINES' | 'HAS_METHOD';
+  type: 'DEFINES' | 'HAS_METHOD' | 'HAS_PROPERTY';
   confidence: number;
   reason: string;
 }
@@ -589,7 +592,7 @@ const findEnclosingFunctionId = (node: any, filePath: string): string | null => 
 // Label detection from capture map
 // ============================================================================
 
-const getLabelFromCaptures = (captureMap: Record<string, any>): string | null => {
+const getLabelFromCaptures = (captureMap: Record<string, any>, language?: string): string | null => {
   // Skip imports (handled separately) and calls
   if (captureMap['import'] || captureMap['call']) return null;
   if (!captureMap['name']) return null;
@@ -603,7 +606,14 @@ const getLabelFromCaptures = (captureMap: Record<string, any>): string | null =>
     return 'CodeElement';
   }
 
-  if (captureMap['definition.function']) return 'Function';
+  if (captureMap['definition.function']) {
+    // Mirror the language-provider labelOverride logic so node labels match
+    // the sequential (parsing-processor) path exactly.
+    if (language === 'python' && isPythonClassMethod(captureMap['definition.function'])) return 'Method';
+    if (language === 'kotlin' && isKotlinClassMethod(captureMap['definition.function'])) return 'Method';
+    if ((language === 'c' || language === 'cpp') && isCppInsideClassOrStruct(captureMap['definition.function'])) return null;
+    return 'Function';
+  }
   if (captureMap['definition.class']) return 'Class';
   if (captureMap['definition.interface']) return 'Interface';
   if (captureMap['definition.method']) return 'Method';
@@ -2639,11 +2649,12 @@ const processFileGroup = (
                     reason: '',
                   });
                   if (propEnclosingClassId) {
+                    // Property nodes use HAS_PROPERTY (mirrors parsing-processor.ts:726)
                     result.relationships.push({
-                      id: generateId('HAS_METHOD', `${propEnclosingClassId}->${nodeId}`),
+                      id: generateId('HAS_PROPERTY', `${propEnclosingClassId}->${nodeId}`),
                       sourceId: propEnclosingClassId,
                       targetId: nodeId,
-                      type: 'HAS_METHOD',
+                      type: 'HAS_PROPERTY',
                       confidence: 1.0,
                       reason: '',
                     });
@@ -2792,7 +2803,7 @@ const processFileGroup = (
         }
       }
 
-      const nodeLabel = getLabelFromCaptures(captureMap);
+      const nodeLabel = getLabelFromCaptures(captureMap, language);
       if (!nodeLabel) continue;
 
       const nameNode = captureMap['name'];
@@ -2946,13 +2957,15 @@ const processFileGroup = (
         reason: '',
       });
 
-      // ── HAS_METHOD: link method/constructor/property to enclosing class ──
+      // ── HAS_METHOD / HAS_PROPERTY: link member to enclosing class ──
+      // Mirror parsing-processor.ts: Property nodes use HAS_PROPERTY; all others use HAS_METHOD.
       if (enclosingClassId) {
+        const memberEdgeType = nodeLabel === 'Property' ? 'HAS_PROPERTY' : 'HAS_METHOD';
         result.relationships.push({
-          id: generateId('HAS_METHOD', `${enclosingClassId}->${nodeId}`),
+          id: generateId(memberEdgeType, `${enclosingClassId}->${nodeId}`),
           sourceId: enclosingClassId,
           targetId: nodeId,
-          type: 'HAS_METHOD',
+          type: memberEdgeType,
           confidence: 1.0,
           reason: '',
         });

--- a/gitnexus/test/integration/parallel-parity.test.ts
+++ b/gitnexus/test/integration/parallel-parity.test.ts
@@ -1,0 +1,655 @@
+/**
+ * Integration regression guard: the parallel-parse worker path
+ * (GITNEXUS_PARALLEL_PARSE=1 / parallelParse:true, now the DEFAULT) produces
+ * a graph BYTE-IDENTICAL to the sequential path (GITNEXUS_PARALLEL_PARSE=0 /
+ * parallelParse:false).
+ *
+ * Bug history (three separate regressions on perf/lsp-analyze-speedup):
+ *
+ *   1. General-call double-emission
+ *      The worker fed general calls into processCallsFromExtracted, causing
+ *      +678 false CALLS / −48 ACCESSES edges vs sequential.
+ *      Fixed: separate Angular calls into result.angularCalls; only those flow
+ *      into the Angular-call processor. General calls re-extracted sequentially.
+ *
+ *   2. Route channel misdirection
+ *      The worker pushed FastAPI / Gin / Angular routes to result.routes
+ *      (Spring-route bucket, later skipped because no controllerName/methodName)
+ *      instead of result.decoratorRoutes.  Sequential path extracted them
+ *      correctly → snapshot divergence on HANDLES_ROUTE edges.
+ *      Fixed: worker places framework routes in result.decoratorRoutes.
+ *
+ *   3. Worker Property nodes lacked declaredType
+ *      Property nodes emitted by the worker had no declaredType field →
+ *      this.field read-ACCESSES disappeared + chained-call receiver resolution
+ *      fell back to unresolved.
+ *      Fixed: worker applies the same field-extractor registry as the
+ *      sequential parsing-processor path.
+ *
+ *   4. Process-detection insertion-order sensitivity
+ *      findEntryPoints tied-score sort, buildCallsGraph callee order,
+ *      deduplicateTraces / deduplicateByEndpoints / limitedTraces sorts were
+ *      not total-order → STEP_IN_PROCESS edge renumbering between the two paths
+ *      (phantom detect_changes diffs, ~180 churned edges per run).
+ *      Fixed: all sorts use length-desc + full-path-lexicographic tiebreak.
+ *
+ * Test strategy:
+ *   - Generate a synthetic multi-language fixture whose TOTAL PARSEABLE BYTES
+ *     exceed MIN_BYTES_FOR_WORKERS=512KB so the worker pool actually spawns.
+ *     The fixture deliberately includes:
+ *       • 10 TypeScript service files with typed class fields (covers Bug 3)
+ *       • A FastAPI Python route file  (covers Bug 2 route-channel path)
+ *       • A Gin Go route file          (covers Bug 2 route-channel path)
+ *       • 3+ hop method call chains    (covers Bug 4 process-detection)
+ *   - Assert the pool ACTUALLY SPAWNED by spying on console.warn for the
+ *     "Parallel parse unavailable, falling back to sequential" message.
+ *     If that warning fires, the test FAILS — not skips — with an instruction
+ *     to run `npm run build`.
+ *   - Run the full pipeline once with parallelParse:false (sequential) and
+ *     once with parallelParse:true (parallel). Snapshot ALL relationships
+ *     sorted by id and assert byte-equality.
+ *   - Additional targeted assertions for STEP_IN_PROCESS and MEMBER_OF so a
+ *     process-detection regression produces a named failure, not just "snapshots differ".
+ */
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import path from 'node:path';
+import fs from 'node:fs';
+import fsPromises from 'node:fs/promises';
+import os from 'node:os';
+
+import { runPipelineFromRepo } from '../../src/core/ingestion/pipeline.js';
+import type { KnowledgeGraph } from '../../src/core/graph/types.js';
+
+// ── Fixture content ───────────────────────────────────────────────────────────
+
+/**
+ * FastAPI route file. Exercises the route-channel fix (Bug 2):
+ * routes emitted by the worker must land in result.decoratorRoutes,
+ * not result.routes (Spring bucket).
+ */
+const FASTAPI_CONTENT = `"""FastAPI route fixture for parallel-parity integration test.
+
+Exercises Bug 2 (route-channel): these routes must appear in both
+sequential and parallel snapshots — if the worker misdirects them
+to the Spring-route bucket they are silently dropped in the parallel path.
+"""
+from fastapi import FastAPI, APIRouter
+
+app = FastAPI()
+router = APIRouter()
+
+
+@app.get("/items")
+async def list_items():
+    """Return all items."""
+    return []
+
+
+@app.post("/items")
+async def create_item(name: str, price: float):
+    """Create and persist a new item."""
+    validated = validate_item(name, price)
+    return save_item(validated)
+
+
+@app.put("/items/{item_id}")
+async def update_item(item_id: int, name: str):
+    """Update an existing item."""
+    return {"id": item_id, "name": name}
+
+
+@app.delete("/items/{item_id}")
+async def delete_item(item_id: int):
+    """Remove an item by id."""
+    return {"deleted": item_id}
+
+
+@router.get("/orders")
+async def list_orders():
+    """Return all orders."""
+    return []
+
+
+@router.post("/orders")
+async def create_order(item_id: int, quantity: int):
+    """Place a new order."""
+    return {"item_id": item_id, "quantity": quantity}
+
+
+def validate_item(name: str, price: float) -> dict:
+    """Validate item fields before persistence."""
+    if price <= 0:
+        raise ValueError("price must be positive")
+    return {"name": name.strip(), "price": price}
+
+
+def save_item(item: dict) -> dict:
+    """Persist item to the database."""
+    return {**item, "id": 1}
+`;
+
+/**
+ * Gin route file. Exercises the route-channel fix (Bug 2) for Go.
+ */
+const GIN_CONTENT = `package main
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+)
+
+// Item is a data model for the inventory.
+type Item struct {
+	ID    int     \`json:"id"\`
+	Name  string  \`json:"name"\`
+	Price float64 \`json:"price"\`
+}
+
+func main() {
+	r := gin.Default()
+	r.GET("/items", listItems)
+	r.POST("/items", createItem)
+	r.PUT("/items/:id", updateItem)
+	r.DELETE("/items/:id", deleteItem)
+	r.GET("/categories", listCategories)
+	r.POST("/categories", createCategory)
+	r.Run(":8080")
+}
+
+func listItems(c *gin.Context) {
+	items := fetchAllItems()
+	enriched := enrichItems(items)
+	c.JSON(http.StatusOK, enriched)
+}
+
+func createItem(c *gin.Context) {
+	var item Item
+	if err := c.ShouldBindJSON(&item); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	saved := persistItem(item)
+	c.JSON(http.StatusCreated, saved)
+}
+
+func updateItem(c *gin.Context) {
+	id, _ := strconv.Atoi(c.Param("id"))
+	var item Item
+	c.ShouldBindJSON(&item)
+	item.ID = id
+	updated := persistItem(item)
+	c.JSON(http.StatusOK, updated)
+}
+
+func deleteItem(c *gin.Context) {
+	id, _ := strconv.Atoi(c.Param("id"))
+	removeItem(id)
+	c.JSON(http.StatusNoContent, nil)
+}
+
+func listCategories(c *gin.Context) {
+	cats := fetchCategories()
+	c.JSON(http.StatusOK, cats)
+}
+
+func createCategory(c *gin.Context) {
+	var cat map[string]string
+	c.ShouldBindJSON(&cat)
+	result := persistCategory(cat)
+	c.JSON(http.StatusCreated, result)
+}
+
+func fetchAllItems() []Item                         { return nil }
+func enrichItems(items []Item) []Item               { return items }
+func persistItem(item Item) Item                    { return item }
+func removeItem(_ int)                              {}
+func fetchCategories() []string                     { return nil }
+func persistCategory(cat map[string]string) map[string]string { return cat }
+`;
+
+/**
+ * Generate a TypeScript service file with:
+ *   - 12 exported interfaces (broad symbol surface)
+ *   - Typed class fields (exercises Bug 3 / declaredType fix)
+ *   - 25 handleX/fetchX/queryX/formatX method groups forming 3-hop call chains
+ *     (exercises Bug 4 / process-detection)
+ *   - 10 standalone exported functions
+ *
+ * Target size: ~35-45 KB per file.  10 files × 40 KB ≈ 400 KB combined
+ * TypeScript parseable bytes.  With the Python and Go files the fixture
+ * comfortably exceeds the MIN_BYTES_FOR_WORKERS = 512 KB gate.
+ *
+ * NOTE: if the total-bytes assertion in beforeAll fails, increase
+ * NUM_METHOD_GROUPS below or add more service files.
+ */
+function generateServiceFile(serviceName: string): string {
+  const NUM_INTERFACES = 12;
+  const NUM_TYPE_ALIASES = 4;
+  const NUM_METHOD_GROUPS = 25; // each group = 4 methods ≈ 40 lines
+  const NUM_STANDALONE_FUNCTIONS = 10;
+
+  const L: string[] = [];
+
+  L.push(`/**`);
+  L.push(` * ${serviceName} — auto-generated fixture for parallel-parity integration test.`);
+  L.push(` *`);
+  L.push(` * DO NOT EDIT — this file is produced by generateServiceFile() in`);
+  L.push(` * test/integration/parallel-parity.test.ts and is regenerated on each test run.`);
+  L.push(` */`);
+  L.push(``);
+
+  // Imports (give the file realistic import structure)
+  L.push(`import type { Logger } from '../utils/logger';`);
+  L.push(`import type { Database } from '../utils/database';`);
+  L.push(`import type { Cache } from '../utils/cache';`);
+  L.push(`import type { EventEmitter } from '../utils/events';`);
+  L.push(``);
+
+  // Interfaces
+  for (let i = 0; i < NUM_INTERFACES; i++) {
+    L.push(`/** ${serviceName} data transfer object ${i} */`);
+    L.push(`export interface ${serviceName}Dto${i} {`);
+    L.push(`  id: string;`);
+    L.push(`  name: string;`);
+    L.push(`  code: string;`);
+    L.push(`  description: string;`);
+    L.push(`  status: 'active' | 'inactive' | 'pending' | 'archived';`);
+    L.push(`  priority: number;`);
+    L.push(`  createdAt: Date;`);
+    L.push(`  updatedAt: Date;`);
+    L.push(`  createdBy: string;`);
+    L.push(`  metadata: Record<string, unknown>;`);
+    L.push(`  tags: string[];`);
+    L.push(`  version: number;`);
+    L.push(`}`);
+    L.push(``);
+  }
+
+  // Type aliases
+  for (let i = 0; i < NUM_TYPE_ALIASES; i++) {
+    L.push(`export type ${serviceName}Result${i} = {`);
+    L.push(`  success: boolean;`);
+    L.push(`  data: ${serviceName}Dto0 | null;`);
+    L.push(`  errors: string[];`);
+    L.push(`  warnings: string[];`);
+    L.push(`  timestamp: number;`);
+    L.push(`  requestId: string;`);
+    L.push(`};`);
+    L.push(``);
+  }
+
+  // Main service class — typed fields exercise the declaredType fix (Bug 3).
+  // The sequential path emits declaredType for each class property.
+  // The parallel (worker) path must also emit declaredType so that
+  // `this.cache.get(...)` resolves as a Cache.get() call in both paths.
+  L.push(`/** ${serviceName} — manages the full lifecycle of ${serviceName} entities. */`);
+  L.push(`export class ${serviceName} {`);
+  L.push(`  /** @type {Logger} Logger instance — used to verify declaredType parity (Bug 3) */`);
+  L.push(`  private readonly logger: Logger;`);
+  L.push(`  /** @type {Database} Primary database connection */`);
+  L.push(`  private readonly database: Database;`);
+  L.push(`  /** @type {Cache<string, ${serviceName}Dto0>} Read-through cache */`);
+  L.push(`  private readonly cache: Cache<string, ${serviceName}Dto0>;`);
+  L.push(`  /** @type {EventEmitter} Domain-event bus */`);
+  L.push(`  private readonly events: EventEmitter;`);
+  L.push(`  /** @type {Map<string, ${serviceName}Dto0>} In-flight items keyed by id */`);
+  L.push(`  private readonly pendingMap: Map<string, ${serviceName}Dto0>;`);
+  L.push(`  /** @type {Set<string>} Ids currently locked for mutation */`);
+  L.push(`  private readonly lockedIds: Set<string>;`);
+  L.push(`  /** @type {${serviceName}Dto0 | null} Currently authenticated entity context */`);
+  L.push(`  private currentContext: ${serviceName}Dto0 | null = null;`);
+  L.push(`  /** @type {number} Configured page size for pagination */`);
+  L.push(`  private readonly pageSize: number = 50;`);
+  L.push(``);
+  L.push(`  constructor(`);
+  L.push(`    logger: Logger,`);
+  L.push(`    database: Database,`);
+  L.push(`    cache: Cache<string, ${serviceName}Dto0>,`);
+  L.push(`    events: EventEmitter,`);
+  L.push(`  ) {`);
+  L.push(`    this.logger = logger;`);
+  L.push(`    this.database = database;`);
+  L.push(`    this.cache = cache;`);
+  L.push(`    this.events = events;`);
+  L.push(`    this.pendingMap = new Map();`);
+  L.push(`    this.lockedIds = new Set();`);
+  L.push(`  }`);
+  L.push(``);
+
+  // Method groups (25 groups × 4 methods × ~10 lines = ~1000 lines)
+  // Each group: handle*(id) → fetch*(id) → query*(id) → format*()
+  // This creates the 3-hop call chain that process detection traces.
+  for (let i = 0; i < NUM_METHOD_GROUPS; i++) {
+    const S = `Record${i}`;
+
+    // Entry-point method (handle*): name matches ^handle[A-Z] → high entry-point score
+    L.push(`  /**`);
+    L.push(`   * Handle ${S} lifecycle request — entry point for the ${S} flow.`);
+    L.push(`   * Calls fetch${S} which calls query${S} (3-hop chain for process detection).`);
+    L.push(`   * @param id — entity identifier`);
+    L.push(`   * @param opts — optional processing hints`);
+    L.push(`   */`);
+    L.push(`  handle${S}(id: string, opts: Record<string, unknown> = {}): ${serviceName}Result0 {`);
+    L.push(`    this.logger.info(\`[${serviceName}] handle${S} id=\${id}\`);`);
+    L.push(`    if (this.lockedIds.has(id)) {`);
+    L.push(`      return { success: false, data: null, errors: ['locked'], warnings: [], timestamp: Date.now(), requestId: id };`);
+    L.push(`    }`);
+    L.push(`    const raw = this.fetch${S}(id);`);
+    L.push(`    if (!raw) {`);
+    L.push(`      return { success: false, data: null, errors: ['not_found'], warnings: [], timestamp: Date.now(), requestId: id };`);
+    L.push(`    }`);
+    L.push(`    const formatted = this.format${S}(raw);`);
+    L.push(`    this.events.emit(\`${serviceName.toLowerCase()}.${S.toLowerCase()}.handled\`, formatted);`);
+    L.push(`    return { success: true, data: formatted, errors: [], warnings: [], timestamp: Date.now(), requestId: id };`);
+    L.push(`  }`);
+    L.push(``);
+
+    // Fetch method: calls query* and populates cache
+    L.push(`  /**`);
+    L.push(`   * Fetch ${S} by id — checks cache then delegates to query${S}.`);
+    L.push(`   */`);
+    L.push(`  private fetch${S}(id: string): ${serviceName}Dto0 | null {`);
+    L.push(`    const hit = this.cache.get(id);`);
+    L.push(`    if (hit) return hit;`);
+    L.push(`    const record = this.query${S}(id);`);
+    L.push(`    if (record) {`);
+    L.push(`      this.cache.set(id, record);`);
+    L.push(`      this.pendingMap.set(id, record);`);
+    L.push(`    }`);
+    L.push(`    return record;`);
+    L.push(`  }`);
+    L.push(``);
+
+    // Query method: terminal step (hits database, no further service calls)
+    L.push(`  /**`);
+    L.push(`   * Query ${S} from the database — terminal step in the ${S} flow.`);
+    L.push(`   */`);
+    L.push(`  private query${S}(id: string): ${serviceName}Dto0 | null {`);
+    L.push(`    return this.database.findById<${serviceName}Dto0>('${serviceName.toLowerCase()}_${i}', id) ?? null;`);
+    L.push(`  }`);
+    L.push(``);
+
+    // Format method: data transformation, no further service calls
+    L.push(`  /**`);
+    L.push(`   * Apply output formatting and normalization for ${S}.`);
+    L.push(`   */`);
+    L.push(`  private format${S}(dto: ${serviceName}Dto0): ${serviceName}Dto0 {`);
+    L.push(`    return {`);
+    L.push(`      ...dto,`);
+    L.push(`      name: dto.name.trim(),`);
+    L.push(`      description: dto.description.trim(),`);
+    L.push(`      updatedAt: new Date(),`);
+    L.push(`      version: dto.version + 1,`);
+    L.push(`    };`);
+    L.push(`  }`);
+    L.push(``);
+  }
+
+  L.push(`}`);
+  L.push(``);
+
+  // Standalone exported functions (add to symbol surface, exercise process detection)
+  for (let i = 0; i < NUM_STANDALONE_FUNCTIONS; i++) {
+    L.push(`/**`);
+    L.push(` * Process a batch of ${serviceName} entities — standalone utility #${i}.`);
+    L.push(` * Exported for cross-file use (isExported=true → higher entry-point score).`);
+    L.push(` */`);
+    L.push(`export function process${serviceName}Batch${i}(`);
+    L.push(`  items: ${serviceName}Dto0[],`);
+    L.push(`  opts: { limit?: number; sortKey?: keyof ${serviceName}Dto0 } = {},`);
+    L.push(`): ${serviceName}Dto0[] {`);
+    L.push(`  const { limit = 100, sortKey = 'id' } = opts;`);
+    L.push(`  const sorted = [...items].sort((a, b) => {`);
+    L.push(`    const av = String(a[sortKey] ?? '');`);
+    L.push(`    const bv = String(b[sortKey] ?? '');`);
+    L.push(`    return av < bv ? -1 : av > bv ? 1 : 0;`);
+    L.push(`  });`);
+    L.push(`  return sorted.slice(0, limit);`);
+    L.push(`}`);
+    L.push(``);
+  }
+
+  return L.join('\n');
+}
+
+// ── Snapshot helper (mirrors mode-a-golden.test.ts) ──────────────────────────
+
+/**
+ * Produce a stable, sorted JSON string for all relationships in `graph`.
+ * Sorted by id so the comparison is order-independent.
+ * Includes step and source so STEP_IN_PROCESS regressions are visible.
+ */
+function snapshotRels(graph: KnowledgeGraph): string {
+  const rels = [...graph.iterRelationships()].map(r => ({
+    id: r.id,
+    sourceId: r.sourceId,
+    targetId: r.targetId,
+    type: r.type,
+    confidence: r.confidence,
+    reason: r.reason,
+    step: r.step ?? null,
+    source: r.source ?? null,
+  }));
+  rels.sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
+  return JSON.stringify(rels, null, 2);
+}
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+const DIST_WORKER = path.resolve(
+  __dirname, '..', '..', 'dist', 'core', 'ingestion', 'workers', 'parse-worker.js',
+);
+
+/**
+ * The pipeline emits this warning when it intended to use workers (total
+ * parseable bytes > 512KB) but could NOT spawn them — e.g. because dist/ is
+ * missing or stale.  If we detect this warning in the parallel run, both
+ * pipeline runs went sequential and the "parity" snapshot comparison would be
+ * a false-green tautology.
+ */
+const FALLBACK_WARN_PATTERN = /Parallel parse unavailable, falling back to sequential/;
+
+/**
+ * 10 TypeScript service class names — enough files to comfortably exceed
+ * the MIN_BYTES_FOR_WORKERS = 512 KB gate when combined with the route files.
+ */
+const SERVICE_NAMES = [
+  'UserService',
+  'OrderService',
+  'ProductService',
+  'PaymentService',
+  'NotificationService',
+  'AuthService',
+  'AuditService',
+  'CacheService',
+  'EmailService',
+  'ReportService',
+];
+
+// ── Test state ────────────────────────────────────────────────────────────────
+
+let fixtureDir = '';
+let seqSnapshot = '';
+let parSnapshot = '';
+let parallelFallbackWarns: string[] = [];
+
+// ── Setup/teardown ────────────────────────────────────────────────────────────
+
+beforeAll(async () => {
+  // ── 1. Gate: dist worker must exist ───────────────────────────────────────
+  //
+  // The parallel parse path spawns a Worker thread from dist/.  If dist/ is
+  // missing the pool silently falls back to sequential (with a console.warn).
+  // We assert its existence BEFORE generating the fixture so the error message
+  // is clear and actionable.
+  expect(
+    fs.existsSync(DIST_WORKER),
+    `dist/core/ingestion/workers/parse-worker.js not found.\n` +
+    `The parallel-parse integration test requires a compiled worker script.\n` +
+    `Fix: cd gitnexus && npm run build`,
+  ).toBe(true);
+
+  // ── 2. Generate fixture in a temporary directory ──────────────────────────
+  fixtureDir = await fsPromises.mkdtemp(
+    path.join(os.tmpdir(), 'gitnexus-parallel-parity-'),
+  );
+
+  const apiDir = path.join(fixtureDir, 'src', 'api');
+  const svcDir = path.join(fixtureDir, 'src', 'services');
+  await fsPromises.mkdir(apiDir, { recursive: true });
+  await fsPromises.mkdir(svcDir, { recursive: true });
+
+  // Route files — exercises route-channel fix (Bug 2)
+  await fsPromises.writeFile(path.join(apiDir, 'routes.py'), FASTAPI_CONTENT, 'utf-8');
+  await fsPromises.writeFile(path.join(apiDir, 'gin_routes.go'), GIN_CONTENT, 'utf-8');
+
+  // TypeScript service files — exercises declaredType (Bug 3) + process detection (Bug 4)
+  for (const svcName of SERVICE_NAMES) {
+    await fsPromises.writeFile(
+      path.join(svcDir, `${svcName.toLowerCase()}.ts`),
+      generateServiceFile(svcName),
+      'utf-8',
+    );
+  }
+
+  // ── 3. Gate: fixture must trip the worker-pool byte threshold ────────────
+  //
+  // If total parseable bytes ≤ 512 KB both pipeline runs go sequential and
+  // the parity test is a false-green tautology.  Fail with an actionable hint
+  // rather than silently passing.
+  let totalBytes = FASTAPI_CONTENT.length + GIN_CONTENT.length;
+  const tsFiles = await fsPromises.readdir(svcDir);
+  for (const f of tsFiles) {
+    const stat = await fsPromises.stat(path.join(svcDir, f));
+    totalBytes += stat.size;
+  }
+
+  expect(
+    totalBytes,
+    `Fixture total parseable bytes (${totalBytes}) must exceed 512 KB ` +
+    `(MIN_BYTES_FOR_WORKERS=${512 * 1024}) so the worker pool actually spawns.\n` +
+    `Increase NUM_METHOD_GROUPS in generateServiceFile() or add more SERVICE_NAMES.`,
+  ).toBeGreaterThan(512 * 1024);
+
+  // ── 4. Sequential run ─────────────────────────────────────────────────────
+  const seqResult = await runPipelineFromRepo(fixtureDir, () => {}, {
+    parallelParse: false,
+  });
+  seqSnapshot = snapshotRels(seqResult.graph);
+
+  // ── 5. Parallel run — capture console.warn to detect pool fallback ────────
+  //
+  // The spy is scoped to the parallel run only so sequential-path warnings
+  // (if any) don't pollute the fallback check.
+  const warnSpy = vi.spyOn(console, 'warn');
+  const parResult = await runPipelineFromRepo(fixtureDir, () => {}, {
+    parallelParse: true,
+  });
+  parallelFallbackWarns = warnSpy.mock.calls
+    .map(args => String(args[0]))
+    .filter(msg => FALLBACK_WARN_PATTERN.test(msg));
+  vi.restoreAllMocks();
+
+  parSnapshot = snapshotRels(parResult.graph);
+}, 300_000); // 5-minute budget for two full pipeline runs
+
+afterAll(async () => {
+  vi.restoreAllMocks();
+  if (fixtureDir) {
+    await fsPromises.rm(fixtureDir, { recursive: true, force: true });
+  }
+});
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('parallel-parse parity (GITNEXUS_PARALLEL_PARSE=1 vs =0)', () => {
+  // ── Pool-spawn gate (must pass before parity tests are meaningful) ─────────
+
+  it('worker pool actually spawned during parallel run (no silent sequential fallback)', () => {
+    // If the fallback warning fires, both runs went sequential and the parity
+    // snapshot comparison below would be a false-green tautology.
+    expect(
+      parallelFallbackWarns,
+      `Worker pool fell back to sequential during the parallel run.\n` +
+      `Ensure dist/ is built: cd gitnexus && npm run build\n` +
+      `Fallback message(s): ${parallelFallbackWarns.join('; ')}`,
+    ).toHaveLength(0);
+  });
+
+  // ── Primary parity assertion ───────────────────────────────────────────────
+
+  it('parallel and sequential pipeline runs produce byte-identical relationship snapshots', () => {
+    // This is the master assertion. It covers ALL edge types (CALLS, CONTAINS,
+    // IMPORTS, HAS_METHOD, HAS_PROPERTY, MEMBER_OF, STEP_IN_PROCESS,
+    // HANDLES_ROUTE, …). A regression in ANY of the four bug areas will cause
+    // a diff here.
+    expect(parSnapshot).toBe(seqSnapshot);
+  });
+
+  // ── Targeted assertions (give named failures when parity breaks) ───────────
+
+  it('(Bug 4) STEP_IN_PROCESS edges are byte-identical between paths', () => {
+    // Process-detection insertion-order bugs produce different proc_<idx>
+    // numbering → different STEP_IN_PROCESS edge ids and step numbers.
+    const seqRels: Array<Record<string, unknown>> = JSON.parse(seqSnapshot);
+    const parRels: Array<Record<string, unknown>> = JSON.parse(parSnapshot);
+
+    const seqStep = seqRels.filter(r => r['type'] === 'STEP_IN_PROCESS');
+    const parStep = parRels.filter(r => r['type'] === 'STEP_IN_PROCESS');
+
+    // There must be at least one STEP_IN_PROCESS edge (fixture has 3-hop chains)
+    expect(seqStep.length).toBeGreaterThan(0);
+    expect(parStep).toEqual(seqStep);
+  });
+
+  it('(Bug 4) MEMBER_OF edges are byte-identical between paths', () => {
+    // Community-detection produces MEMBER_OF edges. If insertion order affects
+    // community assignment, MEMBER_OF edges diverge between paths.
+    const seqRels: Array<Record<string, unknown>> = JSON.parse(seqSnapshot);
+    const parRels: Array<Record<string, unknown>> = JSON.parse(parSnapshot);
+
+    const seqMember = seqRels.filter(r => r['type'] === 'MEMBER_OF');
+    const parMember = parRels.filter(r => r['type'] === 'MEMBER_OF');
+
+    expect(seqMember.length).toBeGreaterThan(0);
+    expect(parMember).toEqual(seqMember);
+  });
+
+  it('(Bug 2) HANDLES_ROUTE edges from FastAPI and Gin files are present in both paths', () => {
+    // Route-channel bug: if the worker misdirects FastAPI/Gin routes to the
+    // Spring bucket (result.routes) instead of result.decoratorRoutes, the
+    // parallel path produces no HANDLES_ROUTE edges from route files while
+    // the sequential path re-extracts them correctly → snapshot divergence.
+    //
+    // This assertion confirms the fixture exercises the route-channel path
+    // and that routes are non-zero in both snapshots. The byte-identical
+    // assertion above catches any count/content divergence.
+    const seqRels: Array<Record<string, unknown>> = JSON.parse(seqSnapshot);
+    const parRels: Array<Record<string, unknown>> = JSON.parse(parSnapshot);
+
+    const seqRoutes = seqRels.filter(r => r['type'] === 'HANDLES_ROUTE');
+    const parRoutes = parRels.filter(r => r['type'] === 'HANDLES_ROUTE');
+
+    expect(seqRoutes.length).toBeGreaterThan(0);
+    expect(parRoutes.length).toBeGreaterThan(0);
+    expect(parRoutes).toEqual(seqRoutes);
+  });
+
+  it('(Bug 3) CALLS edge counts are non-zero and identical (declaredType chained-call fix)', () => {
+    // The declaredType fix ensures that this.field receiver-type resolution
+    // works in the worker path. Without it, chained calls via typed fields
+    // (e.g. this.cache.get()) fail to resolve → fewer CALLS edges in the
+    // parallel path than in the sequential path.
+    const seqRels: Array<Record<string, unknown>> = JSON.parse(seqSnapshot);
+    const parRels: Array<Record<string, unknown>> = JSON.parse(parSnapshot);
+
+    const seqCalls = seqRels.filter(r => r['type'] === 'CALLS');
+    const parCalls = parRels.filter(r => r['type'] === 'CALLS');
+
+    expect(seqCalls.length).toBeGreaterThan(0);
+    expect(parCalls.length).toBe(seqCalls.length);
+  });
+});

--- a/gitnexus/test/unit/process-processor-insertion-order.test.ts
+++ b/gitnexus/test/unit/process-processor-insertion-order.test.ts
@@ -1,0 +1,365 @@
+/**
+ * Regression guard: `processProcesses` is insertion-order-independent.
+ *
+ * Bug history (three separate regressions on perf/lsp-analyze-speedup):
+ *   Bug 1 — findEntryPoints tied-score candidates were in Map insertion order
+ *            → proc_<idx> numbering churned between sequential and parallel-parse paths.
+ *            Fixed: sort uses total-order comparator with id tiebreak.
+ *   Bug 2 — buildCallsGraph callees were in edge insertion order; slice(0, maxBranching)
+ *            picked different callees between the two paths.
+ *            Fixed: adjacency lists sorted by targetId after construction.
+ *   Bug 3 — deduplicateTraces / deduplicateByEndpoints / limitedTraces sorts were
+ *            not total-order → equal-length traces kept/numbered in insertion order.
+ *            Fixed: all three sorts use length-desc + full-path-lexicographic comparator.
+ *
+ * This test builds the same graph twice with nodes and edges added in two
+ * different insertion orders and asserts `processProcesses` produces IDENTICAL
+ * results. "Same" means: same process IDs, same trace arrays, same step numbers.
+ *
+ * Graph topology (designed to exercise all three bug classes):
+ *
+ *   func:hub (name="handleUsers", exported, 5 callees > maxBranching=4)
+ *     → func:hub_callee_alpha → func:hub_term_alpha   ← Bug 2: callee sort
+ *     → func:hub_callee_beta  → func:hub_term_beta
+ *     → func:hub_callee_gamma → func:hub_term_gamma
+ *     → func:hub_callee_delta → func:hub_term_delta
+ *     → func:hub_callee_zeta  → func:hub_term_zeta    ← dropped (last alphabetically)
+ *
+ *   func:ep_a (name="handleA", exported, tied-score 9.0 with ep_b)   ← Bug 1
+ *     → func:mid_a1 → func:term_a1
+ *     → func:mid_a2 → func:term_a2
+ *     → func:mid_a3 → func:term_a3
+ *
+ *   func:ep_b (name="handleB", exported, tied-score 9.0 with ep_a)   ← Bug 1
+ *     → func:mid_b1 → func:term_b1
+ *     → func:mid_b2 → func:term_b2
+ *     → func:mid_b3 → func:term_b3
+ *
+ * Score formula:
+ *   hub:  (5 callees / (0 callers + 1)) × 2.0 × 1.5 × 1.0 = 15.0
+ *   ep_a: (3 callees / (0 callers + 1)) × 2.0 × 1.5 × 1.0 =  9.0  (tied with ep_b)
+ *   ep_b: (3 callees / (0 callers + 1)) × 2.0 × 1.5 × 1.0 =  9.0  (tied with ep_a)
+ *
+ * ORDER_A: hub → ep_a → ep_b (callees in ascending id order, edges forward)
+ * ORDER_B: ep_b → ep_a → hub (callees in descending id order, edges reversed)
+ */
+
+import { describe, it, expect } from 'vitest';
+import { processProcesses } from '../../src/core/ingestion/process-processor.js';
+import { createKnowledgeGraph } from '../../src/core/graph/graph.js';
+import type { KnowledgeGraph } from '../../src/core/graph/types.js';
+import type { CommunityMembership } from '../../src/core/ingestion/community-processor.js';
+
+// ── Graph construction helpers ────────────────────────────────────────────────
+
+function addFn(
+  graph: KnowledgeGraph,
+  id: string,
+  name: string,
+  opts: { exported?: boolean } = {},
+) {
+  graph.addNode({
+    id,
+    label: 'Function',
+    properties: {
+      name,
+      filePath: `src/${id.replace('func:', '')}.ts`,
+      startLine: 1,
+      endLine: 20,
+      isExported: opts.exported ?? false,
+      language: 'typescript' as any,
+    },
+  });
+}
+
+function addCall(
+  graph: KnowledgeGraph,
+  edgeId: string,
+  sourceId: string,
+  targetId: string,
+) {
+  graph.addRelationship({
+    id: edgeId,
+    sourceId,
+    targetId,
+    type: 'CALLS',
+    confidence: 0.9,
+    reason: 'import-resolved',
+  });
+}
+
+// ── Snapshot helpers ──────────────────────────────────────────────────────────
+
+type ProcessResult = Awaited<ReturnType<typeof processProcesses>>;
+
+function snapshotProcesses(result: ProcessResult) {
+  return result.processes
+    .map(p => ({
+      id: p.id,
+      entryPointId: p.entryPointId,
+      terminalId: p.terminalId,
+      trace: [...p.trace],
+    }))
+    .sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
+}
+
+function snapshotSteps(result: ProcessResult) {
+  return result.steps
+    .map(s => ({ nodeId: s.nodeId, processId: s.processId, step: s.step }))
+    .sort((a, b) => {
+      if (a.processId !== b.processId) return a.processId < b.processId ? -1 : 1;
+      return a.step - b.step;
+    });
+}
+
+// ── Fixture definition ────────────────────────────────────────────────────────
+
+const HUB_CALLEES = [
+  { calleeId: 'func:hub_callee_alpha', termId: 'func:hub_term_alpha',
+    callEdgeId: 'call:hub_to_alpha', termEdgeId: 'call:alpha_to_term' },
+  { calleeId: 'func:hub_callee_beta',  termId: 'func:hub_term_beta',
+    callEdgeId: 'call:hub_to_beta',  termEdgeId: 'call:beta_to_term' },
+  { calleeId: 'func:hub_callee_gamma', termId: 'func:hub_term_gamma',
+    callEdgeId: 'call:hub_to_gamma', termEdgeId: 'call:gamma_to_term' },
+  { calleeId: 'func:hub_callee_delta', termId: 'func:hub_term_delta',
+    callEdgeId: 'call:hub_to_delta', termEdgeId: 'call:delta_to_term' },
+  // zeta sorts LAST alphabetically → gets dropped after sort+slice(0, maxBranching=4)
+  { calleeId: 'func:hub_callee_zeta',  termId: 'func:hub_term_zeta',
+    callEdgeId: 'call:hub_to_zeta',  termEdgeId: 'call:zeta_to_term' },
+];
+
+const EP_A_CHAINS = [
+  { midId: 'func:mid_a1', termId: 'func:term_a1',
+    callEdgeId: 'call:a_to_mid1', termEdgeId: 'call:mid1_to_term' },
+  { midId: 'func:mid_a2', termId: 'func:term_a2',
+    callEdgeId: 'call:a_to_mid2', termEdgeId: 'call:mid2_to_term' },
+  { midId: 'func:mid_a3', termId: 'func:term_a3',
+    callEdgeId: 'call:a_to_mid3', termEdgeId: 'call:mid3_to_term' },
+];
+
+const EP_B_CHAINS = [
+  { midId: 'func:mid_b1', termId: 'func:term_b1',
+    callEdgeId: 'call:b_to_mid1', termEdgeId: 'call:mid_b1_to_term' },
+  { midId: 'func:mid_b2', termId: 'func:term_b2',
+    callEdgeId: 'call:b_to_mid2', termEdgeId: 'call:mid_b2_to_term' },
+  { midId: 'func:mid_b3', termId: 'func:term_b3',
+    callEdgeId: 'call:b_to_mid3', termEdgeId: 'call:mid_b3_to_term' },
+];
+
+/**
+ * Populate a KnowledgeGraph with the parity fixture.
+ *
+ * @param insertionOrder
+ *   'ab' — hub first, then ep_a, then ep_b; callees/edges in ascending-id order
+ *   'ba' — ep_b first, then ep_a, then hub; callees/edges in descending-id order
+ *
+ * Both graphs contain identical node and edge SETS; only the insertion (Map) order
+ * differs. Without the three determinism fixes, `processProcesses` would produce
+ * different proc_<idx> numbering and different trace selections between the two.
+ */
+function populateGraph(graph: KnowledgeGraph, insertionOrder: 'ab' | 'ba') {
+  const isAB = insertionOrder === 'ab';
+
+  // ── Entry-point nodes ────────────────────────────────────────────────────
+  //
+  // Score formula: calleeCount/(callerCount+1) × exportMultiplier × nameMultiplier
+  //   hub:  (5/1) × 2.0 × 1.5 = 15.0   ← higher, sorts before ep_a/ep_b
+  //   ep_a: (3/1) × 2.0 × 1.5 =  9.0   ← tied with ep_b; tiebreak by id
+  //   ep_b: (3/1) × 2.0 × 1.5 =  9.0   ← "func:ep_a" < "func:ep_b" → ep_a first
+  //
+  const entryPointDefs = [
+    { id: 'func:hub',  name: 'handleUsers' },
+    { id: 'func:ep_a', name: 'handleA' },
+    { id: 'func:ep_b', name: 'handleB' },
+  ];
+  const epOrder = isAB ? entryPointDefs : [...entryPointDefs].reverse();
+  for (const ep of epOrder) {
+    addFn(graph, ep.id, ep.name, { exported: true });
+  }
+
+  // ── Hub callees + terminals (5 pairs; zeta dropped by sort+slice) ────────
+  const hubOrder = isAB ? HUB_CALLEES : [...HUB_CALLEES].reverse();
+  for (const { calleeId, termId } of hubOrder) {
+    // Use neutral names (no entry-point pattern match, not exported)
+    // to keep their scores well below hub/ep_a/ep_b so they never
+    // become dominant entry points themselves.
+    addFn(graph, calleeId, calleeId.replace('func:hub_callee_', 'step_'));
+    addFn(graph, termId, termId.replace('func:hub_term_', 'sink_'));
+  }
+
+  // ── ep_a mid + terminal nodes ────────────────────────────────────────────
+  const aOrder = isAB ? EP_A_CHAINS : [...EP_A_CHAINS].reverse();
+  for (const { midId, termId } of aOrder) {
+    addFn(graph, midId, midId.replace('func:', ''));
+    addFn(graph, termId, termId.replace('func:', ''));
+  }
+
+  // ── ep_b mid + terminal nodes ────────────────────────────────────────────
+  const bOrder = isAB ? EP_B_CHAINS : [...EP_B_CHAINS].reverse();
+  for (const { midId, termId } of bOrder) {
+    addFn(graph, midId, midId.replace('func:', ''));
+    addFn(graph, termId, termId.replace('func:', ''));
+  }
+
+  // ── CALLS edges ──────────────────────────────────────────────────────────
+  // Edge insertion order is the core of Bug 2: buildCallsGraph iterates
+  // iterRelationships() (insertion order) to build the adjacency list.
+  // Without the callee sort, the 5th callee pushed into adj[hub] would be
+  // whichever was added last, not whichever has the last alphabetical id.
+
+  const hubEdges = hubOrder.flatMap(({ calleeId, termId, callEdgeId, termEdgeId }) => [
+    { id: callEdgeId, src: 'func:hub', tgt: calleeId },
+    { id: termEdgeId, src: calleeId, tgt: termId },
+  ]);
+  const aEdges = aOrder.flatMap(({ midId, termId, callEdgeId, termEdgeId }) => [
+    { id: callEdgeId, src: 'func:ep_a', tgt: midId },
+    { id: termEdgeId, src: midId, tgt: termId },
+  ]);
+  const bEdges = bOrder.flatMap(({ midId, termId, callEdgeId, termEdgeId }) => [
+    { id: callEdgeId, src: 'func:ep_b', tgt: midId },
+    { id: termEdgeId, src: midId, tgt: termId },
+  ]);
+
+  const allEdges = isAB
+    ? [...hubEdges, ...aEdges, ...bEdges]
+    : [...bEdges, ...aEdges, ...hubEdges];
+
+  for (const e of allEdges) {
+    addCall(graph, e.id, e.src, e.tgt);
+  }
+}
+
+// No memberships — all nodes are community-less → processType 'intra_community'
+const NO_MEMBERSHIPS: CommunityMembership[] = [];
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('processProcesses — insertion-order independence', () => {
+  // -----------------------------------------------------------------
+  // Primary regression: run twice with different insertion orders and
+  // assert the output is byte-identical.
+  // -----------------------------------------------------------------
+
+  it('(Bug 1+2+3) process IDs and traces are identical regardless of node/edge insertion order', async () => {
+    const graphAB = createKnowledgeGraph();
+    const graphBA = createKnowledgeGraph();
+
+    populateGraph(graphAB, 'ab');
+    populateGraph(graphBA, 'ba');
+
+    const resultAB = await processProcesses(graphAB, NO_MEMBERSHIPS);
+    const resultBA = await processProcesses(graphBA, NO_MEMBERSHIPS);
+
+    expect(resultAB.processes.length).toBeGreaterThan(0);
+    expect(resultAB.processes.length).toBe(resultBA.processes.length);
+
+    // Snapshot comparison covers id (proc_<idx>), entryPointId, terminalId, trace
+    expect(snapshotProcesses(resultAB)).toEqual(snapshotProcesses(resultBA));
+  });
+
+  it('(Bug 1+2+3) STEP_IN_PROCESS step numbers are identical regardless of insertion order', async () => {
+    const graphAB = createKnowledgeGraph();
+    const graphBA = createKnowledgeGraph();
+
+    populateGraph(graphAB, 'ab');
+    populateGraph(graphBA, 'ba');
+
+    const resultAB = await processProcesses(graphAB, NO_MEMBERSHIPS);
+    const resultBA = await processProcesses(graphBA, NO_MEMBERSHIPS);
+
+    expect(snapshotSteps(resultAB)).toEqual(snapshotSteps(resultBA));
+  });
+
+  // -----------------------------------------------------------------
+  // Bug 2 isolation: callee sort drops the CORRECT 5th callee (zeta)
+  // regardless of which insertion order was used.
+  // -----------------------------------------------------------------
+
+  it('(Bug 2) drops the last-alphabetical callee when >maxBranching callees exist', async () => {
+    const graph = createKnowledgeGraph();
+    populateGraph(graph, 'ab'); // insertion order does not matter for this assertion
+    const result = await processProcesses(graph, NO_MEMBERSHIPS);
+
+    const allTraceNodes = result.processes.flatMap(p => p.trace);
+
+    // func:hub_callee_zeta sorts last → must be dropped by slice(0, maxBranching=4)
+    expect(allTraceNodes).not.toContain('func:hub_callee_zeta');
+    expect(allTraceNodes).not.toContain('func:hub_term_zeta');
+
+    // All four kept callees must appear in traces
+    expect(allTraceNodes).toContain('func:hub_callee_alpha');
+    expect(allTraceNodes).toContain('func:hub_callee_beta');
+    expect(allTraceNodes).toContain('func:hub_callee_gamma');
+    expect(allTraceNodes).toContain('func:hub_callee_delta');
+  });
+
+  it('(Bug 2) insertion order in reverse produces the SAME 4 hub callees', async () => {
+    const graphBA = createKnowledgeGraph();
+    populateGraph(graphBA, 'ba'); // callees added in reverse id order (zeta first)
+    const result = await processProcesses(graphBA, NO_MEMBERSHIPS);
+
+    const allTraceNodes = result.processes.flatMap(p => p.trace);
+
+    // Even though zeta was inserted FIRST in ORDER_B, the callee sort must
+    // still drop it because it sorts last by id — not by insertion position.
+    expect(allTraceNodes).not.toContain('func:hub_callee_zeta');
+    expect(allTraceNodes).not.toContain('func:hub_term_zeta');
+
+    expect(allTraceNodes).toContain('func:hub_callee_alpha');
+    expect(allTraceNodes).toContain('func:hub_callee_beta');
+    expect(allTraceNodes).toContain('func:hub_callee_gamma');
+    expect(allTraceNodes).toContain('func:hub_callee_delta');
+  });
+
+  // -----------------------------------------------------------------
+  // Bug 1 isolation: tied-score entry points (ep_a and ep_b both score
+  // 9.0) must always be ordered by node id, never by insertion order.
+  // -----------------------------------------------------------------
+
+  it('(Bug 1) tied-score entry points always ordered by node id, not insertion order', async () => {
+    const graphAB = createKnowledgeGraph(); // hub, ep_a, ep_b  (ep_a inserted first)
+    const graphBA = createKnowledgeGraph(); // ep_b, ep_a, hub  (ep_b inserted first)
+
+    populateGraph(graphAB, 'ab');
+    populateGraph(graphBA, 'ba');
+
+    const resultAB = await processProcesses(graphAB, NO_MEMBERSHIPS);
+    const resultBA = await processProcesses(graphBA, NO_MEMBERSHIPS);
+
+    // Find the first process index where ep_a / ep_b is the entry point.
+    const firstEpAIdxAB = resultAB.processes.findIndex(p => p.entryPointId === 'func:ep_a');
+    const firstEpBIdxAB = resultAB.processes.findIndex(p => p.entryPointId === 'func:ep_b');
+    const firstEpAIdxBA = resultBA.processes.findIndex(p => p.entryPointId === 'func:ep_a');
+    const firstEpBIdxBA = resultBA.processes.findIndex(p => p.entryPointId === 'func:ep_b');
+
+    // "func:ep_a" < "func:ep_b" → ep_a must always appear before ep_b in both runs
+    expect(firstEpAIdxAB).not.toBe(-1);
+    expect(firstEpBIdxAB).not.toBe(-1);
+    expect(firstEpAIdxAB).toBeLessThan(firstEpBIdxAB);
+
+    expect(firstEpAIdxBA).not.toBe(-1);
+    expect(firstEpBIdxBA).not.toBe(-1);
+    expect(firstEpAIdxBA).toBeLessThan(firstEpBIdxBA);
+
+    // Positions must be IDENTICAL between the two insertion orders
+    expect(firstEpAIdxAB).toBe(firstEpAIdxBA);
+    expect(firstEpBIdxAB).toBe(firstEpBIdxBA);
+  });
+
+  // -----------------------------------------------------------------
+  // Stats sanity: determinism extends to aggregate statistics too.
+  // -----------------------------------------------------------------
+
+  it('stats fields are identical regardless of insertion order', async () => {
+    const graphAB = createKnowledgeGraph();
+    const graphBA = createKnowledgeGraph();
+
+    populateGraph(graphAB, 'ab');
+    populateGraph(graphBA, 'ba');
+
+    const resultAB = await processProcesses(graphAB, NO_MEMBERSHIPS);
+    const resultBA = await processProcesses(graphBA, NO_MEMBERSHIPS);
+
+    expect(resultAB.stats).toEqual(resultBA.stats);
+  });
+});


### PR DESCRIPTION
Stacks on #190 (merge that first, or retarget base to main once it lands).

## Parallel parse → byte-identical + default ON
The worker pool now produces a graph **byte-identical** to the sequential path and is ON by default (`--no-parallel-parse` / `GITNEXUS_PARALLEL_PARSE=0` to opt out; sub-threshold repos still run sequential). Verified 0-diff seq-vs-worker on three repos spanning TS/Python/Java — GitNexus, crawl4ai (FastAPI), tcbs-bond-trading (Spring) — across every edge type including the derived MEMBER_OF / STEP_IN_PROCESS.

Five parity bugs fixed (each measured via GITNEXUS_DUMP_EDGES): general-call double-emission, missing `declaredType` on worker Property symbols, FastAPI/Gin/Angular route channel, Spring constant/inherited routes, and insertion-order-sensitive process detection. Plus R5 (no silent import loss on worker crash) and R9 (visible fallback warning).

**Benchmark (parse phase / total wall):** GitNexus 11.6×/2.49×, crawl4ai 5.1×/2.1×, tcbs 1.75×/1.29×. The total ceiling is ~2.5× (L1) because resolution still re-parses sequentially; eliminating that double-parse is a planned L2 follow-up.

## analyze --lsp observability + cache
Readiness heartbeat + per-candidate progress (no more "looks hung" during pylsp warm-up), live CLI label, and `--lsp-cache` default ON (`--no-lsp-cache` to disable).

## Tests
New `parallel-parity` integration test (byte-identity incl process/community edges, fails if the pool didn't spawn) + `process-processor-insertion-order` unit test. Build clean; resolver + spring/route + lsp suites green (2 pre-existing php/ruby resolver failures unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)